### PR TITLE
[BACKPORT 2.4] QS to 6.5.3

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Enable longer filenames for windows
       - name: Enable longer filenames
-        run: git config --system core.longpaths true
+        run: sudo git config --system core.longpaths true
 
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -22,7 +22,8 @@ jobs:
 
       # Enable longer filenames for windows
       - name: Enable longer filenames
-        run: sudo git config --system core.longpaths true
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
 
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout Plugin
         uses: actions/checkout@v1
 
+      # Enable longer filenames for windows
+      - name: Enable longer filenames
+        run: git config --system core.longpaths true
+
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:

--- a/dashboards-observability/package.json
+++ b/dashboards-observability/package.json
@@ -47,6 +47,7 @@
     "glob-parent": "^6.0.1",
     "ansi-regex": "^5.0.1",
     "json-schema": "^0.4.0",
+    "qs": "~6.5.3",
     "minimatch": "^3.0.5"
   }
 }

--- a/dashboards-observability/yarn.lock
+++ b/dashboards-observability/yarn.lock
@@ -2232,10 +2232,10 @@ pure-color@^1.3.0:
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
   integrity sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=
 
-qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+qs@~6.5.2, qs@~6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 querystring@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Description
Backport QS vulnerability fix to 2.4

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
