### PR TITLE
move performance now to run time dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-graph-vis": "^1.0.5",
     "react-paginate": "^8.1.3",
     "react-plotly.js": "^2.5.1",
-    "redux-persist": "^6.0.0"
+    "redux-persist": "^6.0.0",
+    "performance-now": "^2.1.0"
   },
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
@@ -36,8 +37,7 @@
     "antlr4ts-cli": "^0.5.0-alpha.4",
     "cypress": "^6.0.0",
     "eslint": "^6.8.0",
-    "jest-dom": "^4.0.0",
-    "performance-now": "^2.1.0"
+    "jest-dom": "^4.0.0"
   },
   "resolutions": {
     "react-syntax-highlighter": "^15.4.3",

--- a/release-notes/opensearch-observability.release-notes-2.6.0.0.md
+++ b/release-notes/opensearch-observability.release-notes-2.6.0.0.md
@@ -15,6 +15,7 @@ Compatible with OpenSearch and OpenSearch Dashboards Version 2.6.0
 - Event Analytics Bug Fixes ([#291](https://github.com/opensearch-project/dashboards-observability/pull/291))
 - remove timeseries data validation to get back line chart support ([#292](https://github.com/opensearch-project/dashboards-observability/pull/292))
 - Add missing changes for visualization config pane ([#294](https://github.com/opensearch-project/dashboards-observability/pull/294))
+- Move performance now from a debug dependency to a runtime dependency ([#309](https://github.com/opensearch-project/dashboards-observability/pull/309))
 
 ### Features
 - Add new page/route for notebooks create and rename ([#250](https://github.com/opensearch-project/dashboards-observability/pull/250))([#293](https://github.com/opensearch-project/dashboards-observability/pull/293))
@@ -24,3 +25,4 @@ Compatible with OpenSearch and OpenSearch Dashboards Version 2.6.0
 
 - Cypress test update and related linting fixes ([#220](https://github.com/opensearch-project/dashboards-observability/pull/220))
 - upgrade cypress to 6 ([#249](https://github.com/opensearch-project/dashboards-observability/pull/249))
+- Fix Node.js and Yarn installation in CI ([#299](https://github.com/opensearch-project/dashboards-observability/pull/299))


### PR DESCRIPTION
### Description
performance-now package was moved from `dev-dependencies` to `dependencies`

### Issues Resolved
* move performance now to run time dep 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
