### PR TITLE
[Refactoring] Explorer sidebar refactoring

### DIFF
--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -20,11 +20,10 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import classNames from 'classnames';
-import { cloneDeep, has, isEmpty, isEqual, reduce } from 'lodash';
+import { has, isEmpty, isEqual, reduce } from 'lodash';
 import React, { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import {
-  AVAILABLE_FIELDS,
   DATE_PICKER_FORMAT,
   DEFAULT_AVAILABILITY_QUERY,
   EVENT_ANALYTICS_DOCUMENTATION_URL,
@@ -33,7 +32,6 @@ import {
   PATTERNS_EXTRACTOR_REGEX,
   PATTERNS_REGEX,
   PATTERN_REGEX,
-  PPL_DEFAULT_PATTERN_REGEX_FILETER,
   RAW_QUERY,
   SAVED_OBJECT_ID,
   SAVED_OBJECT_TYPE,
@@ -74,8 +72,7 @@ import { Search } from '../../common/search/search';
 import { getVizContainerProps } from '../../visualizations/charts/helpers';
 import { TabContext, useFetchEvents, useFetchPatterns, useFetchVisualizations } from '../hooks';
 import { selectCountDistribution } from '../redux/slices/count_distribution_slice';
-import { selectFields, sortFields, updateFields } from '../redux/slices/field_slice';
-import { selectPatterns } from '../redux/slices/patterns_slice';
+import { selectFields, updateFields } from '../redux/slices/field_slice';
 import { selectQueryResult } from '../redux/slices/query_result_slice';
 import { changeDateRange, changeQuery, selectQueries } from '../redux/slices/query_slice';
 import { updateTabName } from '../redux/slices/query_tab_slice';
@@ -129,11 +126,11 @@ export const Explorer = ({
 }: IExplorerProps) => {
   const dispatch = useDispatch();
   const requestParams = { tabId };
-  const { getLiveTail, getEvents, getAvailableFields, isEventsLoading } = useFetchEvents({
+  const { getLiveTail, getEvents } = useFetchEvents({
     pplService,
     requestParams,
   });
-  const { getVisualizations, getCountVisualizations, isVisLoading } = useFetchVisualizations({
+  const { getCountVisualizations } = useFetchVisualizations({
     pplService,
     requestParams,
   });
@@ -506,11 +503,6 @@ export const Explorer = ({
     }
   }, [savedObjectId]);
 
-  const handleAddField = (field: IField) => toggleFields(field, AVAILABLE_FIELDS, SELECTED_FIELDS);
-
-  const handleRemoveField = (field: IField) =>
-    toggleFields(field, SELECTED_FIELDS, AVAILABLE_FIELDS);
-
   const handleTimePickerChange = async (timeRange: string[]) => {
     if (appLogEvents) {
       setStartTime(timeRange[0]);
@@ -556,36 +548,6 @@ export const Explorer = ({
         patternErrorHandler
       );
     }
-  };
-
-  /**
-   * Toggle fields between selected and unselected sets
-   * @param field field to be toggled
-   * @param FieldSetToRemove set where this field to be removed from
-   * @param FieldSetToAdd set where this field to be added
-   */
-  const toggleFields = (field: IField, FieldSetToRemove: string, FieldSetToAdd: string) => {
-    const nextFields = cloneDeep(explorerFields);
-    const thisFieldSet = nextFields[FieldSetToRemove];
-    const nextFieldSet = thisFieldSet.filter((fd: IField) => fd.name !== field.name);
-    nextFields[FieldSetToRemove] = nextFieldSet;
-    nextFields[FieldSetToAdd].push(field);
-    batch(() => {
-      dispatch(
-        updateFields({
-          tabId,
-          data: {
-            ...nextFields,
-          },
-        })
-      );
-      dispatch(
-        sortFields({
-          tabId,
-          data: [FieldSetToAdd],
-        })
-      );
-    });
   };
 
   const sidebarClassName = classNames({
@@ -686,8 +648,6 @@ export const Explorer = ({
                   selectedPattern={query[SELECTED_PATTERN_FIELD]}
                   handleOverrideTimestamp={handleOverrideTimestamp}
                   handleOverridePattern={handleOverridePattern}
-                  handleAddField={(field: IField) => handleAddField(field)}
-                  handleRemoveField={(field: IField) => handleRemoveField(field)}
                   isOverridingTimestamp={isOverridingTimestamp}
                   isOverridingPattern={isOverridingPattern}
                   isFieldToggleButtonDisabled={
@@ -891,8 +851,6 @@ export const Explorer = ({
         explorerFields={explorerFields}
         explorerVis={explorerVisualizations}
         explorerData={explorerData}
-        handleAddField={handleAddField}
-        handleRemoveField={handleRemoveField}
         visualizations={visualizations}
         handleOverrideTimestamp={handleOverrideTimestamp}
         callback={callbackForConfig}

--- a/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -1,857 +1,803 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Siderbar component Renders empty sidebar component 1`] = `
-<Sidebar
-  explorerData={Object {}}
-  explorerFields={
+<Provider
+  store={
     Object {
-      "availableFields": Array [],
-      "queriedFields": Array [],
-      "selectedFields": Array [],
-      "unselectedFields": Array [],
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(Symbol.observable): [Function],
     }
   }
-  handleAddField={[MockFunction]}
-  handleOverrideTimestamp={[MockFunction]}
-  handleRemoveField={[MockFunction]}
-  isFieldToggleButtonDisabled={false}
-  isOverridingTimestamp={false}
-  selectedTimestamp="timestamp"
 >
-  <I18nProvider>
-    <IntlProvider
-      defaultLocale="en"
-      formats={
-        Object {
-          "date": Object {
-            "full": Object {
-              "day": "numeric",
-              "month": "long",
-              "weekday": "long",
-              "year": "numeric",
-            },
-            "long": Object {
-              "day": "numeric",
-              "month": "long",
-              "year": "numeric",
-            },
-            "medium": Object {
-              "day": "numeric",
-              "month": "short",
-              "year": "numeric",
-            },
-            "short": Object {
-              "day": "numeric",
-              "month": "numeric",
-              "year": "2-digit",
-            },
-          },
-          "number": Object {
-            "currency": Object {
-              "style": "currency",
-            },
-            "percent": Object {
-              "style": "percent",
-            },
-          },
-          "relative": Object {
-            "days": Object {
-              "units": "day",
-            },
-            "hours": Object {
-              "units": "hour",
-            },
-            "minutes": Object {
-              "units": "minute",
-            },
-            "months": Object {
-              "units": "month",
-            },
-            "seconds": Object {
-              "units": "second",
-            },
-            "years": Object {
-              "units": "year",
-            },
-          },
-          "time": Object {
-            "full": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-              "second": "numeric",
-              "timeZoneName": "short",
-            },
-            "long": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-              "second": "numeric",
-              "timeZoneName": "short",
-            },
-            "medium": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-              "second": "numeric",
-            },
-            "short": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-            },
-          },
-        }
+  <Sidebar
+    explorerData={Object {}}
+    explorerFields={
+      Object {
+        "availableFields": Array [],
+        "queriedFields": Array [],
+        "selectedFields": Array [],
+        "unselectedFields": Array [],
       }
-      locale="en"
-      messages={Object {}}
-      textComponent={Symbol(react.fragment)}
-    >
-      <PseudoLocaleWrapper>
-        <section
-          className="sidebar-list"
-        >
-          <div
-            className="dscSidebar__item"
+    }
+    handleOverrideTimestamp={[MockFunction]}
+    isFieldToggleButtonDisabled={false}
+    isOverridingTimestamp={false}
+    selectedTimestamp="timestamp"
+  >
+    <I18nProvider>
+      <IntlProvider
+        defaultLocale="en"
+        formats={
+          Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          }
+        }
+        locale="en"
+        messages={Object {}}
+        textComponent={Symbol(react.fragment)}
+      >
+        <PseudoLocaleWrapper>
+          <section
+            className="sidebar-list"
           >
-            <EuiFieldSearch
-              compressed={true}
-              data-test-subj="eventExplorer__sidebarSearch"
-              fullWidth={true}
-              incremental={false}
-              isClearable={true}
-              isLoading={false}
-              onChange={[Function]}
-              placeholder="Search field names"
-              value=""
+            <div
+              className="dscSidebar__item"
             >
-              <EuiFormControlLayout
+              <EuiFieldSearch
                 compressed={true}
+                data-test-subj="eventExplorer__sidebarSearch"
                 fullWidth={true}
-                icon="search"
+                incremental={false}
+                isClearable={true}
                 isLoading={false}
+                onChange={[Function]}
+                placeholder="Search field names"
+                value=""
               >
-                <div
-                  className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                <EuiFormControlLayout
+                  compressed={true}
+                  fullWidth={true}
+                  icon="search"
+                  isLoading={false}
                 >
                   <div
-                    className="euiFormControlLayout__childrenWrapper"
+                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                   >
-                    <EuiValidatableControl>
-                      <input
-                        className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                        data-test-subj="eventExplorer__sidebarSearch"
-                        onChange={[Function]}
-                        onKeyUp={[Function]}
-                        placeholder="Search field names"
-                        type="search"
-                        value=""
-                      />
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons
-                      compressed={true}
-                      icon="search"
-                      isLoading={false}
+                    <div
+                      className="euiFormControlLayout__childrenWrapper"
                     >
-                      <div
-                        className="euiFormControlLayoutIcons"
-                      >
-                        <EuiFormControlLayoutCustomIcon
-                          size="s"
+                      <EuiValidatableControl>
+                        <input
+                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
+                          data-test-subj="eventExplorer__sidebarSearch"
+                          onChange={[Function]}
+                          onKeyUp={[Function]}
+                          placeholder="Search field names"
                           type="search"
+                          value=""
+                        />
+                      </EuiValidatableControl>
+                      <EuiFormControlLayoutIcons
+                        compressed={true}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayoutIcons"
                         >
-                          <span
-                            className="euiFormControlLayoutCustomIcon"
+                          <EuiFormControlLayoutCustomIcon
+                            size="s"
+                            type="search"
                           >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiFormControlLayoutCustomIcon__icon"
-                              size="s"
-                              type="search"
+                            <span
+                              className="euiFormControlLayoutCustomIcon"
                             >
-                              <EuiIconEmpty
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiFormControlLayoutCustomIcon__icon"
+                                size="s"
+                                type="search"
                               >
-                                <svg
+                                <EuiIconEmpty
                                   aria-hidden={true}
                                   className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                   focusable="false"
-                                  height={16}
                                   role="img"
                                   style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </EuiIconEmpty>
-                            </EuiIcon>
-                          </span>
-                        </EuiFormControlLayoutCustomIcon>
-                      </div>
-                    </EuiFormControlLayoutIcons>
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  />
+                                </EuiIconEmpty>
+                              </EuiIcon>
+                            </span>
+                          </EuiFormControlLayoutCustomIcon>
+                        </div>
+                      </EuiFormControlLayoutIcons>
+                    </div>
                   </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiFieldSearch>
-          </div>
-          <EuiSpacer
-            size="s"
-          >
+                </EuiFormControlLayout>
+              </EuiFieldSearch>
+            </div>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
             <div
-              className="euiSpacer euiSpacer--s"
+              className="sidebar-list"
             />
-          </EuiSpacer>
-          <div
-            className="sidebar-list"
-          />
-        </section>
-      </PseudoLocaleWrapper>
-    </IntlProvider>
-  </I18nProvider>
-</Sidebar>
+          </section>
+        </PseudoLocaleWrapper>
+      </IntlProvider>
+    </I18nProvider>
+  </Sidebar>
+</Provider>
 `;
 
 exports[`Siderbar component Renders sidebar component 1`] = `
-<Sidebar
-  explorerData={
+<Provider
+  store={
     Object {
-      "jsonData": Array [
-        Object {
-          "double_per_ip_bytes": 11606,
-          "host": "artifacts.opensearch.org",
-          "ip_count": 176,
-          "per_ip_bytes": 5803,
-          "resp_code": "404",
-          "sum_bytes": 1021420,
-        },
-        Object {
-          "double_per_ip_bytes": 10100,
-          "host": "www.opensearch.org",
-          "ip_count": 111,
-          "per_ip_bytes": 5050,
-          "resp_code": "404",
-          "sum_bytes": 560638,
-        },
-        Object {
-          "double_per_ip_bytes": 0,
-          "host": "artifacts.opensearch.org",
-          "ip_count": 94,
-          "per_ip_bytes": 0,
-          "resp_code": "503",
-          "sum_bytes": 0,
-        },
-        Object {
-          "double_per_ip_bytes": 0,
-          "host": "www.opensearch.org",
-          "ip_count": 78,
-          "per_ip_bytes": 0,
-          "resp_code": "503",
-          "sum_bytes": 0,
-        },
-        Object {
-          "double_per_ip_bytes": 11526,
-          "host": "cdn.opensearch-opensearch-opensearch.org",
-          "ip_count": 43,
-          "per_ip_bytes": 5763,
-          "resp_code": "404",
-          "sum_bytes": 247840,
-        },
-        Object {
-          "double_per_ip_bytes": 0,
-          "host": "cdn.opensearch-opensearch-opensearch.org",
-          "ip_count": 34,
-          "per_ip_bytes": 0,
-          "resp_code": "503",
-          "sum_bytes": 0,
-        },
-        Object {
-          "double_per_ip_bytes": 8882,
-          "host": "opensearch-opensearch-opensearch.org",
-          "ip_count": 13,
-          "per_ip_bytes": 4441,
-          "resp_code": "404",
-          "sum_bytes": 57735,
-        },
-        Object {
-          "double_per_ip_bytes": 0,
-          "host": "opensearch-opensearch-opensearch.org",
-          "ip_count": 6,
-          "per_ip_bytes": 0,
-          "resp_code": "503",
-          "sum_bytes": 0,
-        },
-      ],
-      "jsonDataAll": Array [
-        Object {
-          "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1",
-          "bytes": 6219,
-          "clientip": "223.87.60.27",
-          "event": "{\\"dataset\\":\\"sample_web_logs\\"}",
-          "extension": "deb",
-          "geo": "{\\"srcdest\\":\\"IN:US\\",\\"src\\":\\"IN\\",\\"coordinates\\":{\\"lat\\":39.41042861,\\"lon\\":-88.8454325},\\"dest\\":\\"US\\"}",
-          "host": "artifacts.opensearch.org",
-          "index": "opensearch_dashboards_sample_data_logs",
-          "ip": "223.87.60.27",
-          "machine": "{\\"os\\":\\"win 8\\",\\"ram\\":8589934592}",
-          "memory": "null",
-          "message": "223.87.60.27 - - [2018-07-22T00:39:02.912Z] \\"GET /opensearch/opensearch-1.0.0.deb_1 HTTP/1.1\\" 200 6219 \\"-\\" \\"Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1\\"",
-          "phpmemory": "null",
-          "referer": "http://twitter.com/success/wendy-lawrence",
-          "request": "/opensearch/opensearch-1.0.0.deb",
-          "response": "200",
-          "tags": "success",
-          "timestamp": "2021-11-14 00:39:02.912",
-          "url": "https://artifacts.opensearch.org/downloads/opensearch/opensearch-1.0.0.deb_1",
-          "utc_time": "2021-11-14 00:39:02.912",
-        },
-        Object {
-          "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1",
-          "bytes": 6850,
-          "clientip": "130.246.123.197",
-          "event": "{\\"dataset\\":\\"sample_web_logs\\"}",
-          "extension": "",
-          "geo": "{\\"srcdest\\":\\"JP:IN\\",\\"src\\":\\"JP\\",\\"coordinates\\":{\\"lat\\":38.58338806,\\"lon\\":-86.46248778},\\"dest\\":\\"IN\\"}",
-          "host": "www.opensearch.org",
-          "index": "opensearch_dashboards_sample_data_logs",
-          "ip": "130.246.123.197",
-          "machine": "{\\"os\\":\\"win 8\\",\\"ram\\":3221225472}",
-          "memory": "null",
-          "message": "130.246.123.197 - - [2018-07-22T03:26:21.326Z] \\"GET /beats/metricbeat_1 HTTP/1.1\\" 200 6850 \\"-\\" \\"Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1\\"",
-          "phpmemory": "null",
-          "referer": "http://www.opensearch-opensearch-opensearch.com/success/james-mcdivitt",
-          "request": "/beats/metricbeat",
-          "response": "200",
-          "tags": "success",
-          "timestamp": "2021-11-14 03:26:21.326",
-          "url": "https://www.opensearch.org/downloads/beats/metricbeat_1",
-          "utc_time": "2021-11-14 03:26:21.326",
-        },
-        Object {
-          "agent": "Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24",
-          "bytes": 0,
-          "clientip": "120.49.143.213",
-          "event": "{\\"dataset\\":\\"sample_web_logs\\"}",
-          "extension": "css",
-          "geo": "{\\"srcdest\\":\\"CO:DE\\",\\"src\\":\\"CO\\",\\"coordinates\\":{\\"lat\\":36.96015,\\"lon\\":-78.18499861},\\"dest\\":\\"DE\\"}",
-          "host": "cdn.opensearch-opensearch-opensearch.org",
-          "index": "opensearch_dashboards_sample_data_logs",
-          "ip": "120.49.143.213",
-          "machine": "{\\"os\\":\\"ios\\",\\"ram\\":20401094656}",
-          "memory": "null",
-          "message": "120.49.143.213 - - [2018-07-22T03:30:25.131Z] \\"GET /styles/main.css_1 HTTP/1.1\\" 503 0 \\"-\\" \\"Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24\\"",
-          "phpmemory": "null",
-          "referer": "http://twitter.com/success/konstantin-feoktistov",
-          "request": "/styles/main.css",
-          "response": "503",
-          "tags": "success",
-          "timestamp": "2021-11-14 03:30:25.131",
-          "url": "https://cdn.opensearch-opensearch-opensearch.org/styles/main.css_1",
-          "utc_time": "2021-11-14 03:30:25.131",
-        },
-      ],
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(Symbol.observable): [Function],
     }
   }
-  explorerFields={
-    Object {
-      "availableFields": Array [
-        Object {
-          "name": "agent",
-          "type": "string",
-        },
-        Object {
-          "name": "bytes",
-          "type": "long",
-        },
-        Object {
-          "name": "clientip",
-          "type": "ip",
-        },
-        Object {
-          "name": "event",
-          "type": "struct",
-        },
-        Object {
-          "name": "extension",
-          "type": "string",
-        },
-        Object {
-          "name": "geo",
-          "type": "struct",
-        },
-        Object {
-          "name": "host",
-          "type": "string",
-        },
-        Object {
-          "name": "index",
-          "type": "string",
-        },
-        Object {
-          "name": "ip",
-          "type": "ip",
-        },
-        Object {
-          "name": "machine",
-          "type": "struct",
-        },
-        Object {
-          "name": "memory",
-          "type": "double",
-        },
-        Object {
-          "name": "message",
-          "type": "string",
-        },
-        Object {
-          "name": "phpmemory",
-          "type": "long",
-        },
-        Object {
-          "name": "referer",
-          "type": "string",
-        },
-        Object {
-          "name": "request",
-          "type": "string",
-        },
-        Object {
-          "name": "response",
-          "type": "string",
-        },
-        Object {
-          "name": "tags",
-          "type": "string",
-        },
-        Object {
-          "name": "timestamp",
-          "type": "timestamp",
-        },
-        Object {
-          "name": "url",
-          "type": "string",
-        },
-        Object {
-          "name": "utc_time",
-          "type": "timestamp",
-        },
-      ],
-      "queriedFields": Array [
-        Object {
-          "name": "double_per_ip_bytes",
-          "type": "long",
-        },
-        Object {
-          "name": "host",
-          "type": "text",
-        },
-        Object {
-          "name": "ip_count",
-          "type": "integer",
-        },
-        Object {
-          "name": "per_ip_bytes",
-          "type": "long",
-        },
-        Object {
-          "name": "resp_code",
-          "type": "text",
-        },
-        Object {
-          "name": "sum_bytes",
-          "type": "long",
-        },
-      ],
-      "selectedFields": Array [],
-      "unselectedFields": Array [],
-    }
-  }
-  handleAddField={[MockFunction]}
-  handleOverrideTimestamp={[MockFunction]}
-  handleRemoveField={[MockFunction]}
-  isFieldToggleButtonDisabled={false}
-  isOverridingTimestamp={false}
-  selectedTimestamp="timestamp"
 >
-  <I18nProvider>
-    <IntlProvider
-      defaultLocale="en"
-      formats={
-        Object {
-          "date": Object {
-            "full": Object {
-              "day": "numeric",
-              "month": "long",
-              "weekday": "long",
-              "year": "numeric",
-            },
-            "long": Object {
-              "day": "numeric",
-              "month": "long",
-              "year": "numeric",
-            },
-            "medium": Object {
-              "day": "numeric",
-              "month": "short",
-              "year": "numeric",
-            },
-            "short": Object {
-              "day": "numeric",
-              "month": "numeric",
-              "year": "2-digit",
-            },
+  <Sidebar
+    explorerData={
+      Object {
+        "jsonData": Array [
+          Object {
+            "double_per_ip_bytes": 11606,
+            "host": "artifacts.opensearch.org",
+            "ip_count": 176,
+            "per_ip_bytes": 5803,
+            "resp_code": "404",
+            "sum_bytes": 1021420,
           },
-          "number": Object {
-            "currency": Object {
-              "style": "currency",
-            },
-            "percent": Object {
-              "style": "percent",
-            },
+          Object {
+            "double_per_ip_bytes": 10100,
+            "host": "www.opensearch.org",
+            "ip_count": 111,
+            "per_ip_bytes": 5050,
+            "resp_code": "404",
+            "sum_bytes": 560638,
           },
-          "relative": Object {
-            "days": Object {
-              "units": "day",
-            },
-            "hours": Object {
-              "units": "hour",
-            },
-            "minutes": Object {
-              "units": "minute",
-            },
-            "months": Object {
-              "units": "month",
-            },
-            "seconds": Object {
-              "units": "second",
-            },
-            "years": Object {
-              "units": "year",
-            },
+          Object {
+            "double_per_ip_bytes": 0,
+            "host": "artifacts.opensearch.org",
+            "ip_count": 94,
+            "per_ip_bytes": 0,
+            "resp_code": "503",
+            "sum_bytes": 0,
           },
-          "time": Object {
-            "full": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-              "second": "numeric",
-              "timeZoneName": "short",
-            },
-            "long": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-              "second": "numeric",
-              "timeZoneName": "short",
-            },
-            "medium": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-              "second": "numeric",
-            },
-            "short": Object {
-              "hour": "numeric",
-              "minute": "numeric",
-            },
+          Object {
+            "double_per_ip_bytes": 0,
+            "host": "www.opensearch.org",
+            "ip_count": 78,
+            "per_ip_bytes": 0,
+            "resp_code": "503",
+            "sum_bytes": 0,
           },
-        }
+          Object {
+            "double_per_ip_bytes": 11526,
+            "host": "cdn.opensearch-opensearch-opensearch.org",
+            "ip_count": 43,
+            "per_ip_bytes": 5763,
+            "resp_code": "404",
+            "sum_bytes": 247840,
+          },
+          Object {
+            "double_per_ip_bytes": 0,
+            "host": "cdn.opensearch-opensearch-opensearch.org",
+            "ip_count": 34,
+            "per_ip_bytes": 0,
+            "resp_code": "503",
+            "sum_bytes": 0,
+          },
+          Object {
+            "double_per_ip_bytes": 8882,
+            "host": "opensearch-opensearch-opensearch.org",
+            "ip_count": 13,
+            "per_ip_bytes": 4441,
+            "resp_code": "404",
+            "sum_bytes": 57735,
+          },
+          Object {
+            "double_per_ip_bytes": 0,
+            "host": "opensearch-opensearch-opensearch.org",
+            "ip_count": 6,
+            "per_ip_bytes": 0,
+            "resp_code": "503",
+            "sum_bytes": 0,
+          },
+        ],
+        "jsonDataAll": Array [
+          Object {
+            "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1",
+            "bytes": 6219,
+            "clientip": "223.87.60.27",
+            "event": "{\\"dataset\\":\\"sample_web_logs\\"}",
+            "extension": "deb",
+            "geo": "{\\"srcdest\\":\\"IN:US\\",\\"src\\":\\"IN\\",\\"coordinates\\":{\\"lat\\":39.41042861,\\"lon\\":-88.8454325},\\"dest\\":\\"US\\"}",
+            "host": "artifacts.opensearch.org",
+            "index": "opensearch_dashboards_sample_data_logs",
+            "ip": "223.87.60.27",
+            "machine": "{\\"os\\":\\"win 8\\",\\"ram\\":8589934592}",
+            "memory": "null",
+            "message": "223.87.60.27 - - [2018-07-22T00:39:02.912Z] \\"GET /opensearch/opensearch-1.0.0.deb_1 HTTP/1.1\\" 200 6219 \\"-\\" \\"Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1\\"",
+            "phpmemory": "null",
+            "referer": "http://twitter.com/success/wendy-lawrence",
+            "request": "/opensearch/opensearch-1.0.0.deb",
+            "response": "200",
+            "tags": "success",
+            "timestamp": "2021-11-14 00:39:02.912",
+            "url": "https://artifacts.opensearch.org/downloads/opensearch/opensearch-1.0.0.deb_1",
+            "utc_time": "2021-11-14 00:39:02.912",
+          },
+          Object {
+            "agent": "Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1",
+            "bytes": 6850,
+            "clientip": "130.246.123.197",
+            "event": "{\\"dataset\\":\\"sample_web_logs\\"}",
+            "extension": "",
+            "geo": "{\\"srcdest\\":\\"JP:IN\\",\\"src\\":\\"JP\\",\\"coordinates\\":{\\"lat\\":38.58338806,\\"lon\\":-86.46248778},\\"dest\\":\\"IN\\"}",
+            "host": "www.opensearch.org",
+            "index": "opensearch_dashboards_sample_data_logs",
+            "ip": "130.246.123.197",
+            "machine": "{\\"os\\":\\"win 8\\",\\"ram\\":3221225472}",
+            "memory": "null",
+            "message": "130.246.123.197 - - [2018-07-22T03:26:21.326Z] \\"GET /beats/metricbeat_1 HTTP/1.1\\" 200 6850 \\"-\\" \\"Mozilla/5.0 (X11; Linux x86_64; rv:6.0a1) Gecko/20110421 Firefox/6.0a1\\"",
+            "phpmemory": "null",
+            "referer": "http://www.opensearch-opensearch-opensearch.com/success/james-mcdivitt",
+            "request": "/beats/metricbeat",
+            "response": "200",
+            "tags": "success",
+            "timestamp": "2021-11-14 03:26:21.326",
+            "url": "https://www.opensearch.org/downloads/beats/metricbeat_1",
+            "utc_time": "2021-11-14 03:26:21.326",
+          },
+          Object {
+            "agent": "Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24",
+            "bytes": 0,
+            "clientip": "120.49.143.213",
+            "event": "{\\"dataset\\":\\"sample_web_logs\\"}",
+            "extension": "css",
+            "geo": "{\\"srcdest\\":\\"CO:DE\\",\\"src\\":\\"CO\\",\\"coordinates\\":{\\"lat\\":36.96015,\\"lon\\":-78.18499861},\\"dest\\":\\"DE\\"}",
+            "host": "cdn.opensearch-opensearch-opensearch.org",
+            "index": "opensearch_dashboards_sample_data_logs",
+            "ip": "120.49.143.213",
+            "machine": "{\\"os\\":\\"ios\\",\\"ram\\":20401094656}",
+            "memory": "null",
+            "message": "120.49.143.213 - - [2018-07-22T03:30:25.131Z] \\"GET /styles/main.css_1 HTTP/1.1\\" 503 0 \\"-\\" \\"Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.50 Safari/534.24\\"",
+            "phpmemory": "null",
+            "referer": "http://twitter.com/success/konstantin-feoktistov",
+            "request": "/styles/main.css",
+            "response": "503",
+            "tags": "success",
+            "timestamp": "2021-11-14 03:30:25.131",
+            "url": "https://cdn.opensearch-opensearch-opensearch.org/styles/main.css_1",
+            "utc_time": "2021-11-14 03:30:25.131",
+          },
+        ],
       }
-      locale="en"
-      messages={Object {}}
-      textComponent={Symbol(react.fragment)}
-    >
-      <PseudoLocaleWrapper>
-        <section
-          className="sidebar-list"
-        >
-          <div
-            className="dscSidebar__item"
+    }
+    explorerFields={
+      Object {
+        "availableFields": Array [
+          Object {
+            "name": "agent",
+            "type": "string",
+          },
+          Object {
+            "name": "bytes",
+            "type": "long",
+          },
+          Object {
+            "name": "clientip",
+            "type": "ip",
+          },
+          Object {
+            "name": "event",
+            "type": "struct",
+          },
+          Object {
+            "name": "extension",
+            "type": "string",
+          },
+          Object {
+            "name": "geo",
+            "type": "struct",
+          },
+          Object {
+            "name": "host",
+            "type": "string",
+          },
+          Object {
+            "name": "index",
+            "type": "string",
+          },
+          Object {
+            "name": "ip",
+            "type": "ip",
+          },
+          Object {
+            "name": "machine",
+            "type": "struct",
+          },
+          Object {
+            "name": "memory",
+            "type": "double",
+          },
+          Object {
+            "name": "message",
+            "type": "string",
+          },
+          Object {
+            "name": "phpmemory",
+            "type": "long",
+          },
+          Object {
+            "name": "referer",
+            "type": "string",
+          },
+          Object {
+            "name": "request",
+            "type": "string",
+          },
+          Object {
+            "name": "response",
+            "type": "string",
+          },
+          Object {
+            "name": "tags",
+            "type": "string",
+          },
+          Object {
+            "name": "timestamp",
+            "type": "timestamp",
+          },
+          Object {
+            "name": "url",
+            "type": "string",
+          },
+          Object {
+            "name": "utc_time",
+            "type": "timestamp",
+          },
+        ],
+        "queriedFields": Array [
+          Object {
+            "name": "double_per_ip_bytes",
+            "type": "long",
+          },
+          Object {
+            "name": "host",
+            "type": "text",
+          },
+          Object {
+            "name": "ip_count",
+            "type": "integer",
+          },
+          Object {
+            "name": "per_ip_bytes",
+            "type": "long",
+          },
+          Object {
+            "name": "resp_code",
+            "type": "text",
+          },
+          Object {
+            "name": "sum_bytes",
+            "type": "long",
+          },
+        ],
+        "selectedFields": Array [],
+        "unselectedFields": Array [],
+      }
+    }
+    handleOverrideTimestamp={[MockFunction]}
+    isFieldToggleButtonDisabled={false}
+    isOverridingTimestamp={false}
+    selectedTimestamp="timestamp"
+  >
+    <I18nProvider>
+      <IntlProvider
+        defaultLocale="en"
+        formats={
+          Object {
+            "date": Object {
+              "full": Object {
+                "day": "numeric",
+                "month": "long",
+                "weekday": "long",
+                "year": "numeric",
+              },
+              "long": Object {
+                "day": "numeric",
+                "month": "long",
+                "year": "numeric",
+              },
+              "medium": Object {
+                "day": "numeric",
+                "month": "short",
+                "year": "numeric",
+              },
+              "short": Object {
+                "day": "numeric",
+                "month": "numeric",
+                "year": "2-digit",
+              },
+            },
+            "number": Object {
+              "currency": Object {
+                "style": "currency",
+              },
+              "percent": Object {
+                "style": "percent",
+              },
+            },
+            "relative": Object {
+              "days": Object {
+                "units": "day",
+              },
+              "hours": Object {
+                "units": "hour",
+              },
+              "minutes": Object {
+                "units": "minute",
+              },
+              "months": Object {
+                "units": "month",
+              },
+              "seconds": Object {
+                "units": "second",
+              },
+              "years": Object {
+                "units": "year",
+              },
+            },
+            "time": Object {
+              "full": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "long": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+                "timeZoneName": "short",
+              },
+              "medium": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+                "second": "numeric",
+              },
+              "short": Object {
+                "hour": "numeric",
+                "minute": "numeric",
+              },
+            },
+          }
+        }
+        locale="en"
+        messages={Object {}}
+        textComponent={Symbol(react.fragment)}
+      >
+        <PseudoLocaleWrapper>
+          <section
+            className="sidebar-list"
           >
-            <EuiFieldSearch
-              compressed={true}
-              data-test-subj="eventExplorer__sidebarSearch"
-              fullWidth={true}
-              incremental={false}
-              isClearable={true}
-              isLoading={false}
-              onChange={[Function]}
-              placeholder="Search field names"
-              value=""
+            <div
+              className="dscSidebar__item"
             >
-              <EuiFormControlLayout
+              <EuiFieldSearch
                 compressed={true}
+                data-test-subj="eventExplorer__sidebarSearch"
                 fullWidth={true}
-                icon="search"
+                incremental={false}
+                isClearable={true}
                 isLoading={false}
+                onChange={[Function]}
+                placeholder="Search field names"
+                value=""
               >
-                <div
-                  className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                <EuiFormControlLayout
+                  compressed={true}
+                  fullWidth={true}
+                  icon="search"
+                  isLoading={false}
                 >
                   <div
-                    className="euiFormControlLayout__childrenWrapper"
+                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                   >
-                    <EuiValidatableControl>
-                      <input
-                        className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                        data-test-subj="eventExplorer__sidebarSearch"
-                        onChange={[Function]}
-                        onKeyUp={[Function]}
-                        placeholder="Search field names"
-                        type="search"
-                        value=""
-                      />
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons
-                      compressed={true}
-                      icon="search"
-                      isLoading={false}
+                    <div
+                      className="euiFormControlLayout__childrenWrapper"
                     >
-                      <div
-                        className="euiFormControlLayoutIcons"
-                      >
-                        <EuiFormControlLayoutCustomIcon
-                          size="s"
+                      <EuiValidatableControl>
+                        <input
+                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
+                          data-test-subj="eventExplorer__sidebarSearch"
+                          onChange={[Function]}
+                          onKeyUp={[Function]}
+                          placeholder="Search field names"
                           type="search"
+                          value=""
+                        />
+                      </EuiValidatableControl>
+                      <EuiFormControlLayoutIcons
+                        compressed={true}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayoutIcons"
                         >
-                          <span
-                            className="euiFormControlLayoutCustomIcon"
+                          <EuiFormControlLayoutCustomIcon
+                            size="s"
+                            type="search"
                           >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiFormControlLayoutCustomIcon__icon"
-                              size="s"
-                              type="search"
+                            <span
+                              className="euiFormControlLayoutCustomIcon"
                             >
-                              <EuiIconSearch
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiFormControlLayoutCustomIcon__icon"
+                                size="s"
+                                type="search"
                               >
-                                <svg
+                                <EuiIconSearch
                                   aria-hidden={true}
                                   className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                   focusable="false"
-                                  height={16}
                                   role="img"
                                   style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
                                 >
-                                  <path
-                                    d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
-                                  />
-                                </svg>
-                              </EuiIconSearch>
-                            </EuiIcon>
-                          </span>
-                        </EuiFormControlLayoutCustomIcon>
-                      </div>
-                    </EuiFormControlLayoutIcons>
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                    />
+                                  </svg>
+                                </EuiIconSearch>
+                              </EuiIcon>
+                            </span>
+                          </EuiFormControlLayoutCustomIcon>
+                        </div>
+                      </EuiFormControlLayoutIcons>
+                    </div>
                   </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiFieldSearch>
-          </div>
-          <EuiSpacer
-            size="s"
-          >
-            <div
-              className="euiSpacer euiSpacer--s"
-            />
-          </EuiSpacer>
-          <div
-            className="sidebar-list"
-          >
-            <EuiAccordion
-              arrowDisplay="left"
-              buttonContent={
-                <EuiTitle
-                  size="xxxs"
-                >
-                  <span>
-                    Query fields
-                  </span>
-                </EuiTitle>
-              }
-              id="fieldSelector__queriedFields"
-              initialIsOpen={true}
-              isLoading={false}
-              isLoadingMessage={false}
-              paddingSize="xs"
+                </EuiFormControlLayout>
+              </EuiFieldSearch>
+            </div>
+            <EuiSpacer
+              size="s"
             >
               <div
-                className="euiAccordion euiAccordion-isOpen"
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <div
+              className="sidebar-list"
+            >
+              <EuiAccordion
+                arrowDisplay="left"
+                buttonContent={
+                  <EuiTitle
+                    size="xxxs"
+                  >
+                    <span>
+                      Query fields
+                    </span>
+                  </EuiTitle>
+                }
+                id="fieldSelector__queriedFields"
+                initialIsOpen={true}
+                isLoading={false}
+                isLoadingMessage={false}
+                paddingSize="xs"
               >
                 <div
-                  className="euiAccordion__triggerWrapper"
+                  className="euiAccordion euiAccordion-isOpen"
                 >
-                  <button
-                    aria-controls="fieldSelector__queriedFields"
-                    aria-expanded={true}
-                    className="euiAccordion__button"
-                    id="random_html_id"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="euiAccordion__triggerWrapper"
                   >
-                    <span
-                      className="euiAccordion__iconWrapper"
+                    <button
+                      aria-controls="fieldSelector__queriedFields"
+                      aria-expanded={true}
+                      className="euiAccordion__button"
+                      id="random_html_id"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <EuiIcon
-                        className="euiAccordion__icon euiAccordion__icon-isOpen"
-                        size="m"
-                        type="arrowRight"
+                      <span
+                        className="euiAccordion__iconWrapper"
                       >
-                        <EuiIconEmpty
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
-                          focusable="false"
-                          role="img"
-                          style={null}
+                        <EuiIcon
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          size="m"
+                          type="arrowRight"
                         >
-                          <svg
+                          <EuiIconEmpty
                             aria-hidden={true}
                             className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
                             focusable="false"
-                            height={16}
                             role="img"
                             style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </EuiIconEmpty>
-                      </EuiIcon>
-                    </span>
-                    <span
-                      className="euiIEFlexWrapFix"
-                    >
-                      <EuiTitle
-                        size="xxxs"
-                      >
-                        <span
-                          className="euiTitle euiTitle--xxxsmall"
-                        >
-                          Query fields
-                        </span>
-                      </EuiTitle>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  aria-labelledby="random_html_id"
-                  className="euiAccordion__childWrapper"
-                  id="fieldSelector__queriedFields"
-                  role="region"
-                  tabIndex={-1}
-                >
-                  <EuiResizeObserver
-                    onResize={[Function]}
-                  >
-                    <div>
-                      <div
-                        className="euiAccordion__padding--xs"
-                      >
-                        <ul
-                          aria-labelledby="queried_fields"
-                          className="dscSidebarList dscFieldList--selected"
-                          data-test-subj="fieldList-selected"
-                        >
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="double_per_ip_bytes"
-                            key="fielddouble_per_ip_bytes"
                           >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "double_per_ip_bytes",
-                                  "type": "long",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={true}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={true}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={false}
+                            <svg
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            />
+                          </EuiIconEmpty>
+                        </EuiIcon>
+                      </span>
+                      <span
+                        className="euiIEFlexWrapFix"
+                      >
+                        <EuiTitle
+                          size="xxxs"
+                        >
+                          <span
+                            className="euiTitle euiTitle--xxxsmall"
+                          >
+                            Query fields
+                          </span>
+                        </EuiTitle>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-labelledby="random_html_id"
+                    className="euiAccordion__childWrapper"
+                    id="fieldSelector__queriedFields"
+                    role="region"
+                    tabIndex={-1}
+                  >
+                    <EuiResizeObserver
+                      onResize={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="euiAccordion__padding--xs"
+                        >
+                          <ul
+                            aria-labelledby="queried_fields"
+                            className="dscSidebarList dscFieldList--selected"
+                            data-test-subj="fieldList-selected"
+                          >
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="double_per_ip_bytes"
+                              key="fielddouble_per_ip_bytes"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-double_per_ip_bytes-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Remove double_per_ip_bytes from table"
-                                              className="dscSidebarItem__action"
-                                              color="ghost"
-                                              data-test-subj="fieldToggle-double_per_ip_bytes"
-                                              display="fill"
-                                              iconType="cross"
-                                              isDisabled={true}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="long"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-double_per_ip_bytes"
-                                        title="double_per_ip_bytes"
-                                      >
-                                        double_per_ip_bytes
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "double_per_ip_bytes",
+                                    "type": "long",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={true}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={true}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={false}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-double_per_ip_bytes-showDetails"
@@ -909,268 +855,268 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-double_per_ip_bytes-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="long"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-double_per_ip_bytes-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="long"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="long"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Remove double_per_ip_bytes from table"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
+                                                  data-test-subj="fieldToggle-double_per_ip_bytes"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="long"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-double_per_ip_bytes"
+                                            title="double_per_ip_bytes"
+                                          >
+                                            double_per_ip_bytes
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-double_per_ip_bytes-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="long"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="long"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="long"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="long"
-                                                    size="l"
-                                                    title="long"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="long"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="long"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="long"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-double_per_ip_bytes"
-                                              title="double_per_ip_bytes"
-                                            >
-                                              double_per_ip_bytes
+                                                        title="long"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="long"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Remove double_per_ip_bytes from table"
-                                                className="dscSidebarItem__action"
-                                                color="ghost"
-                                                data-test-subj="fieldToggle-double_per_ip_bytes"
-                                                display="fill"
-                                                iconType="cross"
-                                                isDisabled={true}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-double_per_ip_bytes"
+                                                title="double_per_ip_bytes"
                                               >
-                                                <button
+                                                double_per_ip_bytes
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Remove double_per_ip_bytes from table"
-                                                  className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
                                                   data-test-subj="fieldToggle-double_per_ip_bytes"
-                                                  disabled={true}
-                                                  type="button"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="cross"
+                                                  <button
+                                                    aria-label="Remove double_per_ip_bytes from table"
+                                                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-double_per_ip_bytes"
+                                                    disabled={true}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="cross"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="host"
-                            key="fieldhost"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "host",
-                                  "type": "text",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={true}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={true}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={false}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="host"
+                              key="fieldhost"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-host-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Remove host from table"
-                                              className="dscSidebarItem__action"
-                                              color="ghost"
-                                              data-test-subj="fieldToggle-host"
-                                              display="fill"
-                                              iconType="cross"
-                                              isDisabled={true}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="text"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-host"
-                                        title="host"
-                                      >
-                                        host
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "host",
+                                    "type": "text",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={true}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={true}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={false}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-host-showDetails"
@@ -1228,268 +1174,268 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-host-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="text"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-host-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="text"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="text"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Remove host from table"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
+                                                  data-test-subj="fieldToggle-host"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="text"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-host"
+                                            title="host"
+                                          >
+                                            host
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-host-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="text"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="text"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="text"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="text"
-                                                    size="l"
-                                                    title="text"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="text"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="text"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="text"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-host"
-                                              title="host"
-                                            >
-                                              host
+                                                        title="text"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="text"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Remove host from table"
-                                                className="dscSidebarItem__action"
-                                                color="ghost"
-                                                data-test-subj="fieldToggle-host"
-                                                display="fill"
-                                                iconType="cross"
-                                                isDisabled={true}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-host"
+                                                title="host"
                                               >
-                                                <button
+                                                host
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Remove host from table"
-                                                  className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
                                                   data-test-subj="fieldToggle-host"
-                                                  disabled={true}
-                                                  type="button"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="cross"
+                                                  <button
+                                                    aria-label="Remove host from table"
+                                                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-host"
+                                                    disabled={true}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="cross"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="ip_count"
-                            key="fieldip_count"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "ip_count",
-                                  "type": "integer",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={true}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={true}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={false}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="ip_count"
+                              key="fieldip_count"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-ip_count-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Remove ip_count from table"
-                                              className="dscSidebarItem__action"
-                                              color="ghost"
-                                              data-test-subj="fieldToggle-ip_count"
-                                              display="fill"
-                                              iconType="cross"
-                                              isDisabled={true}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="integer"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-ip_count"
-                                        title="ip_count"
-                                      >
-                                        ip_count
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "ip_count",
+                                    "type": "integer",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={true}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={true}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={false}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-ip_count-showDetails"
@@ -1547,268 +1493,268 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-ip_count-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="integer"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-ip_count-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="integer"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="integer"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Remove ip_count from table"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
+                                                  data-test-subj="fieldToggle-ip_count"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="integer"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-ip_count"
+                                            title="ip_count"
+                                          >
+                                            ip_count
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-ip_count-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="integer"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="integer"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="integer"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="integer"
-                                                    size="l"
-                                                    title="integer"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="integer"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="integer"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="integer"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-ip_count"
-                                              title="ip_count"
-                                            >
-                                              ip_count
+                                                        title="integer"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="integer"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Remove ip_count from table"
-                                                className="dscSidebarItem__action"
-                                                color="ghost"
-                                                data-test-subj="fieldToggle-ip_count"
-                                                display="fill"
-                                                iconType="cross"
-                                                isDisabled={true}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-ip_count"
+                                                title="ip_count"
                                               >
-                                                <button
+                                                ip_count
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Remove ip_count from table"
-                                                  className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
                                                   data-test-subj="fieldToggle-ip_count"
-                                                  disabled={true}
-                                                  type="button"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="cross"
+                                                  <button
+                                                    aria-label="Remove ip_count from table"
+                                                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-ip_count"
+                                                    disabled={true}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="cross"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="per_ip_bytes"
-                            key="fieldper_ip_bytes"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "per_ip_bytes",
-                                  "type": "long",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={true}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={true}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={false}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="per_ip_bytes"
+                              key="fieldper_ip_bytes"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-per_ip_bytes-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Remove per_ip_bytes from table"
-                                              className="dscSidebarItem__action"
-                                              color="ghost"
-                                              data-test-subj="fieldToggle-per_ip_bytes"
-                                              display="fill"
-                                              iconType="cross"
-                                              isDisabled={true}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="long"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-per_ip_bytes"
-                                        title="per_ip_bytes"
-                                      >
-                                        per_ip_bytes
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "per_ip_bytes",
+                                    "type": "long",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={true}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={true}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={false}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-per_ip_bytes-showDetails"
@@ -1866,268 +1812,268 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-per_ip_bytes-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="long"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-per_ip_bytes-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="long"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="long"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Remove per_ip_bytes from table"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
+                                                  data-test-subj="fieldToggle-per_ip_bytes"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="long"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-per_ip_bytes"
+                                            title="per_ip_bytes"
+                                          >
+                                            per_ip_bytes
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-per_ip_bytes-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="long"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="long"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="long"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="long"
-                                                    size="l"
-                                                    title="long"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="long"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="long"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="long"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-per_ip_bytes"
-                                              title="per_ip_bytes"
-                                            >
-                                              per_ip_bytes
+                                                        title="long"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="long"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Remove per_ip_bytes from table"
-                                                className="dscSidebarItem__action"
-                                                color="ghost"
-                                                data-test-subj="fieldToggle-per_ip_bytes"
-                                                display="fill"
-                                                iconType="cross"
-                                                isDisabled={true}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-per_ip_bytes"
+                                                title="per_ip_bytes"
                                               >
-                                                <button
+                                                per_ip_bytes
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Remove per_ip_bytes from table"
-                                                  className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
                                                   data-test-subj="fieldToggle-per_ip_bytes"
-                                                  disabled={true}
-                                                  type="button"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="cross"
+                                                  <button
+                                                    aria-label="Remove per_ip_bytes from table"
+                                                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-per_ip_bytes"
+                                                    disabled={true}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="cross"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="resp_code"
-                            key="fieldresp_code"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "resp_code",
-                                  "type": "text",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={true}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={true}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={false}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="resp_code"
+                              key="fieldresp_code"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-resp_code-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Remove resp_code from table"
-                                              className="dscSidebarItem__action"
-                                              color="ghost"
-                                              data-test-subj="fieldToggle-resp_code"
-                                              display="fill"
-                                              iconType="cross"
-                                              isDisabled={true}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="text"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-resp_code"
-                                        title="resp_code"
-                                      >
-                                        resp_code
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "resp_code",
+                                    "type": "text",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={true}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={true}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={false}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-resp_code-showDetails"
@@ -2185,268 +2131,268 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-resp_code-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="text"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-resp_code-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="text"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="text"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Remove resp_code from table"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
+                                                  data-test-subj="fieldToggle-resp_code"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="text"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-resp_code"
+                                            title="resp_code"
+                                          >
+                                            resp_code
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-resp_code-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="text"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="text"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="text"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="text"
-                                                    size="l"
-                                                    title="text"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="text"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="text"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="text"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-resp_code"
-                                              title="resp_code"
-                                            >
-                                              resp_code
+                                                        title="text"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="text"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Remove resp_code from table"
-                                                className="dscSidebarItem__action"
-                                                color="ghost"
-                                                data-test-subj="fieldToggle-resp_code"
-                                                display="fill"
-                                                iconType="cross"
-                                                isDisabled={true}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-resp_code"
+                                                title="resp_code"
                                               >
-                                                <button
+                                                resp_code
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Remove resp_code from table"
-                                                  className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
                                                   data-test-subj="fieldToggle-resp_code"
-                                                  disabled={true}
-                                                  type="button"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="cross"
+                                                  <button
+                                                    aria-label="Remove resp_code from table"
+                                                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-resp_code"
+                                                    disabled={true}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="cross"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="sum_bytes"
-                            key="fieldsum_bytes"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "sum_bytes",
-                                  "type": "long",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={true}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={true}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={false}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="sum_bytes"
+                              key="fieldsum_bytes"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-sum_bytes-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Remove sum_bytes from table"
-                                              className="dscSidebarItem__action"
-                                              color="ghost"
-                                              data-test-subj="fieldToggle-sum_bytes"
-                                              display="fill"
-                                              iconType="cross"
-                                              isDisabled={true}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="long"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-sum_bytes"
-                                        title="sum_bytes"
-                                      >
-                                        sum_bytes
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "sum_bytes",
+                                    "type": "long",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={true}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={true}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={false}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-sum_bytes-showDetails"
@@ -2504,494 +2450,483 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-sum_bytes-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="long"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-sum_bytes-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="long"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="long"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Remove sum_bytes from table"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
+                                                  data-test-subj="fieldToggle-sum_bytes"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="long"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-sum_bytes"
+                                            title="sum_bytes"
+                                          >
+                                            sum_bytes
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-sum_bytes-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="long"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="long"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="long"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="long"
-                                                    size="l"
-                                                    title="long"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="long"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="long"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="long"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-sum_bytes"
-                                              title="sum_bytes"
-                                            >
-                                              sum_bytes
+                                                        title="long"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="long"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Toggle button is disabled on query contains 'stats' or no hits for the search"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Remove sum_bytes from table"
-                                                className="dscSidebarItem__action"
-                                                color="ghost"
-                                                data-test-subj="fieldToggle-sum_bytes"
-                                                display="fill"
-                                                iconType="cross"
-                                                isDisabled={true}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-sum_bytes"
+                                                title="sum_bytes"
                                               >
-                                                <button
+                                                sum_bytes
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Toggle button is disabled on query contains 'stats' or no hits for the search"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Remove sum_bytes from table"
-                                                  className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="ghost"
                                                   data-test-subj="fieldToggle-sum_bytes"
-                                                  disabled={true}
-                                                  type="button"
+                                                  display="fill"
+                                                  iconType="cross"
+                                                  isDisabled={true}
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="cross"
+                                                  <button
+                                                    aria-label="Remove sum_bytes from table"
+                                                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--ghost euiButtonIcon--fill euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-sum_bytes"
+                                                    disabled={true}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="cross"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                        </ul>
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
-                    </div>
-                  </EuiResizeObserver>
+                    </EuiResizeObserver>
+                  </div>
                 </div>
-              </div>
-            </EuiAccordion>
-            <EuiSpacer
-              size="s"
-            >
-              <div
-                className="euiSpacer euiSpacer--s"
-              />
-            </EuiSpacer>
-            <EuiAccordion
-              arrowDisplay="left"
-              buttonContent={
-                <EuiTitle
-                  size="xxxs"
-                >
-                  <span>
-                    Selected Fields
-                  </span>
-                </EuiTitle>
-              }
-              id="fieldSelector__selectedFields"
-              initialIsOpen={true}
-              isLoading={false}
-              isLoadingMessage={false}
-              paddingSize="xs"
-            >
-              <div
-                className="euiAccordion euiAccordion-isOpen"
+              </EuiAccordion>
+              <EuiSpacer
+                size="s"
               >
                 <div
-                  className="euiAccordion__triggerWrapper"
-                >
-                  <button
-                    aria-controls="fieldSelector__selectedFields"
-                    aria-expanded={true}
-                    className="euiAccordion__button"
-                    id="random_html_id"
-                    onClick={[Function]}
-                    type="button"
+                  className="euiSpacer euiSpacer--s"
+                />
+              </EuiSpacer>
+              <EuiAccordion
+                arrowDisplay="left"
+                buttonContent={
+                  <EuiTitle
+                    size="xxxs"
                   >
-                    <span
-                      className="euiAccordion__iconWrapper"
+                    <span>
+                      Selected Fields
+                    </span>
+                  </EuiTitle>
+                }
+                id="fieldSelector__selectedFields"
+                initialIsOpen={true}
+                isLoading={false}
+                isLoadingMessage={false}
+                paddingSize="xs"
+              >
+                <div
+                  className="euiAccordion euiAccordion-isOpen"
+                >
+                  <div
+                    className="euiAccordion__triggerWrapper"
+                  >
+                    <button
+                      aria-controls="fieldSelector__selectedFields"
+                      aria-expanded={true}
+                      className="euiAccordion__button"
+                      id="random_html_id"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <EuiIcon
-                        className="euiAccordion__icon euiAccordion__icon-isOpen"
-                        size="m"
-                        type="arrowRight"
+                      <span
+                        className="euiAccordion__iconWrapper"
                       >
-                        <EuiIconEmpty
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
-                          focusable="false"
-                          role="img"
-                          style={null}
+                        <EuiIcon
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          size="m"
+                          type="arrowRight"
                         >
-                          <svg
+                          <EuiIconEmpty
                             aria-hidden={true}
                             className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
                             focusable="false"
-                            height={16}
                             role="img"
                             style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </EuiIconEmpty>
-                      </EuiIcon>
-                    </span>
-                    <span
-                      className="euiIEFlexWrapFix"
-                    >
-                      <EuiTitle
-                        size="xxxs"
-                      >
-                        <span
-                          className="euiTitle euiTitle--xxxsmall"
-                        >
-                          Selected Fields
-                        </span>
-                      </EuiTitle>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  aria-labelledby="random_html_id"
-                  className="euiAccordion__childWrapper"
-                  id="fieldSelector__selectedFields"
-                  role="region"
-                  tabIndex={-1}
-                >
-                  <EuiResizeObserver
-                    onResize={[Function]}
-                  >
-                    <div>
-                      <div
-                        className="euiAccordion__padding--xs"
-                      >
-                        <ul
-                          aria-labelledby="selected_fields"
-                          className="dscSidebarList dscFieldList--selected"
-                          data-test-subj="fieldList-selected"
-                        />
-                      </div>
-                    </div>
-                  </EuiResizeObserver>
-                </div>
-              </div>
-            </EuiAccordion>
-            <EuiSpacer
-              size="s"
-            >
-              <div
-                className="euiSpacer euiSpacer--s"
-              />
-            </EuiSpacer>
-            <EuiAccordion
-              arrowDisplay="left"
-              buttonContent={
-                <EuiTitle
-                  size="xxxs"
-                >
-                  <span>
-                    Available Fields
-                  </span>
-                </EuiTitle>
-              }
-              id="fieldSelector__availableFields"
-              initialIsOpen={true}
-              isLoading={false}
-              isLoadingMessage={false}
-              paddingSize="xs"
-            >
-              <div
-                className="euiAccordion euiAccordion-isOpen"
-              >
-                <div
-                  className="euiAccordion__triggerWrapper"
-                >
-                  <button
-                    aria-controls="fieldSelector__availableFields"
-                    aria-expanded={true}
-                    className="euiAccordion__button"
-                    id="random_html_id"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="euiAccordion__iconWrapper"
-                    >
-                      <EuiIcon
-                        className="euiAccordion__icon euiAccordion__icon-isOpen"
-                        size="m"
-                        type="arrowRight"
-                      >
-                        <EuiIconEmpty
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </EuiIconEmpty>
-                      </EuiIcon>
-                    </span>
-                    <span
-                      className="euiIEFlexWrapFix"
-                    >
-                      <EuiTitle
-                        size="xxxs"
-                      >
-                        <span
-                          className="euiTitle euiTitle--xxxsmall"
-                        >
-                          Available Fields
-                        </span>
-                      </EuiTitle>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  aria-labelledby="random_html_id"
-                  className="euiAccordion__childWrapper"
-                  id="fieldSelector__availableFields"
-                  role="region"
-                  tabIndex={-1}
-                >
-                  <EuiResizeObserver
-                    onResize={[Function]}
-                  >
-                    <div>
-                      <div
-                        className="euiAccordion__padding--xs"
-                      >
-                        <ul
-                          aria-labelledby="available_fields"
-                          className="dscFieldList dscFieldList--unpopular hidden-sm hidden-xs"
-                          data-test-subj="fieldList-unpopular"
-                        >
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="agent"
-                            key="fieldagent"
                           >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "agent",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                            <svg
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            />
+                          </EuiIconEmpty>
+                        </EuiIcon>
+                      </span>
+                      <span
+                        className="euiIEFlexWrapFix"
+                      >
+                        <EuiTitle
+                          size="xxxs"
+                        >
+                          <span
+                            className="euiTitle euiTitle--xxxsmall"
+                          >
+                            Selected Fields
+                          </span>
+                        </EuiTitle>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-labelledby="random_html_id"
+                    className="euiAccordion__childWrapper"
+                    id="fieldSelector__selectedFields"
+                    role="region"
+                    tabIndex={-1}
+                  >
+                    <EuiResizeObserver
+                      onResize={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="euiAccordion__padding--xs"
+                        >
+                          <ul
+                            aria-labelledby="selected_fields"
+                            className="dscSidebarList dscFieldList--selected"
+                            data-test-subj="fieldList-selected"
+                          />
+                        </div>
+                      </div>
+                    </EuiResizeObserver>
+                  </div>
+                </div>
+              </EuiAccordion>
+              <EuiSpacer
+                size="s"
+              >
+                <div
+                  className="euiSpacer euiSpacer--s"
+                />
+              </EuiSpacer>
+              <EuiAccordion
+                arrowDisplay="left"
+                buttonContent={
+                  <EuiTitle
+                    size="xxxs"
+                  >
+                    <span>
+                      Available Fields
+                    </span>
+                  </EuiTitle>
+                }
+                id="fieldSelector__availableFields"
+                initialIsOpen={true}
+                isLoading={false}
+                isLoadingMessage={false}
+                paddingSize="xs"
+              >
+                <div
+                  className="euiAccordion euiAccordion-isOpen"
+                >
+                  <div
+                    className="euiAccordion__triggerWrapper"
+                  >
+                    <button
+                      aria-controls="fieldSelector__availableFields"
+                      aria-expanded={true}
+                      className="euiAccordion__button"
+                      id="random_html_id"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="euiAccordion__iconWrapper"
+                      >
+                        <EuiIcon
+                          className="euiAccordion__icon euiAccordion__icon-isOpen"
+                          size="m"
+                          type="arrowRight"
+                        >
+                          <EuiIconEmpty
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
+                            focusable="false"
+                            role="img"
+                            style={null}
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon euiAccordion__icon-isOpen"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            />
+                          </EuiIconEmpty>
+                        </EuiIcon>
+                      </span>
+                      <span
+                        className="euiIEFlexWrapFix"
+                      >
+                        <EuiTitle
+                          size="xxxs"
+                        >
+                          <span
+                            className="euiTitle euiTitle--xxxsmall"
+                          >
+                            Available Fields
+                          </span>
+                        </EuiTitle>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    aria-labelledby="random_html_id"
+                    className="euiAccordion__childWrapper"
+                    id="fieldSelector__availableFields"
+                    role="region"
+                    tabIndex={-1}
+                  >
+                    <EuiResizeObserver
+                      onResize={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="euiAccordion__padding--xs"
+                        >
+                          <ul
+                            aria-labelledby="available_fields"
+                            className="dscFieldList dscFieldList--unpopular hidden-sm hidden-xs"
+                            data-test-subj="fieldList-unpopular"
+                          >
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="agent"
+                              key="fieldagent"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-agent-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add agent to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-agent"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-agent"
-                                        title="agent"
-                                      >
-                                        agent
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "agent",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-agent-showDetails"
@@ -3060,314 +2995,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-agent-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-agent-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add agent to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-agent"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-agent"
+                                            title="agent"
+                                          >
+                                            agent
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-agent-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-agent"
-                                              title="agent"
-                                            >
-                                              agent
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-agent"
+                                                title="agent"
                                               >
-                                                <button
+                                                agent
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add agent to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-agent"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add agent to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-agent"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add agent to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-agent"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="bytes"
-                            key="fieldbytes"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "bytes",
-                                  "type": "long",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="bytes"
+                              key="fieldbytes"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-bytes-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add bytes to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-bytes"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="long"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-bytes"
-                                        title="bytes"
-                                      >
-                                        bytes
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "bytes",
+                                    "type": "long",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-bytes-showDetails"
@@ -3424,267 +3371,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-bytes-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="long"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-bytes-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="long"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="long"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add bytes to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-bytes"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="long"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-bytes"
+                                            title="bytes"
+                                          >
+                                            bytes
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-bytes-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="long"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="long"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="long"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="long"
-                                                    size="l"
-                                                    title="long"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="long"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="long"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="long"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-bytes"
-                                              title="bytes"
-                                            >
-                                              bytes
+                                                        title="long"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="long"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add bytes to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-bytes"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-bytes"
+                                                title="bytes"
                                               >
-                                                <button
+                                                bytes
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add bytes to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-bytes"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add bytes to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-bytes"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="clientip"
-                            key="fieldclientip"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "clientip",
-                                  "type": "ip",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="clientip"
+                              key="fieldclientip"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-clientip-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add clientip to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-clientip"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="ip"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-clientip"
-                                        title="clientip"
-                                      >
-                                        clientip
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "clientip",
+                                    "type": "ip",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-clientip-showDetails"
@@ -3741,267 +3688,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-clientip-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="ip"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-clientip-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="ip"
-                                                className="osdFieldIcon"
-                                                iconType="tokenIP"
-                                                size="l"
-                                                title="ip"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add clientip to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-clientip"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="ip"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-clientip"
+                                            title="clientip"
+                                          >
+                                            clientip
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-clientip-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="ip"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis9 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="ip"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenIP"
+                                                  size="l"
+                                                  title="ip"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="ip"
-                                                    size="l"
-                                                    title="ip"
-                                                    type="tokenIP"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis9 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="ip"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="ip"
+                                                      type="tokenIP"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="ip"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-clientip"
-                                              title="clientip"
-                                            >
-                                              clientip
+                                                        title="ip"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="ip"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add clientip to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-clientip"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-clientip"
+                                                title="clientip"
                                               >
-                                                <button
+                                                clientip
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add clientip to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-clientip"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add clientip to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-clientip"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="event"
-                            key="fieldevent"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "event",
-                                  "type": "struct",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="event"
+                              key="fieldevent"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-event-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add event to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-event"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="struct"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-event"
-                                        title="event"
-                                      >
-                                        event
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "event",
+                                    "type": "struct",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-event-showDetails"
@@ -4058,279 +4005,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-event-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="struct"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-event-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="struct"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="struct"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add event to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-event"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="struct"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-event"
+                                            title="event"
+                                          >
+                                            event
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-event-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="struct"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="struct"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="struct"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="struct"
-                                                    size="l"
-                                                    title="struct"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="struct"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="struct"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="struct"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-event"
-                                              title="event"
-                                            >
-                                              event
+                                                        title="struct"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="struct"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add event to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-event"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-event"
+                                                title="event"
                                               >
-                                                <button
+                                                event
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add event to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-event"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add event to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-event"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="extension"
-                            key="fieldextension"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "extension",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="extension"
+                              key="fieldextension"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-extension-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add extension to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-extension"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-extension"
-                                        title="extension"
-                                      >
-                                        extension
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "extension",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-extension-showDetails"
@@ -4399,314 +4334,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-extension-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-extension-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add extension to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-extension"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-extension"
+                                            title="extension"
+                                          >
+                                            extension
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-extension-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-extension"
-                                              title="extension"
-                                            >
-                                              extension
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-extension"
+                                                title="extension"
                                               >
-                                                <button
+                                                extension
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add extension to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-extension"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add extension to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-extension"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add extension to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-extension"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="geo"
-                            key="fieldgeo"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "geo",
-                                  "type": "struct",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="geo"
+                              key="fieldgeo"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-geo-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add geo to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-geo"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="struct"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-geo"
-                                        title="geo"
-                                      >
-                                        geo
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "geo",
+                                    "type": "struct",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-geo-showDetails"
@@ -4763,279 +4710,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-geo-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="struct"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-geo-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="struct"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="struct"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add geo to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-geo"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="struct"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-geo"
+                                            title="geo"
+                                          >
+                                            geo
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-geo-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="struct"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="struct"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="struct"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="struct"
-                                                    size="l"
-                                                    title="struct"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="struct"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="struct"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="struct"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-geo"
-                                              title="geo"
-                                            >
-                                              geo
+                                                        title="struct"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="struct"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add geo to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-geo"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-geo"
+                                                title="geo"
                                               >
-                                                <button
+                                                geo
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add geo to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-geo"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add geo to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-geo"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="host"
-                            key="fieldhost"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "host",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="host"
+                              key="fieldhost"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-host-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add host to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-host"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-host"
-                                        title="host"
-                                      >
-                                        host
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "host",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-host-showDetails"
@@ -5104,326 +5039,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-host-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-host-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add host to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-host"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-host"
+                                            title="host"
+                                          >
+                                            host
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-host-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-host"
-                                              title="host"
-                                            >
-                                              host
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-host"
+                                                title="host"
                                               >
-                                                <button
+                                                host
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add host to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-host"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add host to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-host"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add host to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-host"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="index"
-                            key="fieldindex"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "index",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="index"
+                              key="fieldindex"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-index-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add index to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-index"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-index"
-                                        title="index"
-                                      >
-                                        index
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "index",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-index-showDetails"
@@ -5492,314 +5427,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-index-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-index-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add index to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-index"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-index"
+                                            title="index"
+                                          >
+                                            index
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-index-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-index"
-                                              title="index"
-                                            >
-                                              index
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-index"
+                                                title="index"
                                               >
-                                                <button
+                                                index
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add index to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-index"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add index to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-index"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add index to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-index"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="ip"
-                            key="fieldip"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "ip",
-                                  "type": "ip",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="ip"
+                              key="fieldip"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-ip-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add ip to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-ip"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="ip"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-ip"
-                                        title="ip"
-                                      >
-                                        ip
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "ip",
+                                    "type": "ip",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-ip-showDetails"
@@ -5856,267 +5803,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-ip-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="ip"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-ip-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="ip"
-                                                className="osdFieldIcon"
-                                                iconType="tokenIP"
-                                                size="l"
-                                                title="ip"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add ip to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-ip"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="ip"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-ip"
+                                            title="ip"
+                                          >
+                                            ip
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-ip-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="ip"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis9 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="ip"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenIP"
+                                                  size="l"
+                                                  title="ip"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="ip"
-                                                    size="l"
-                                                    title="ip"
-                                                    type="tokenIP"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis9 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="ip"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="ip"
+                                                      type="tokenIP"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="ip"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-ip"
-                                              title="ip"
-                                            >
-                                              ip
+                                                        title="ip"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="ip"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add ip to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-ip"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-ip"
+                                                title="ip"
                                               >
-                                                <button
+                                                ip
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add ip to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-ip"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add ip to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-ip"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="machine"
-                            key="fieldmachine"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "machine",
-                                  "type": "struct",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="machine"
+                              key="fieldmachine"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-machine-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add machine to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-machine"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="struct"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-machine"
-                                        title="machine"
-                                      >
-                                        machine
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "machine",
+                                    "type": "struct",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-machine-showDetails"
@@ -6173,267 +6120,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-machine-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="struct"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-machine-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="struct"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="struct"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add machine to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-machine"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="struct"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-machine"
+                                            title="machine"
+                                          >
+                                            machine
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-machine-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="struct"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="struct"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="struct"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="struct"
-                                                    size="l"
-                                                    title="struct"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="struct"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="struct"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="struct"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-machine"
-                                              title="machine"
-                                            >
-                                              machine
+                                                        title="struct"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="struct"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add machine to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-machine"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-machine"
+                                                title="machine"
                                               >
-                                                <button
+                                                machine
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add machine to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-machine"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add machine to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-machine"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="memory"
-                            key="fieldmemory"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "memory",
-                                  "type": "double",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="memory"
+                              key="fieldmemory"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-memory-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add memory to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-memory"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="double"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-memory"
-                                        title="memory"
-                                      >
-                                        memory
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "memory",
+                                    "type": "double",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-memory-showDetails"
@@ -6490,279 +6437,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-memory-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="double"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-memory-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="double"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="double"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add memory to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-memory"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="double"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-memory"
+                                            title="memory"
+                                          >
+                                            memory
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-memory-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="double"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="double"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="double"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="double"
-                                                    size="l"
-                                                    title="double"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="double"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="double"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="double"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-memory"
-                                              title="memory"
-                                            >
-                                              memory
+                                                        title="double"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="double"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add memory to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-memory"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-memory"
+                                                title="memory"
                                               >
-                                                <button
+                                                memory
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add memory to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-memory"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add memory to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-memory"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="message"
-                            key="fieldmessage"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "message",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="message"
+                              key="fieldmessage"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-message-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add message to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-message"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-message"
-                                        title="message"
-                                      >
-                                        message
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "message",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-message-showDetails"
@@ -6831,314 +6766,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-message-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-message-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add message to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-message"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-message"
+                                            title="message"
+                                          >
+                                            message
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-message-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-message"
-                                              title="message"
-                                            >
-                                              message
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-message"
+                                                title="message"
                                               >
-                                                <button
+                                                message
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add message to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-message"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add message to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-message"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add message to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-message"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="phpmemory"
-                            key="fieldphpmemory"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "phpmemory",
-                                  "type": "long",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="phpmemory"
+                              key="fieldphpmemory"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-phpmemory-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add phpmemory to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-phpmemory"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="long"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-phpmemory"
-                                        title="phpmemory"
-                                      >
-                                        phpmemory
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "phpmemory",
+                                    "type": "long",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-phpmemory-showDetails"
@@ -7195,279 +7142,267 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-phpmemory-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="long"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-phpmemory-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="long"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="long"
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add phpmemory to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-phpmemory"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="long"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-phpmemory"
+                                            title="phpmemory"
+                                          >
+                                            phpmemory
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-phpmemory-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="long"
                                               >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                                <EuiToken
+                                                  aria-label="long"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="long"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="long"
-                                                    size="l"
-                                                    title="long"
-                                                    type="tokenString"
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="long"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="long"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="long"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-phpmemory"
-                                              title="phpmemory"
-                                            >
-                                              phpmemory
+                                                        title="long"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="long"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add phpmemory to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-phpmemory"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-phpmemory"
+                                                title="phpmemory"
                                               >
-                                                <button
+                                                phpmemory
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Add phpmemory to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-phpmemory"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add phpmemory to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-phpmemory"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="referer"
-                            key="fieldreferer"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "referer",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="referer"
+                              key="fieldreferer"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-referer-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add referer to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-referer"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-referer"
-                                        title="referer"
-                                      >
-                                        referer
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "referer",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-referer-showDetails"
@@ -7536,326 +7471,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-referer-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-referer-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add referer to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-referer"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-referer"
+                                            title="referer"
+                                          >
+                                            referer
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-referer-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-referer"
-                                              title="referer"
-                                            >
-                                              referer
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-referer"
+                                                title="referer"
                                               >
-                                                <button
+                                                referer
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add referer to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-referer"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add referer to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-referer"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add referer to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-referer"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="request"
-                            key="fieldrequest"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "request",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="request"
+                              key="fieldrequest"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-request-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add request to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-request"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-request"
-                                        title="request"
-                                      >
-                                        request
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "request",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-request-showDetails"
@@ -7924,326 +7859,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-request-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-request-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add request to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-request"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-request"
+                                            title="request"
+                                          >
+                                            request
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-request-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-request"
-                                              title="request"
-                                            >
-                                              request
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-request"
+                                                title="request"
                                               >
-                                                <button
+                                                request
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add request to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-request"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add request to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-request"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add request to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-request"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="response"
-                            key="fieldresponse"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "response",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="response"
+                              key="fieldresponse"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-response-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add response to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-response"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-response"
-                                        title="response"
-                                      >
-                                        response
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "response",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-response-showDetails"
@@ -8312,326 +8247,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-response-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-response-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add response to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-response"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-response"
+                                            title="response"
+                                          >
+                                            response
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-response-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-response"
-                                              title="response"
-                                            >
-                                              response
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-response"
+                                                title="response"
                                               >
-                                                <button
+                                                response
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add response to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-response"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add response to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-response"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add response to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-response"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="tags"
-                            key="fieldtags"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "tags",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="tags"
+                              key="fieldtags"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-tags-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add tags to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-tags"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-tags"
-                                        title="tags"
-                                      >
-                                        tags
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "tags",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-tags-showDetails"
@@ -8700,320 +8635,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-tags-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-tags-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add tags to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-tags"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-tags"
+                                            title="tags"
+                                          >
+                                            tags
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-tags-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-tags"
-                                              title="tags"
-                                            >
-                                              tags
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-tags"
+                                                title="tags"
                                               >
-                                                <button
+                                                tags
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add tags to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-tags"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add tags to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-tags"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add tags to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-tags"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="timestamp"
-                            key="fieldtimestamp"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "timestamp",
-                                  "type": "timestamp",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="timestamp"
+                              key="fieldtimestamp"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-timestamp-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiMark
-                                              data-test-subj="eventFields__default-timestamp-mark"
-                                            >
-                                              Default Timestamp
-                                            </EuiMark>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add timestamp to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-timestamp"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="date"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-timestamp"
-                                        title="timestamp"
-                                      >
-                                        timestamp
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "timestamp",
+                                    "type": "timestamp",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-timestamp-showDetails"
@@ -9076,290 +9017,284 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-timestamp-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="date"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-timestamp-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="date"
-                                                className="osdFieldIcon"
-                                                iconType="tokenDate"
-                                                size="l"
-                                                title="date"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis6 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiMark
+                                                  data-test-subj="eventFields__default-timestamp-mark"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="date"
-                                                    size="l"
-                                                    title="date"
-                                                    type="tokenDate"
+                                                  Default Timestamp
+                                                </EuiMark>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add timestamp to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-timestamp"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="date"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-timestamp"
+                                            title="timestamp"
+                                          >
+                                            timestamp
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-timestamp-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="date"
+                                              >
+                                                <EuiToken
+                                                  aria-label="date"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenDate"
+                                                  size="l"
+                                                  title="date"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis6 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="date"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="date"
+                                                      type="tokenDate"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="date"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-timestamp"
-                                              title="timestamp"
-                                            >
-                                              timestamp
+                                                        title="date"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="date"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiMark
-                                                data-test-subj="eventFields__default-timestamp-mark"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-timestamp"
+                                                title="timestamp"
                                               >
-                                                <mark
-                                                  className="euiMark"
+                                                timestamp
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiMark
                                                   data-test-subj="eventFields__default-timestamp-mark"
                                                 >
-                                                  Default Timestamp
-                                                </mark>
-                                              </EuiMark>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            >
-                                              <EuiButtonIcon
-                                                aria-label="Add timestamp to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-timestamp"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
-                                              >
-                                                <button
-                                                  aria-label="Add timestamp to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
-                                                  data-test-subj="fieldToggle-timestamp"
-                                                  disabled={false}
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <mark
+                                                    className="euiMark"
+                                                    data-test-subj="eventFields__default-timestamp-mark"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    Default Timestamp
+                                                  </mark>
+                                                </EuiMark>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
+                                                  aria-label="Add timestamp to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-timestamp"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                >
+                                                  <button
+                                                    aria-label="Add timestamp to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-timestamp"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
+                                                  >
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="url"
-                            key="fieldurl"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "url",
-                                  "type": "string",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="url"
+                              key="fieldurl"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-url-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_pattern"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultPattern"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add url to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-url"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="string"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-url"
-                                        title="url"
-                                      >
-                                        url
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "url",
+                                    "type": "string",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-url-showDetails"
@@ -9428,326 +9363,326 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-url-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="string"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-url-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="string"
-                                                className="osdFieldIcon"
-                                                iconType="tokenString"
-                                                size="l"
-                                                title="string"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_pattern"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="string"
-                                                    size="l"
-                                                    title="string"
-                                                    type="tokenString"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add url to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-url"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="string"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-url"
+                                            title="url"
+                                          >
+                                            url
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-url-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="string"
+                                              >
+                                                <EuiToken
+                                                  aria-label="string"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenString"
+                                                  size="l"
+                                                  title="string"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="string"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="string"
+                                                      type="tokenString"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="string"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-url"
-                                              title="url"
-                                            >
-                                              url
+                                                        title="string"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="string"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_pattern"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-url"
+                                                title="url"
                                               >
-                                                <button
+                                                url
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_pattern"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_pattern"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add url to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-url"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add url to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-url"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add url to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-url"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                          <li
-                            className="dscSidebar__item"
-                            data-attr-field="utc_time"
-                            key="fieldutc_time"
-                          >
-                            <Field
-                              field={
-                                Object {
-                                  "name": "utc_time",
-                                  "type": "timestamp",
-                                }
-                              }
-                              handleOverrideTimestamp={[MockFunction]}
-                              isFieldToggleButtonDisabled={false}
-                              isOverridingTimestamp={false}
-                              onToggleField={[MockFunction]}
-                              selected={false}
-                              selectedTimestamp="timestamp"
-                              showTimestampOverrideButton={true}
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                            <li
+                              className="dscSidebar__item"
+                              data-attr-field="utc_time"
+                              key="fieldutc_time"
                             >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <FieldButton
-                                    className="shard__fieldSelectorField explorer__fieldSelectorField"
-                                    dataTestSubj="field-utc_time-showDetails"
-                                    fieldAction={
-                                      <React.Fragment>
-                                        <EuiToolTip
-                                          content="Override default pattern"
-                                          delay="long"
-                                          id="override-pattern"
-                                          position="top"
-                                        >
-                                          <React.Fragment />
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Override default timestamp"
-                                          delay="long"
-                                          id="override-timestamp"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-labelledby="override_timestamp"
-                                              className="dscSidebarItem__action"
-                                              color="text"
-                                              data-test-subj="eventExplorer__overrideDefaultTimestamp"
-                                              iconType="inputOutput"
-                                              onClick={[Function]}
-                                              size="s"
-                                            >
-                                              Override
-                                            </EuiButtonIcon>
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                        <EuiToolTip
-                                          content="Add field as column"
-                                          delay="long"
-                                          position="top"
-                                        >
-                                          <React.Fragment>
-                                            <EuiButtonIcon
-                                              aria-label="Add utc_time to table"
-                                              className="dscSidebarItem__action"
-                                              color="primary"
-                                              data-test-subj="fieldToggle-utc_time"
-                                              iconType="plusInCircleFilled"
-                                              onClick={[Function]}
-                                            />
-                                          </React.Fragment>
-                                        </EuiToolTip>
-                                      </React.Fragment>
-                                    }
-                                    fieldIcon={
-                                      <FieldIcon
-                                        type="date"
-                                      />
-                                    }
-                                    fieldName={
-                                      <span
-                                        className="dscSidebarField__name"
-                                        data-test-subj="field-utc_time"
-                                        title="utc_time"
-                                      >
-                                        utc_time
-                                      </span>
-                                    }
-                                    isActive={false}
-                                    onClick={[Function]}
-                                    size="m"
-                                  />
+                              <Field
+                                field={
+                                  Object {
+                                    "name": "utc_time",
+                                    "type": "timestamp",
+                                  }
                                 }
-                                closePopover={[Function]}
-                                display="block"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelClassName="dscSidebarItem__fieldPopoverPanel"
-                                panelPaddingSize="m"
+                                handleOverrideTimestamp={[MockFunction]}
+                                isFieldToggleButtonDisabled={false}
+                                isOverridingTimestamp={false}
+                                onToggleField={[Function]}
+                                selected={false}
+                                selectedTimestamp="timestamp"
+                                showTimestampOverrideButton={true}
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="rightUp"
+                                  button={
                                     <FieldButton
                                       className="shard__fieldSelectorField explorer__fieldSelectorField"
                                       dataTestSubj="field-utc_time-showDetails"
@@ -9816,230 +9751,315 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                       isActive={false}
                                       onClick={[Function]}
                                       size="m"
+                                    />
+                                  }
+                                  closePopover={[Function]}
+                                  display="block"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelClassName="dscSidebarItem__fieldPopoverPanel"
+                                  panelPaddingSize="m"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
                                     >
-                                      <div
-                                        className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
-                                      >
-                                        <button
-                                          className="osd-resetFocusState osdFieldButton__button"
-                                          data-test-subj="field-utc_time-showDetails"
-                                          onClick={[Function]}
-                                        >
-                                          <span
-                                            className="osdFieldButton__fieldIcon"
-                                          >
-                                            <FieldIcon
-                                              type="date"
+                                      <FieldButton
+                                        className="shard__fieldSelectorField explorer__fieldSelectorField"
+                                        dataTestSubj="field-utc_time-showDetails"
+                                        fieldAction={
+                                          <React.Fragment>
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
                                             >
-                                              <EuiToken
-                                                aria-label="date"
-                                                className="osdFieldIcon"
-                                                iconType="tokenDate"
-                                                size="l"
-                                                title="date"
-                                              >
-                                                <span
-                                                  className="euiToken euiToken--euiColorVis6 euiToken--square euiToken--light euiToken--large osdFieldIcon"
-                                                  style={Object {}}
+                                              <React.Fragment />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-labelledby="override_timestamp"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
+                                                  data-test-subj="eventExplorer__overrideDefaultTimestamp"
+                                                  iconType="inputOutput"
+                                                  onClick={[Function]}
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-label="date"
-                                                    size="l"
-                                                    title="date"
-                                                    type="tokenDate"
+                                                  Override
+                                                </EuiButtonIcon>
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
+                                            >
+                                              <React.Fragment>
+                                                <EuiButtonIcon
+                                                  aria-label="Add utc_time to table"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
+                                                  data-test-subj="fieldToggle-utc_time"
+                                                  iconType="plusInCircleFilled"
+                                                  onClick={[Function]}
+                                                />
+                                              </React.Fragment>
+                                            </EuiToolTip>
+                                          </React.Fragment>
+                                        }
+                                        fieldIcon={
+                                          <FieldIcon
+                                            type="date"
+                                          />
+                                        }
+                                        fieldName={
+                                          <span
+                                            className="dscSidebarField__name"
+                                            data-test-subj="field-utc_time"
+                                            title="utc_time"
+                                          >
+                                            utc_time
+                                          </span>
+                                        }
+                                        isActive={false}
+                                        onClick={[Function]}
+                                        size="m"
+                                      >
+                                        <div
+                                          className="osdFieldButton shard__fieldSelectorField explorer__fieldSelectorField"
+                                        >
+                                          <button
+                                            className="osd-resetFocusState osdFieldButton__button"
+                                            data-test-subj="field-utc_time-showDetails"
+                                            onClick={[Function]}
+                                          >
+                                            <span
+                                              className="osdFieldButton__fieldIcon"
+                                            >
+                                              <FieldIcon
+                                                type="date"
+                                              >
+                                                <EuiToken
+                                                  aria-label="date"
+                                                  className="osdFieldIcon"
+                                                  iconType="tokenDate"
+                                                  size="l"
+                                                  title="date"
+                                                >
+                                                  <span
+                                                    className="euiToken euiToken--euiColorVis6 euiToken--square euiToken--light euiToken--large osdFieldIcon"
+                                                    style={Object {}}
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
+                                                    <EuiIcon
                                                       aria-label="date"
-                                                      className="euiIcon euiIcon--large euiIcon-isLoading"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                      size="l"
                                                       title="date"
+                                                      type="tokenDate"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         aria-label="date"
                                                         className="euiIcon euiIcon--large euiIcon-isLoading"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiToken>
-                                            </FieldIcon>
-                                          </span>
-                                          <span
-                                            className="osdFieldButton__name"
-                                          >
-                                            <span
-                                              className="dscSidebarField__name"
-                                              data-test-subj="field-utc_time"
-                                              title="utc_time"
-                                            >
-                                              utc_time
+                                                        title="date"
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          aria-label="date"
+                                                          className="euiIcon euiIcon--large euiIcon-isLoading"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </span>
+                                                </EuiToken>
+                                              </FieldIcon>
                                             </span>
-                                          </span>
-                                        </button>
-                                        <div
-                                          className="osdFieldButton__fieldAction"
-                                        >
-                                          <EuiToolTip
-                                            content="Override default pattern"
-                                            delay="long"
-                                            id="override-pattern"
-                                            position="top"
-                                          >
                                             <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            />
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Override default timestamp"
-                                            delay="long"
-                                            id="override-timestamp"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                              className="osdFieldButton__name"
                                             >
-                                              <EuiButtonIcon
-                                                aria-labelledby="override_timestamp"
-                                                className="dscSidebarItem__action"
-                                                color="text"
-                                                data-test-subj="eventExplorer__overrideDefaultTimestamp"
-                                                iconType="inputOutput"
-                                                onClick={[Function]}
-                                                size="s"
+                                              <span
+                                                className="dscSidebarField__name"
+                                                data-test-subj="field-utc_time"
+                                                title="utc_time"
                                               >
-                                                <button
+                                                utc_time
+                                              </span>
+                                            </span>
+                                          </button>
+                                          <div
+                                            className="osdFieldButton__fieldAction"
+                                          >
+                                            <EuiToolTip
+                                              content="Override default pattern"
+                                              delay="long"
+                                              id="override-pattern"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              />
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Override default timestamp"
+                                              delay="long"
+                                              id="override-timestamp"
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-labelledby="override_timestamp"
-                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="text"
                                                   data-test-subj="eventExplorer__overrideDefaultTimestamp"
-                                                  disabled={false}
+                                                  iconType="inputOutput"
                                                   onClick={[Function]}
-                                                  type="button"
+                                                  size="s"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="inputOutput"
+                                                  <button
+                                                    aria-labelledby="override_timestamp"
+                                                    className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--small dscSidebarItem__action"
+                                                    data-test-subj="eventExplorer__overrideDefaultTimestamp"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="inputOutput"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                          <EuiToolTip
-                                            content="Add field as column"
-                                            delay="long"
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                            <EuiToolTip
+                                              content="Add field as column"
+                                              delay="long"
+                                              position="top"
                                             >
-                                              <EuiButtonIcon
-                                                aria-label="Add utc_time to table"
-                                                className="dscSidebarItem__action"
-                                                color="primary"
-                                                data-test-subj="fieldToggle-utc_time"
-                                                iconType="plusInCircleFilled"
-                                                onClick={[Function]}
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                               >
-                                                <button
+                                                <EuiButtonIcon
                                                   aria-label="Add utc_time to table"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                  className="dscSidebarItem__action"
+                                                  color="primary"
                                                   data-test-subj="fieldToggle-utc_time"
-                                                  disabled={false}
+                                                  iconType="plusInCircleFilled"
                                                   onClick={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="plusInCircleFilled"
+                                                  <button
+                                                    aria-label="Add utc_time to table"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarItem__action"
+                                                    data-test-subj="fieldToggle-utc_time"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconEmpty
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="plusInCircleFilled"
                                                     >
-                                                      <svg
+                                                      <EuiIconEmpty
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        />
+                                                      </EuiIconEmpty>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </div>
                                         </div>
-                                      </div>
-                                    </FieldButton>
+                                      </FieldButton>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </Field>
-                          </li>
-                        </ul>
+                                </EuiPopover>
+                              </Field>
+                            </li>
+                          </ul>
+                        </div>
                       </div>
-                    </div>
-                  </EuiResizeObserver>
+                    </EuiResizeObserver>
+                  </div>
                 </div>
-              </div>
-            </EuiAccordion>
-          </div>
-        </section>
-      </PseudoLocaleWrapper>
-    </IntlProvider>
-  </I18nProvider>
-</Sidebar>
+              </EuiAccordion>
+            </div>
+          </section>
+        </PseudoLocaleWrapper>
+      </IntlProvider>
+    </I18nProvider>
+  </Sidebar>
+</Provider>
 `;

--- a/public/components/event_analytics/explorer/sidebar/__tests__/sidebar.test.tsx
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/sidebar.test.tsx
@@ -4,52 +4,64 @@
  */
 
 import { configure, mount } from 'enzyme';
+import { useDispatch, Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { Sidebar } from '../sidebar';
-import { 
-  SELECTED_FIELDS, 
+import {
+  SELECTED_FIELDS,
   AVAILABLE_FIELDS,
   UNSELECTED_FIELDS,
-  QUERIED_FIELDS
+  QUERIED_FIELDS,
 } from '../../../../../../common/constants/explorer';
-import { 
+import {
   AVAILABLE_FIELDS as SIDEBAR_AVAILABLE_FIELDS,
   QUERY_FIELDS,
   JSON_DATA,
-  JSON_DATA_ALL
+  JSON_DATA_ALL,
 } from '../../../../../../test/event_analytics_constants';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
 
 describe('Siderbar component', () => {
   configure({ adapter: new Adapter() });
+  const store = configureStore({
+    reducer: jest.fn(),
+  });
+  beforeEach(() => {
+    useDispatch.mockClear();
+    useDispatch.mockReturnValue(jest.fn());
+  });
 
   it('Renders empty sidebar component', async () => {
     const explorerFields = {
       [SELECTED_FIELDS]: [],
       [AVAILABLE_FIELDS]: [],
       [UNSELECTED_FIELDS]: [],
-      [QUERIED_FIELDS]: []
+      [QUERIED_FIELDS]: [],
     };
-    const handleAddField = jest.fn();
     const handleOverrideTimestamp = jest.fn();
     const selectedTimestamp = 'timestamp';
     const explorerData = {};
-    const handleRemoveField = jest.fn();
-    
+
     const wrapper = mount(
-      <Sidebar 
-        explorerFields={explorerFields}
-        explorerData={explorerData}
-        selectedTimestamp={selectedTimestamp}
-        handleOverrideTimestamp={handleOverrideTimestamp}
-        handleAddField={handleAddField}
-        handleRemoveField={handleRemoveField}
-        isFieldToggleButtonDisabled={false}
-        isOverridingTimestamp={false}
-      />
+      <Provider store={store}>
+        <Sidebar
+          explorerFields={explorerFields}
+          explorerData={explorerData}
+          selectedTimestamp={selectedTimestamp}
+          handleOverrideTimestamp={handleOverrideTimestamp}
+          isFieldToggleButtonDisabled={false}
+          isOverridingTimestamp={false}
+        />
+      </Provider>
     );
-    
+
     wrapper.update();
 
     await waitFor(() => {
@@ -62,28 +74,26 @@ describe('Siderbar component', () => {
       [SELECTED_FIELDS]: [],
       [UNSELECTED_FIELDS]: [],
       [AVAILABLE_FIELDS]: SIDEBAR_AVAILABLE_FIELDS,
-      [QUERIED_FIELDS]: QUERY_FIELDS
+      [QUERIED_FIELDS]: QUERY_FIELDS,
     };
-    const handleAddField = jest.fn();
     const handleOverrideTimestamp = jest.fn();
     const selectedTimestamp = 'timestamp';
     const explorerData = {
-      'jsonData': JSON_DATA,
-      'jsonDataAll': JSON_DATA_ALL
+      jsonData: JSON_DATA,
+      jsonDataAll: JSON_DATA_ALL,
     };
-    const handleRemoveField = jest.fn();
-    
+
     const wrapper = mount(
-      <Sidebar 
-        explorerFields={explorerFields}
-        explorerData={explorerData}
-        selectedTimestamp={selectedTimestamp}
-        handleOverrideTimestamp={handleOverrideTimestamp}
-        handleAddField={handleAddField}
-        handleRemoveField={handleRemoveField}
-        isFieldToggleButtonDisabled={false}
-        isOverridingTimestamp={false}
-      />
+      <Provider store={store}>
+        <Sidebar
+          explorerFields={explorerFields}
+          explorerData={explorerData}
+          selectedTimestamp={selectedTimestamp}
+          handleOverrideTimestamp={handleOverrideTimestamp}
+          isFieldToggleButtonDisabled={false}
+          isOverridingTimestamp={false}
+        />
+      </Provider>
     );
 
     await waitFor(() => {

--- a/public/components/event_analytics/explorer/visualizations/index.tsx
+++ b/public/components/event_analytics/explorer/visualizations/index.tsx
@@ -29,8 +29,6 @@ interface IExplorerVisualizationsProps {
   explorerVis: any;
   explorerFields: ExplorerFields;
   explorerData: any;
-  handleAddField: (field: IField) => void;
-  handleRemoveField: (field: IField) => void;
   visualizations: IVisualizationContainerProps;
   handleOverrideTimestamp: (field: IField) => void;
   callback?: any;
@@ -44,8 +42,6 @@ export const ExplorerVisualizations = ({
   explorerVis,
   explorerFields,
   explorerData,
-  handleAddField,
-  handleRemoveField,
   visualizations,
   handleOverrideTimestamp,
   callback,
@@ -111,8 +107,6 @@ export const ExplorerVisualizations = ({
                     explorerData={explorerData}
                     selectedTimestamp={visualizations?.data?.query[SELECTED_TIMESTAMP] || ''}
                     handleOverrideTimestamp={handleOverrideTimestamp}
-                    handleAddField={(field: IField) => handleAddField(field)}
-                    handleRemoveField={(field: IField) => handleRemoveField(field)}
                     isFieldToggleButtonDisabled={
                       vis.name === VIS_CHART_TYPES.LogsView
                         ? isEmpty(explorerData.jsonData) ||

--- a/public/components/event_analytics/hooks/use_fetch_events.ts
+++ b/public/components/event_analytics/hooks/use_fetch_events.ts
@@ -83,6 +83,7 @@ export const useFetchEvents = ({ pplService, requestParams }: IFetchEventsParams
             [UNSELECTED_FIELDS]: res?.schema ? [...res.schema] : [],
             [QUERIED_FIELDS]: [],
             [AVAILABLE_FIELDS]: res?.schema || [],
+            [SELECTED_FIELDS]: [],
           },
         })
       );


### PR DESCRIPTION
### Description
Sidebar related refactoring

- move fields toggling functions to under sidebar component rather than under explorer.tsx
- fix a bug -> when switching to a different index, previous selected fields still shows up under selected fields
  - currently any new refresh button click to trigger a search would clear out the selected fields if there are any, as it does not yet have the capability to detect index change for updating fields accordingly. To add such index difference detection would add to data fetching flow which is under refactoring. We may need to add support to update all fields only when index changes
- update tests/snapshots

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
