### PR TITLE
Temporarily hide reporting context menu in notebooks

### DIFF
--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -859,22 +859,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         title: 'Reporting',
         items: [
           {
-            name: 'Download PDF',
-            icon: <EuiIcon type="download" />,
-            onClick: () => {
-              this.setState({ isReportingActionsPopoverOpen: false });
-              generateInContextReport('pdf', this.props, this.toggleReportingLoadingModal);
-            },
-          },
-          {
-            name: 'Download PNG',
-            icon: <EuiIcon type="download" />,
-            onClick: () => {
-              this.setState({ isReportingActionsPopoverOpen: false });
-              generateInContextReport('png', this.props, this.toggleReportingLoadingModal);
-            },
-          },
-          {
             name: 'Create report definition',
             icon: <EuiIcon type="calendar" />,
             onClick: () => {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Reporting plugin has changed the report generation mechanism, and triggering on demand reports from observability plugin no longer works. Remove those broken buttons for now while working on a fix

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
