### PR TITLE
Add reporting on-demand menu items back in notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .cypress/screenshots
 .cypress/videos
 common/query_manager/antlr/output
+.eslintcache

--- a/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
+++ b/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
@@ -6,7 +6,7 @@
 import {
   contextMenuCreateReportDefinition,
   contextMenuViewReports,
-  generateInContextReport
+  generateInContextReport,
 } from '../reporting_context_menu_helper';
 
 describe('reporting_context_menu_helper tests', () => {
@@ -52,7 +52,8 @@ describe('reporting_context_menu_helper tests', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         status,
-        json: () => Promise.resolve({ filename, fileFormat, data: 'test-data' }),
+        json: () =>
+          Promise.resolve({ filename, fileFormat, data: 'test-data', reportId: 'test-id' }),
         text: () => Promise.resolve({ tenant }),
       })
     );
@@ -65,7 +66,7 @@ describe('reporting_context_menu_helper tests', () => {
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.csv', '__user__', setToast, toggleReportingLoadingModal);
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
+    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
   });
 
   it('generates pdf for global tenant', async () => {
@@ -73,7 +74,7 @@ describe('reporting_context_menu_helper tests', () => {
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.pdf', '', setToast, toggleReportingLoadingModal);
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
+    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
   });
 
   it('generates png for custom tenant', async () => {
@@ -81,15 +82,7 @@ describe('reporting_context_menu_helper tests', () => {
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
-  });
-
-  it('generates png for custom tenant', async () => {
-    const setToast = jest.fn();
-    const toggleReportingLoadingModal = jest.fn();
-    await generateReport(200, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
+    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
   });
 
   it('handles 404 error', async () => {
@@ -132,7 +125,11 @@ describe('reporting_context_menu_helper tests', () => {
     global.fetch = jest.fn(() => Promise.reject({ status: 500 }));
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
-    await generateInContextReport('csv', { setToast }, toggleReportingLoadingModal);
+    try {
+      await generateInContextReport('csv', { setToast }, toggleReportingLoadingModal);
+    } catch (error) {
+      expect(error.status).toEqual(500);
+    }
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
     expect(setToast).toBeCalledWith('Tenant error', 'danger', 'Failed to get user tenant.');
   });

--- a/public/components/notebooks/components/helpers/reporting_context_menu_helper.tsx
+++ b/public/components/notebooks/components/helpers/reporting_context_menu_helper.tsx
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { parse } from "url";
+import { parse } from 'url';
 
 const getReportSourceURL = (baseURI: string) => {
   return baseURI.substr(baseURI.lastIndexOf('/') + 1, baseURI.length);
-}
+};
 
 export const readDataReportToFile = async (
   stream: string,
@@ -29,11 +29,7 @@ const getFileFormatPrefix = (fileFormat: string) => {
   return fileFormatPrefix;
 };
 
-const readStreamToFile = async (
-  stream: string,
-  fileFormat: string,
-  fileName: string
-) => {
+const readStreamToFile = async (stream: string, fileFormat: string, fileName: string) => {
   let link = document.createElement('a');
   if (fileName.includes('csv')) {
     readDataReportToFile(stream, fileFormat, fileName);
@@ -93,8 +89,7 @@ function addTenantToURL(url, userRequestedTenant) {
   // build fake url from relative url
   const fakeUrl = `http://opensearch.com${url}`;
   const tenantKey = 'security_tenant';
-  const tenantKeyAndValue =
-    tenantKey + '=' + encodeURIComponent(userRequestedTenant);
+  const tenantKeyAndValue = tenantKey + '=' + encodeURIComponent(userRequestedTenant);
 
   const { pathname, search } = parse(fakeUrl);
   const queryDelimiter = !search ? '?' : '&';
@@ -127,14 +122,10 @@ export const generateInContextReport = async (
   try {
     const tenant = await getTenantInfoIfExists();
     if (tenant) {
-      baseUrl = addTenantToURL(baseUrl, tenant) 
+      baseUrl = addTenantToURL(baseUrl, tenant);
     }
   } catch (error) {
-    props.setToast(
-      'Tenant error',
-      'danger',
-      'Failed to get user tenant.'
-    );
+    props.setToast('Tenant error', 'danger', 'Failed to get user tenant.');
     console.log(`failed to get user tenant: ${error}`);
   }
 
@@ -151,7 +142,7 @@ export const generateInContextReport = async (
         core_params: {
           base_url: baseUrl,
           report_format: fileFormat,
-          time_duration: 'PT30M', // time duration can be hard-coded 
+          time_duration: 'PT30M', // time duration can be hard-coded
           ...rest,
         },
       },
@@ -166,71 +157,63 @@ export const generateInContextReport = async (
       },
     },
   };
-  fetch(
-    '../api/reporting/generateReport',
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        'osd-xsrf': 'true',
-        accept: '*/*',
-        'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
-        pragma: 'no-cache',
-        'sec-fetch-dest': 'empty',
-        'sec-fetch-mode': 'cors',
-        'sec-fetch-site': 'same-origin',
-      },
-      method: 'POST',
-      body: JSON.stringify(contextMenuOnDemandReport),
-      referrerPolicy: 'strict-origin-when-cross-origin',
-      mode: 'cors',
-      credentials: 'include',
-    }
-  )
-  .then((response) => {
-    toggleReportingLoadingModal(false);
-    if (response.status === 200) {
-      // success toast
-      props.setToast('Successfully generated report.', 'success');
-    } else {
-      if (response.status === 403) {
-        // permissions failure toast
-        props.setToast(
-          'Error generating report,',
-          'danger',
-          'Insufficient permissions. Reach out to your OpenSearch Dashboards administrator.'
-        );
-      } else if (response.status === 503) {
-        // timeout failure
-        props.setToast(
-          'Error generating report.',
-          'danger',
-          'Timed out generating on-demand report from notebook. Try again later.'
-        );
+  fetch('../api/reporting/generateReport', {
+    headers: {
+      'Content-Type': 'application/json',
+      'osd-xsrf': 'true',
+      accept: '*/*',
+      'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
+      pragma: 'no-cache',
+      'sec-fetch-dest': 'empty',
+      'sec-fetch-mode': 'cors',
+      'sec-fetch-site': 'same-origin',
+    },
+    method: 'POST',
+    body: JSON.stringify(contextMenuOnDemandReport),
+    referrerPolicy: 'strict-origin-when-cross-origin',
+    mode: 'cors',
+    credentials: 'include',
+  })
+    .then(async (response) => [response.status, await response.json()])
+    .then(async ([status, data]) => {
+      toggleReportingLoadingModal(false);
+      if (status === 200) {
+        const a = document.createElement('a');
+        a.href = window.location.origin + `${data.queryUrl}&visualReportId=${data.reportId}`;
+        a.target = '_blank';
+        a.rel = 'noreferrer';
+        a.click();
+        // success toast
+        props.setToast('Please continue report generation in the new tab.', 'success');
       } else {
-        // generic failure
-        props.setToast(
-          'Download error',
-          'danger',
-          'There was an error generating this report.'
-        );
+        if (status === 403) {
+          // permissions failure toast
+          props.setToast(
+            'Error generating report,',
+            'danger',
+            'Insufficient permissions. Reach out to your OpenSearch Dashboards administrator.'
+          );
+        } else if (status === 503) {
+          // timeout failure
+          props.setToast(
+            'Error generating report.',
+            'danger',
+            'Timed out generating on-demand report from notebook. Try again later.'
+          );
+        } else {
+          // generic failure
+          props.setToast('Download error', 'danger', 'There was an error generating this report.');
+        }
       }
-    }
-    return response.json();
-  })
-  .then(async (data) => {
-    await readStreamToFile(data.data, fileFormat, data.filename);
-  })
-}
+    });
+};
 
 export const contextMenuCreateReportDefinition = (baseURI: string) => {
   const reportSourceId = getReportSourceURL(baseURI);
   let reportSource = 'notebook:';
 
   reportSource += reportSourceId.toString();
-  window.location.assign(
-    `reports-dashboards#/create?previous=${reportSource}?timeFrom=0?timeTo=0`
-  );
+  window.location.assign(`reports-dashboards#/create?previous=${reportSource}?timeFrom=0?timeTo=0`);
 };
 
-export const contextMenuViewReports = () =>
-  window.location.assign('reports-dashboards#/');
+export const contextMenuViewReports = () => window.location.assign('reports-dashboards#/');

--- a/public/components/notebooks/components/helpers/reporting_context_menu_helper.tsx
+++ b/public/components/notebooks/components/helpers/reporting_context_menu_helper.tsx
@@ -16,7 +16,7 @@ export const readDataReportToFile = async (
 ) => {
   const blob = new Blob([stream]);
   const url = URL.createObjectURL(blob);
-  let link = document.createElement('a');
+  const link = document.createElement('a');
   link.setAttribute('href', url);
   link.setAttribute('download', fileName);
   document.body.appendChild(link);
@@ -25,18 +25,18 @@ export const readDataReportToFile = async (
 };
 
 const getFileFormatPrefix = (fileFormat: string) => {
-  var fileFormatPrefix = 'data:' + fileFormat + ';base64,';
+  const fileFormatPrefix = 'data:' + fileFormat + ';base64,';
   return fileFormatPrefix;
 };
 
 const readStreamToFile = async (stream: string, fileFormat: string, fileName: string) => {
-  let link = document.createElement('a');
+  const link = document.createElement('a');
   if (fileName.includes('csv')) {
     readDataReportToFile(stream, fileFormat, fileName);
     return;
   }
-  let fileFormatPrefix = getFileFormatPrefix(fileFormat);
-  let url = fileFormatPrefix + stream;
+  const fileFormatPrefix = getFileFormatPrefix(fileFormat);
+  const url = fileFormatPrefix + stream;
   if (typeof link.download !== 'string') {
     window.open(url, '_blank');
     return;
@@ -126,7 +126,6 @@ export const generateInContextReport = async (
     }
   } catch (error) {
     props.setToast('Tenant error', 'danger', 'Failed to get user tenant.');
-    console.log(`failed to get user tenant: ${error}`);
   }
 
   const reportSource = 'Notebook';
@@ -157,7 +156,7 @@ export const generateInContextReport = async (
       },
     },
   };
-  fetch('../api/reporting/generateReport', {
+  await fetch('../api/reporting/generateReport', {
     headers: {
       'Content-Type': 'application/json',
       'osd-xsrf': 'true',

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -859,6 +859,22 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         title: 'Reporting',
         items: [
           {
+            name: 'Download PDF',
+            icon: <EuiIcon type="download" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              generateInContextReport('pdf', this.props, this.toggleReportingLoadingModal);
+            },
+          },
+          {
+            name: 'Download PNG',
+            icon: <EuiIcon type="download" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              generateInContextReport('png', this.props, this.toggleReportingLoadingModal);
+            },
+          },
+          {
             name: 'Create report definition',
             icon: <EuiIcon type="calendar" />,
             onClick: () => {


### PR DESCRIPTION
### Description
Add reporting on-demand menu items back in notebooks. Clicking on them will open a new tab of notebooks in `output only` mode and trigger report generation

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
