### PR TITLE
Remove timeseries data validation to get back line chart support

### DIFF
--- a/public/components/visualizations/visualization.tsx
+++ b/public/components/visualizations/visualization.tsx
@@ -34,10 +34,6 @@ export const Visualization = ({
 
     if (isEmpty(series)) return [false, VISUALIZATION_ERROR.INVALID_DATA]; // series is required to any visualization type
 
-    // timeseries
-    if (vis.id === VIS_CHART_TYPES.Line && (isEmpty(span) || dimensions.length > 0))
-      return [false, VISUALIZATION_ERROR.INVALID_DATA];
-
     // bars, pie
     if (dimensions.length < 1 && isEmpty(span)) return [false, VISUALIZATION_ERROR.INVALID_DATA];
 


### PR DESCRIPTION
Signed-off-by: Eric Wei <menwe@amazon.com>

### Description
Remove timeseries data validation to bring back line chart support. 

@anirudha @ps48 will need to discuss how to support both timeseries and line in Observability. 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
