### PR TITLE
[BUG]: App-analytics - fixed issue for app break on update chart

### DIFF
--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -80,6 +80,7 @@ export const REDUX_EXPL_SLICE_VISUALIZATION = 'explorerVisualization';
 export const REDUX_EXPL_SLICE_COUNT_DISTRIBUTION = 'countDistributionVisualization';
 export const PLOTLY_GAUGE_COLUMN_NUMBER = 4;
 export const APP_ANALYTICS_TAB_ID_REGEX = /application-analytics-tab.+/;
+export const DEFAULT_AVAILABILITY_QUERY = 'stats count() by span( timestamp, 1h )';
 export const ADD_BUTTON_TEXT = '+ Add color theme';
 export const NUMBER_INPUT_MIN_LIMIT = 1;
 

--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -80,7 +80,6 @@ export const REDUX_EXPL_SLICE_VISUALIZATION = 'explorerVisualization';
 export const REDUX_EXPL_SLICE_COUNT_DISTRIBUTION = 'countDistributionVisualization';
 export const PLOTLY_GAUGE_COLUMN_NUMBER = 4;
 export const APP_ANALYTICS_TAB_ID_REGEX = /application-analytics-tab.+/;
-export const DEFAULT_AVAILABILITY_QUERY = 'stats count() by span( timestamp, 1h )';
 export const ADD_BUTTON_TEXT = '+ Add color theme';
 export const NUMBER_INPUT_MIN_LIMIT = 1;
 

--- a/dashboards-observability/common/query_manager/antlr/ppl_syntax_parser.ts
+++ b/dashboards-observability/common/query_manager/antlr/ppl_syntax_parser.ts
@@ -20,7 +20,7 @@ export class PPLSyntaxParser {
     return this.createParser(this.createLexer(query));
   }
 
