### PR TITLE
[BACKPORT 2.x] fix for debug cve issue (#221)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -817,7 +817,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@^2.6.9, debug@^3.1.0, debug@^4.0.1, debug@^4.1.1:
+debug@^2.6.9, debug@^3.1.0, debug@^4.0.1, debug@^4.1.1, debug@^4.3.4:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==


### PR DESCRIPTION
Signed-off-by: Eric Wei <menwe@amazon.com>

Signed-off-by: Eric Wei <menwe@amazon.com>
(cherry picked from commit 864f28540d062120598a05db5ba1f1ca5c5d57aa)

### Description
Manually backport #221 to 2.x

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
