### PR TITLE
Modify one legacy query in sample panels for timeseries that causes invalid data issue

### DIFF
--- a/server/common/helpers/events_explorer/sample_savedObjects.ts
+++ b/server/common/helpers/events_explorer/sample_savedObjects.ts
@@ -147,7 +147,8 @@ export const sampleVisualizations = [
   {
     name: '[Logs] Max and average bytes by host',
     description: '',
-    query: 'source = opensearch_dashboards_sample_data_logs | stats max(bytes), avg(bytes) by host',
+    query:
+      'source = opensearch_dashboards_sample_data_logs | stats max(bytes), avg(bytes) by span(timestamp, 1M)',
     type: 'line',
     selected_date_range: {
       start: 'now/y',


### PR DESCRIPTION
Signed-off-by: Eric Wei <menwe@amazon.com>

### Description
There is one sample data query that is not valid after we changed line to timeseries which restricts dimension to only be timespan. Changed the query to use timespan. 
Impact: users will still see invalid data in existing sample data, but any newly added sample data will not have this error. Need to decide if we should support BWC for this.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
