### PR TITLE
Fix typo in fetch_visualization metrics name

### DIFF
--- a/server/routes/notebooks/vizRouter.ts
+++ b/server/routes/notebooks/vizRouter.ts
@@ -24,7 +24,7 @@ export function registerVizRoute(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      addRequestToMetric('notebooks', 'visualization', 'count');
+      addRequestToMetric('notebooks', 'fetch_visualization', 'count');
       const params: RequestParams.Search = {
         index: '.kibana',
         size: NOTEBOOKS_FETCH_SIZE,
@@ -44,7 +44,7 @@ export function registerVizRoute(router: IRouter) {
           body: { savedVisualizations: vizResponse },
         });
       } catch (error) {
-        addRequestToMetric('notebooks', 'visualization', error);
+        addRequestToMetric('notebooks', 'fetch_visualization', error);
         return response.custom({
           statusCode: error.statusCode || 500,
           body: error.message,


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
under notebooks the metric name should be `fetch_visualization` instead of `visualization`.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
