### PR TITLE
add edit as rename modal open support

### DIFF
--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -330,7 +330,7 @@ export class Main extends React.Component<MainProps, MainState> {
             />
             <Route
               exact
-              path={['/notebooks/:id', '/notebooks/edit/:id']}
+              path={['/notebooks/:id', '/notebooks/:id/edit']}
               render={(props) => (
                 <Notebook
                   pplService={this.props.pplService}

--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -330,7 +330,7 @@ export class Main extends React.Component<MainProps, MainState> {
             />
             <Route
               exact
-              path="/notebooks/:id"
+              path={['/notebooks/:id', '/notebooks/edit/:id']}
               render={(props) => (
                 <Notebook
                   pplService={this.props.pplService}

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -707,7 +707,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     // If the URL changes to /edit or the notebook name is loaded in with the URL as /edit.
     // This second condition is to update the rename modal with the loaded notebook name on page laod
     // if the page if first loaded in as /edit.
-    if (prevProps.location !== this.props.location || prevState.path !== this.state.path) {
+    if (prevProps.location.pathname !== this.props.location.pathname || prevState.path !== this.state.path) {
       if (this.props.location.pathname.split('/').at(-1) === 'edit') {
         this.showRenameModal();
       }

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -705,7 +705,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
 
   componentDidUpdate(prevProps: NotebookProps, prevState: NotebookState) {
     // If the URL changes to /edit or the notebook name is loaded in with the URL as /edit.
-    // This second condition is to update the rename modal with the loaded notebook name on page laod
+    // This second condition is to update the rename modal with the loaded notebook name on page load
     // if the page if first loaded in as /edit.
     if (prevProps.location.pathname !== this.props.location.pathname || prevState.path !== this.state.path) {
       if (this.props.location.pathname.split('/').at(-1) === 'edit') {

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -679,6 +679,9 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   }
 
   componentDidMount() {
+    if (this.props.location.pathname.split('/').at(-2) === 'edit') {
+      this.showRenameModal();
+    }
     this.setBreadcrumbs('');
     this.loadNotebook();
     this.checkIfReportingPluginIsInstalled();

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -288,8 +288,18 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
           this.props.renameNotebook(newName, this.props.openedNoteId);
           this.setState({ isModalVisible: false });
           this.loadNotebook();
+          this.props.history.replace({
+            ...this.props.location,
+            pathname: this.props.location.pathname.substring(0, this.props.location.pathname.lastIndexOf("/")),
+          });
         },
-        () => this.setState({ isModalVisible: false }),
+        () => {
+          this.setState({ isModalVisible: false });
+          this.props.history.replace({
+            ...this.props.location,
+            pathname: this.props.location.pathname.substring(0, this.props.location.pathname.lastIndexOf("/")),
+          });
+        },
         'Name',
         'Rename notebook',
         'Cancel',
@@ -679,12 +689,12 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   }
 
   componentDidMount() {
-    if (this.props.location.pathname.split('/').at(-2) === 'edit') {
-      this.showRenameModal();
-    }
     this.setBreadcrumbs('');
     this.loadNotebook();
     this.checkIfReportingPluginIsInstalled();
+    if (this.props.location.pathname.split('/').at(-1) === 'edit') {
+      this.showRenameModal();
+    }
     const searchParams = queryString.parse(this.props.location.search);
     const view = searchParams['view'];
     if (!view) {
@@ -694,6 +704,14 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       this.setState({ selectedViewId: 'output_only' });
     } else if (view === 'input_only') {
       this.setState({ selectedViewId: 'input_only' });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.location !== this.props.location) {
+      if (this.props.location.pathname.split('/').at(-1) === 'edit') {
+        this.showRenameModal();
+      }
     }
   }
 
@@ -835,7 +853,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             name: 'Rename notebook',
             onClick: () => {
               this.setState({ isNoteActionsPopoverOpen: false });
-              this.showRenameModal();
+              this.props.history.replace({
+                ...this.props.location,
+                pathname: this.props.location.pathname + '/edit'
+              });
             },
           },
           {

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -47,7 +47,6 @@ import {
 } from './helpers/reporting_context_menu_helper';
 import { zeppelinParagraphParser } from './helpers/zeppelin_parser';
 import { Paragraphs } from './paragraph_components/paragraphs';
-import { Location } from 'history';
 const panelStyles: CSS.Properties = {
   float: 'left',
   width: '100%',

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -47,6 +47,7 @@ import {
 } from './helpers/reporting_context_menu_helper';
 import { zeppelinParagraphParser } from './helpers/zeppelin_parser';
 import { Paragraphs } from './paragraph_components/paragraphs';
+import { Location } from 'history';
 const panelStyles: CSS.Properties = {
   float: 'left',
   width: '100%',
@@ -287,7 +288,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         (newName: string) => {
           this.props.renameNotebook(newName, this.props.openedNoteId);
           this.setState({ isModalVisible: false });
-          this.loadNotebook();
           this.props.history.replace({
             ...this.props.location,
             pathname: this.props.location.pathname.substring(0, this.props.location.pathname.lastIndexOf("/")),
@@ -692,9 +692,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     this.setBreadcrumbs('');
     this.loadNotebook();
     this.checkIfReportingPluginIsInstalled();
-    if (this.props.location.pathname.split('/').at(-1) === 'edit') {
-      this.showRenameModal();
-    }
     const searchParams = queryString.parse(this.props.location.search);
     const view = searchParams['view'];
     if (!view) {
@@ -707,8 +704,11 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.location !== this.props.location) {
+  componentDidUpdate(prevProps: NotebookProps, prevState: NotebookState) {
+    // If the URL changes to /edit or the notebook name is loaded in with the URL as /edit.
+    // This second condition is to update the rename modal with the loaded notebook name on page laod
+    // if the page if first loaded in as /edit.
+    if (prevProps.location !== this.props.location || prevState.path !== this.state.path) {
       if (this.props.location.pathname.split('/').at(-1) === 'edit') {
         this.showRenameModal();
       }


### PR DESCRIPTION
### Description
Creates an edit path that hooks into a specific notebook page with rename modal open - will be sued for dashboard list integration

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