-  createLexer(query: string) {
+  createLexer(query: string = '') {
     return new OpenSearchPPLLexer(new CaseInsensitiveCharStream(CharStreams.fromString(query)));
   }
 

--- a/dashboards-observability/common/utils/query_utils.ts
+++ b/dashboards-observability/common/utils/query_utils.ts
@@ -59,7 +59,7 @@ export const buildQuery = (baseQuery: string, currQuery: string) => {
   if (baseQuery) {
     fullQuery = baseQuery;
     if (currQuery) {
-      fullQuery += currQuery.trim().charAt(0) !== '|' ? '| ' : '' + currQuery;
+      fullQuery += '| ' + currQuery;
     }
   } else {
     fullQuery = currQuery;

--- a/dashboards-observability/common/utils/query_utils.ts
+++ b/dashboards-observability/common/utils/query_utils.ts
@@ -59,7 +59,7 @@ export const buildQuery = (baseQuery: string, currQuery: string) => {
   if (baseQuery) {
     fullQuery = baseQuery;
     if (currQuery) {
-      fullQuery += '| ' + currQuery;
+      fullQuery += currQuery.trim().charAt(0) !== '|' ? '| ' : '' + currQuery;
     }
   } else {
     fullQuery = currQuery;

--- a/dashboards-observability/common/utils/query_utils.ts
+++ b/dashboards-observability/common/utils/query_utils.ts
@@ -75,7 +75,7 @@ export const composeFinalQuery = (
   isLiveQuery: boolean,
   appBaseQuery: string
 ) => {
-  const fullQuery = buildQuery(appBaseQuery, curQuery);
+  const fullQuery = curQuery.includes(appBaseQuery) ? curQuery : buildQuery(appBaseQuery, curQuery);
   if (isEmpty(fullQuery)) return '';
   return preprocessQuery({
     rawQuery: fullQuery,

--- a/dashboards-observability/public/components/app.tsx
+++ b/dashboards-observability/public/components/app.tsx
@@ -73,6 +73,7 @@ export const App = ({
                       dslService={dslService}
                       savedObjects={savedObjects}
                       timestampUtils={timestampUtils}
+                      queryManager={queryManager}
                     />
                   );
                 }}

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -66,6 +66,7 @@ import { ServiceDetailFlyout } from './flyout_components/service_detail_flyout';
 import { SpanDetailFlyout } from '../../../../public/components/trace_analytics/components/traces/span_detail_flyout';
 import { TraceDetailFlyout } from './flyout_components/trace_detail_flyout';
 import { fetchAppById, initializeTabData } from '../helpers/utils';
+import { QueryManager } from '../../../../common/query_manager/ppl_query_manager';
 
 const searchBarConfigs = {
   [TAB_EVENT_ID]: {
@@ -86,6 +87,7 @@ interface AppDetailProps extends AppAnalyticsComponentDeps {
   savedObjects: SavedObjects;
   timestampUtils: TimestampUtils;
   notifications: NotificationsStart;
+  queryManager: QueryManager;
   updateApp: (appId: string, updateAppData: Partial<ApplicationRequestType>, type: string) => void;
   setToasts: (title: string, color?: string, text?: ReactChild) => void;
   callback: (childfunction: () => void) => void;
@@ -110,6 +112,7 @@ export function Application(props: AppDetailProps) {
     setToasts,
     setFilters,
     callback,
+    queryManager,
   } = props;
   const [application, setApplication] = useState<ApplicationType>({
     id: '',
@@ -377,6 +380,7 @@ export function Application(props: AppDetailProps) {
         appBaseQuery={application.baseQuery}
         callback={callback}
         callbackInApp={callbackInApp}
+        queryManager={queryManager}
         curSelectedTabId={selectedTabId}
       />
     );

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -377,7 +377,7 @@ export function Application(props: AppDetailProps) {
         endTime={appEndTime}
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
-        appBaseQuery={application.baseQuery}
+        appBaseQuery={application.baseQuery.trim()}
         callback={callback}
         callbackInApp={callbackInApp}
         queryManager={queryManager}

--- a/dashboards-observability/public/components/application_analytics/home.tsx
+++ b/dashboards-observability/public/components/application_analytics/home.tsx
@@ -38,6 +38,7 @@ import {
   CUSTOM_PANELS_API_PREFIX,
   CUSTOM_PANELS_DOCUMENTATION_URL,
 } from '../../../common/constants/custom_panels';
+import { QueryManager } from '../../../common/query_manager/ppl_query_manager';
 
 export type AppAnalyticsCoreDeps = TraceAnalyticsCoreDeps;
 
@@ -47,6 +48,7 @@ interface HomeProps extends RouteComponentProps, AppAnalyticsCoreDeps {
   savedObjects: SavedObjects;
   timestampUtils: TimestampUtils;
   notifications: NotificationsStart;
+  queryManager: QueryManager;
 }
 
 export interface AppAnalyticsComponentDeps extends TraceAnalyticsComponentDeps {
@@ -69,6 +71,7 @@ export const Home = (props: HomeProps) => {
     http,
     chrome,
     notifications,
+    queryManager,
   } = props;
   const [triggerSwitchToEvent, setTriggerSwitchToEvent] = useState(0);
   const dispatch = useDispatch();
@@ -435,6 +438,7 @@ export const Home = (props: HomeProps) => {
               setToasts={setToast}
               updateApp={updateApp}
               callback={callback}
+              queryManager={queryManager}
               {...commonProps}
             />
           )}

--- a/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
@@ -1458,16 +1458,72 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
             useResizeHandler={true}
           >
             <div
-              id="explorerPlotComponent"
-              style={
-                Object {
-                  "height": "100%",
-                  "width": "100%",
-                }
-              }
-            />
-          </PlotlyComponent>
-        </Plt>
+              className="euiText euiText--extraSmall lnsChart__empty"
+              data-test-subj="vizWorkspace__noData"
+            >
+              <EuiTextAlign
+                textAlign="center"
+              >
+                <div
+                  className="euiTextAlign euiTextAlign--center"
+                >
+                  <EuiTextColor
+                    color="subdued"
+                    component="div"
+                  >
+                    <div
+                      className="euiTextColor euiTextColor--subdued"
+                    >
+                      <EuiIcon
+                        color="subdued"
+                        size="xxl"
+                        type="visBarVerticalStacked"
+                      >
+                        <EuiIconEmpty
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
+                          focusable="false"
+                          role="img"
+                          style={null}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          />
+                        </EuiIconEmpty>
+                      </EuiIcon>
+                      <EuiSpacer
+                        size="l"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--l"
+                        />
+                      </EuiSpacer>
+                      <p>
+                        <FormattedMessage
+                          defaultMessage="No results found"
+                          id="visualization_noData"
+                          values={Object {}}
+                        >
+                          <span>
+                            No results found
+                          </span>
+                        </FormattedMessage>
+                      </p>
+                    </div>
+                  </EuiTextColor>
+                </div>
+              </EuiTextAlign>
+            </div>
+          </EuiText>
+        </EmptyPlaceholder>
       </Bar>
     </VisualizationChart>
   </Visualization>

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -966,10 +966,6 @@ export const Explorer = ({
 
   const handleQueryChange = async (newQuery: string) => setTempQuery(newQuery);
 
-  useEffect(() => {
-    console.log(tempQuery);
-  }, [tempQuery]);
-
   const handleSavingObject = async () => {
     const currQuery = queryRef.current;
     const currFields = explorerFieldsRef.current;

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -54,7 +54,6 @@ import {
   EVENT_ANALYTICS_DOCUMENTATION_URL,
   TAB_EVENT_ID,
   TAB_CHART_ID,
-  DEFAULT_AVAILABILITY_QUERY,
   DATE_PICKER_FORMAT,
   GROUPBY,
   AGGREGATIONS,
@@ -412,8 +411,8 @@ export const Explorer = ({
   const prepareAvailability = async () => {
     setSelectedContentTab(TAB_CHART_ID);
     setTriggerAvailability(true);
-    await setTempQuery(DEFAULT_AVAILABILITY_QUERY);
-    await updateQueryInStore(DEFAULT_AVAILABILITY_QUERY);
+    await setTempQuery('');
+    await updateQueryInStore('');
     await handleTimeRangePickerRefresh(true);
   };
 

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -111,7 +111,7 @@ const getSpanValue = (statsTokens: statsChunk) => {
 const defaultUserConfigs = (queryString, visualizationName: string) => {
   let tempUserConfigs = {};
   const qm = new QueryManager();
-  const statsTokens = qm.queryParser().parse(queryString.rawQuery).getStats();
+  const statsTokens = qm.queryParser().parse(queryString.finalQuery).getStats();
   if (!statsTokens) {
     tempUserConfigs = {
       [AGGREGATIONS]: [],


### PR DESCRIPTION
Signed-off-by: Dipra Aich <dipra_aich@persistent.com>

### Description
Application Analytics - App does not respond if configuration is added and Update Chart is clicked

### Issues Resolved
- Elimination of error on Update chart click
- Update of query into query search box on update chart click
- Restrict reset of configuration of update chart click
- Fetch and represent proper data on update chart click
- App analytics internally stores the entire query, i.e including the base query in raw query property, 
but only displays the part excluding the base query in UI.
- If a query exists in the search panel and use clicks Update chart, the query is updated to the latest. 
It does not concatenate with the previous query.

[#1136](https://github.com/opensearch-project/observability/issues/1136)
[#1168](https://github.com/opensearch-project/observability/issues/1168)

### Check List
- [ ] Clicking the Update Chart updates the configuration, chart UI and query properly
- [ ] Commits are signed per the DCO using --signoff

