### PR TITLE
Fix event analytics field blank margin

### DIFF
--- a/public/components/visualizations/charts/logs_view/logs_view.scss
+++ b/public/components/visualizations/charts/logs_view/logs_view.scss
@@ -12,10 +12,6 @@ td {
   text-align: left;
 }
 
-th {
-  width: 30%;
-}
-
 tr:hover {
   background-color: #ddd;
 }


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
closes https://github.com/opensearch-project/dashboards-observability/issues/165
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/28062824/210892338-9cab67f9-47bd-4446-a69b-c7327929b808.png">

The style was added by commit db674583bf026df783dad2553699ea432259354c. I checked doesn't seem to break other places but not sure why it was added

### Issues Resolved
#165 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
