### PR TITLE
[Backport main] move performance now to run time dep (#309)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-graph-vis": "^1.0.5",
     "react-paginate": "^8.1.3",
     "react-plotly.js": "^2.5.1",
-    "redux-persist": "^6.0.0"
+    "redux-persist": "^6.0.0",
+    "performance-now": "^2.1.0"
   },
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
@@ -48,7 +49,7 @@
     "husky": "6.0.0",
     "jest-dom": "^4.0.0",
     "lint-staged": "^13.1.0",
-    "performance-now": "^2.1.0"
+    "jest-dom": "^4.0.0"
   },
   "resolutions": {
     "react-syntax-highlighter": "^15.4.3",

--- a/release-notes/opensearch-observability.release-notes-2.6.0.0.md
+++ b/release-notes/opensearch-observability.release-notes-2.6.0.0.md
@@ -1,0 +1,28 @@
+## Version 2.6.0.0 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards Version 2.6.0
+
+### Bug Fixes
+
+- correct ppl leran more link ([#189](https://github.com/opensearch-project/dashboards-observability/pull/189))
+- Few fixes regarding issues for visualization rendering ([#187](https://github.com/opensearch-project/dashboards-observability/pull/187))
+- Debug CVE fix ([#223](https://github.com/opensearch-project/dashboards-observability/pull/223)) ([#263](https://github.com/opensearch-project/dashboards-observability/pull/263))
+- Fix bugs related to trace analytics jaeger mode ([#237](https://github.com/opensearch-project/dashboards-observability/pull/237))([#271](https://github.com/opensearch-project/dashboards-observability/pull/271))([#280](https://github.com/opensearch-project/dashboards-observability/pull/280))
+- Update error handling in viz container ([#252](https://github.com/opensearch-project/dashboards-observability/pull/252))
+- Panels filter check for where clause ([#253](https://github.com/opensearch-project/dashboards-observability/pull/253))
+- Fix explorer dark mode issue and restructure scss  ([#262](https://github.com/opensearch-project/dashboards-observability/pull/262))
+- Operational panels cypress fix ([#274](https://github.com/opensearch-project/dashboards-observability/pull/274))
+- Event Analytics Bug Fixes ([#291](https://github.com/opensearch-project/dashboards-observability/pull/291))
+- remove timeseries data validation to get back line chart support ([#292](https://github.com/opensearch-project/dashboards-observability/pull/292))
+- Add missing changes for visualization config pane ([#294](https://github.com/opensearch-project/dashboards-observability/pull/294))
+- Move performance now from a debug dependency to a runtime dependency ([#309](https://github.com/opensearch-project/dashboards-observability/pull/309))
+
+### Features
+- Add new page/route for notebooks create and rename ([#250](https://github.com/opensearch-project/dashboards-observability/pull/250))([#293](https://github.com/opensearch-project/dashboards-observability/pull/293))
+
+
+### Maintenance
+
+- Cypress test update and related linting fixes ([#220](https://github.com/opensearch-project/dashboards-observability/pull/220))
+- upgrade cypress to 6 ([#249](https://github.com/opensearch-project/dashboards-observability/pull/249))
+- Fix Node.js and Yarn installation in CI ([#299](https://github.com/opensearch-project/dashboards-observability/pull/299))


### PR DESCRIPTION
* move performance now to run time dep

Signed-off-by: Derek Ho <dxho@amazon.com>

* update release notes for this PR and CI fix PR

Signed-off-by: Derek Ho <dxho@amazon.com>

---------

Signed-off-by: Derek Ho <dxho@amazon.com>
(cherry picked from commit c0464990e3ba502d6def838edf14a0d7ef5bea92)

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
