### PR TITLE
fix bug for failed notebook create

### DIFF
--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -331,7 +331,7 @@ export class Main extends React.Component<MainProps, MainState> {
             />
             <Route
               exact
-              path={['/notebooks/:id', '/notebooks/edit/:id']}
+              path="/notebooks/:id"
               render={(props) => (
                 <Notebook
                   pplService={this.props.pplService}

--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -95,6 +95,7 @@ export class Main extends React.Component<MainProps, MainState> {
   createNotebook = (newNoteName: string) => {
     if (newNoteName.length >= 50 || newNoteName.length === 0) {
       this.setToast('Invalid notebook name', 'danger');
+      window.location.assign('#/notebooks');
       return;
     }
     const newNoteObject = {
@@ -330,7 +331,7 @@ export class Main extends React.Component<MainProps, MainState> {
             />
             <Route
               exact
-              path="/notebooks/:id"
+              path={['/notebooks/:id', '/notebooks/edit/:id']}
               render={(props) => (
                 <Notebook
                   pplService={this.props.pplService}


### PR DESCRIPTION
### Description
if creation of notebook fails due to invalid name, the user will be dumped onto the notebook table page, with /create persisted in the url. This will prevent the user from being able to get create notebook modal open again unless they refresh the page or manually clear out the url

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
