### PR TITLE
[Fix] Panels/Dashboard Duplicate Action fails when source is saved-object

### DIFF
--- a/.cypress/integration/3_panels.spec.ts
+++ b/.cypress/integration/3_panels.spec.ts
@@ -110,7 +110,7 @@ describe('Testing panels table', () => {
       moveToPanelHome();
     });
 
-    it('Duplicates a legacy panel', () => {
+    it('Duplicates the legacy panel', () => {
       cy.get('.euiTableRow').should('have.length', 1);
       selectThePanel();
       openActionsDropdown();
@@ -123,7 +123,7 @@ describe('Testing panels table', () => {
       expectUuid(duplicate);
     });
 
-    it('Renames the panel', () => {
+    it('Renames the legacy panel', () => {
       createLegacyPanel();
       cy.reload();
       const cell = cy.get('.euiTableCellContent');
@@ -137,7 +137,7 @@ describe('Testing panels table', () => {
       expectUuid(renamed);
     });
 
-    it('Deletes the panel', () => {
+    it('Deletes the legacy panel', () => {
       cy.get('input[data-test-subj="checkboxSelectAll"]').click();
       openActionsDropdown();
       cy.get('button[data-test-subj="deleteContextMenuItem"]').click();
@@ -159,13 +159,11 @@ describe('Testing panels table', () => {
       cy.get('.euiTableRow').should('have.length', 1);
     });
 
-    it('Duplicates the panel', () => {
+    it('Duplicates a saved object panel', () => {
       selectThePanel();
       openActionsDropdown();
-      console.log('about to click duplicate');
       cy.get('button[data-test-subj="duplicateContextMenuItem"]').click();
       cy.get('button[data-test-subj="runModalButton"]').click();
-      console.log('confirmed modal');
       const duplicateName = TEST_PANEL + ' (copy)';
       cy.get('.euiTableRow').should('have.length', 2);
       cy.contains(duplicateName).should('exist');
@@ -173,7 +171,7 @@ describe('Testing panels table', () => {
       expectUuid(duplicate);
     });
 
-    it('Renames the panel', () => {
+    it('Renames a saved-objects panel', () => {
       selectThePanel();
       openActionsDropdown();
       cy.get('button[data-test-subj="renameContextMenuItem"]').click();
@@ -183,7 +181,7 @@ describe('Testing panels table', () => {
       cy.get('button[data-test-subj="runModalButton"]').click();
     });
 
-    it('Deletes the panel', () => {
+    it('Deletes saved object panels', () => {
       createSavedObjectPanel();
       cy.get('input[data-test-subj="checkboxSelectAll"]').click();
       openActionsDropdown();

--- a/.cypress/integration/3_panels.spec.ts
+++ b/.cypress/integration/3_panels.spec.ts
@@ -276,7 +276,7 @@ describe('Testing a panel', () => {
 
     cy.get(`input.euiFieldText[value="${TEST_PANEL} (copy)"]`)
       .focus()
-      .clear({force: true})
+      .clear({ force: true })
       .focus()
       .type('Renamed Panel', {
         delay: 200,
@@ -349,9 +349,9 @@ describe('Testing a panel', () => {
 
     cy.get('h5[data-test-subj="visualizationHeader"]')
       .contains(PPL_VISUALIZATIONS_NAMES[1])
-      .trigger('mousedown', {which: 1})
-      .trigger('mousemove', {clientX: 1100, clientY: 0})
-      .trigger('mouseup', {force: true});
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', { clientX: 1100, clientY: 0 })
+      .trigger('mouseup', { force: true });
 
     cy.get('button[data-test-subj="savePanelButton"]').click();
     cy.wait(delay * 3);
@@ -366,9 +366,9 @@ describe('Testing a panel', () => {
 
     cy.get('.react-resizable-handle')
       .eq(1)
-      .trigger('mousedown', {which: 1})
-      .trigger('mousemove', {clientX: 2000, clientY: 800})
-      .trigger('mouseup', {force: true});
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', { clientX: 2000, clientY: 800 })
+      .trigger('mouseup', { force: true });
 
     cy.get('button[data-test-subj="savePanelButton"]').click();
     cy.wait(delay * 3);
@@ -483,7 +483,7 @@ describe('Testing a panel', () => {
     cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]').trigger('mouseover').click();
     cy.wait(1000);
     cy.get('[data-test-subj="eventExplorer__querySaveName"]')
-      .clear({force: true})
+      .clear({ force: true })
       .type(NEW_VISUALIZATION_NAME, {
         delay: 200,
       });

--- a/.cypress/integration/3_panels.spec.ts
+++ b/.cypress/integration/3_panels.spec.ts
@@ -79,8 +79,8 @@ describe('Creating visualizations', () => {
 
 describe('Testing panels table', () => {
   beforeEach(() => {
-    moveToPanelHome();
     eraseTestPanels();
+    moveToPanelHome();
   });
 
   describe('Without Any Panels', () => {
@@ -143,14 +143,18 @@ describe('Testing panels table', () => {
 
   describe('with a SavedObjects Panel', () => {
     it.only('Duplicates a saved object panel', () => {
-      createSavedObjectPanel();
+      createSavedObjectPanel()
+      cy.reload();
+      cy.wait(250)
       selectThePanel();
+      cy.wait(250)
       openActionsDropdown();
       cy.get('button[data-test-subj="duplicateContextMenuItem"]').click();
       cy.get('button[data-test-subj="runModalButton"]').click();
-      cy.contains(TEST_PANEL + ' (copy)').should('exist');
-      const duplicate = testPanelTableCell();
-      expectUuid(duplicate);
+      const duplicateName = TEST_PANEL + " (copy)"
+      cy.contains(duplicateName).should('exist');
+      const duplicate = cy.get('.euiLink').contains(duplicateName).parent()
+      expectUuid(duplicate)
     });
 
     it('Renames a saved-objects panel', () => {
@@ -258,7 +262,7 @@ describe('Testing a panel', () => {
 
     cy.get(`input.euiFieldText[value="${TEST_PANEL} (copy)"]`)
       .focus()
-      .clear({ force: true })
+      .clear({force: true})
       .focus()
       .type('Renamed Panel', {
         delay: 200,
@@ -331,9 +335,9 @@ describe('Testing a panel', () => {
 
     cy.get('h5[data-test-subj="visualizationHeader"]')
       .contains(PPL_VISUALIZATIONS_NAMES[1])
-      .trigger('mousedown', { which: 1 })
-      .trigger('mousemove', { clientX: 1100, clientY: 0 })
-      .trigger('mouseup', { force: true });
+      .trigger('mousedown', {which: 1})
+      .trigger('mousemove', {clientX: 1100, clientY: 0})
+      .trigger('mouseup', {force: true});
 
     cy.get('button[data-test-subj="savePanelButton"]').click();
     cy.wait(delay * 3);
@@ -348,9 +352,9 @@ describe('Testing a panel', () => {
 
     cy.get('.react-resizable-handle')
       .eq(1)
-      .trigger('mousedown', { which: 1 })
-      .trigger('mousemove', { clientX: 2000, clientY: 800 })
-      .trigger('mouseup', { force: true });
+      .trigger('mousedown', {which: 1})
+      .trigger('mousemove', {clientX: 2000, clientY: 800})
+      .trigger('mouseup', {force: true});
 
     cy.get('button[data-test-subj="savePanelButton"]').click();
     cy.wait(delay * 3);
@@ -465,7 +469,7 @@ describe('Testing a panel', () => {
     cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]').trigger('mouseover').click();
     cy.wait(1000);
     cy.get('[data-test-subj="eventExplorer__querySaveName"]')
-      .clear({ force: true })
+      .clear({force: true})
       .type(NEW_VISUALIZATION_NAME, {
         delay: 200,
       });
@@ -525,13 +529,13 @@ const moveToEventsHome = () => {
 };
 
 const moveToPanelHome = () => {
-  cy.visit(`${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/`, {
-    timeout: 3000,
-  });
+  cy.visit(
+    `${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/`
+    , {timeout: 3000});
   cy.wait(delay * 3);
 };
 
-const testPanelTableCell = () => cy.get('.euiTableCellContent').contains(TEST_PANEL);
+const testPanelTableCell = (name = TEST_PANEL) => cy.get('.euiTableCellContent').contains(name)
 
 const moveToTestPanel = () => {
   moveToPanelHome();
@@ -552,22 +556,25 @@ const eraseLegacyPanels = () => {
       'osd-xsrf': true,
     },
   }).then((response) => {
-    response.body.panels.map((panel) => {
-      cy.request({
-        method: 'DELETE',
-        failOnStatusCode: false,
-        url: `api/observability/operational_panels/panels/${panel.id}`,
-        headers: {
-          'content-type': 'application/json;charset=UTF-8',
-          'osd-xsrf': true,
-        },
-      }).then((response) => {
-        const deletedId = response.allRequestResponses[0]['Request URL'].split('/').slice(-1);
-        console.log('erased panel', deletedId);
-      });
-    });
-  });
-};
+      response.body.panels
+        .map(panel => {
+            cy.request({
+              method: 'DELETE',
+              failOnStatusCode: false,
+              url: `api/observability/operational_panels/panels/${panel.id}`,
+              headers: {
+                'content-type': 'application/json;charset=UTF-8',
+                'osd-xsrf': true,
+              }
+            }).then(response => {
+              const deletedId = response.allRequestResponses[0]['Request URL'].split('/').slice(-1)
+              console.log("erased panel", deletedId)
+            })
+          }
+        )
+    }
+  )
+}
 
 const eraseSavedObjectPaenls = () => {
   return cy
@@ -596,10 +603,10 @@ const eraseSavedObjectPaenls = () => {
 };
 
 const eraseTestPanels = () => {
-  eraseLegacyPanels();
-  eraseSavedObjectPaenls();
-};
-const uuidRx = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+  eraseLegacyPanels()
+  eraseSavedObjectPaenls()
+}
+const uuidRx = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/;
 
 const clickCreatePanelButton = () =>
   cy.get('a[data-test-subj="customPanels__createNewPanels"]').click();

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:5602",
+  "baseUrl": "http://localhost:5601",
   "video": true,
   "chromeWebSecurity": true,
   "fixturesFolder": ".cypress/fixtures",
@@ -17,7 +17,7 @@
   "experimentalNetworkStubbing": true,
   "env": {
     "opensearch": "localhost:9200",
-    "opensearchDashboards": "localhost:5602",
+    "opensearchDashboards": "localhost:5601",
     "security_enabled": true
   },
   "cypress-watch-and-reload": {

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -131,7 +131,10 @@ export const CustomPanelTable = ({
     const sourcePanel = selectedCustomPanels[0];
     console.log('onClone', { sourcePanel });
     if (sourcePanel.savedObject) {
-      dispatch(createPanel({ ...sourcePanel, name: sourcePanel.name + ' (copy)', id: undefined }));
+      const { id, ...newPanel } = { ...sourcePanel, title: sourcePanel.title + ' (copy)' };
+      console.log('onClone', { newPanel });
+
+      dispatch(createPanel(newPanel));
     } else {
       cloneCustomPanel(newName, selectedCustomPanels[0].id);
     }

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -129,15 +129,9 @@ export const CustomPanelTable = ({
 
   const onClone = async (newName: string) => {
     const sourcePanel = selectedCustomPanels[0];
-    console.log('onClone', { sourcePanel });
-    if (sourcePanel.savedObject) {
-      const { id, ...newPanel } = { ...sourcePanel, title: sourcePanel.title + ' (copy)' };
-      console.log('onClone', { newPanel });
+    const { id, ...newPanel } = { ...sourcePanel, title: sourcePanel.title + ' (copy)' };
 
-      dispatch(createPanel(newPanel));
-    } else {
-      cloneCustomPanel(newName, selectedCustomPanels[0].id);
-    }
+    dispatch(createPanel(newPanel));
     closeModal();
   };
 

--- a/public/components/custom_panels/custom_panel_view.tsx
+++ b/public/components/custom_panels/custom_panel_view.tsx
@@ -30,7 +30,6 @@ import React, { useEffect, useState } from 'react';
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
 import moment from 'moment';
 import _ from 'lodash';
-import { useDispatch, useSelector } from 'react-redux';
 import DSLService from '../../services/requests/dsl';
 import { CoreStart } from '../../../../../src/core/public';
 import { EmptyPanelView } from './panel_modules/empty_panel';
@@ -49,10 +48,9 @@ import PPLService from '../../services/requests/ppl';
 import {
   isDateValid,
   convertDateTime,
-  prependRecentlyUsedRange as onTimeChange,
+  onTimeChange,
   isPPLFilterValid,
   fetchVisualizationById,
-  prependRecentlyUsedRange,
 } from './helpers/utils';
 import { UI_DATE_FORMAT } from '../../../common/constants/shared';
 import { VisaulizationFlyout } from './panel_modules/visualization_flyout';
@@ -66,7 +64,6 @@ import {
 } from '../common/search/autocomplete_logic';
 import { AddVisualizationPopover } from './helpers/add_visualization_popover';
 import { DeleteModal } from '../common/helpers/delete_modal';
-import { selectPanel, updatePanel } from './redux/panel_slice';
 
 /*
  * "CustomPanelsView" module used to render an Operational Panel
@@ -145,9 +142,6 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
     onAddClick,
   } = props;
 
-  const dispatch = useDispatch();
-  const panel = useSelector(selectPanel);
-
   const [openPanelName, setOpenPanelName] = useState('');
   const [panelCreatedTime, setPanelCreatedTime] = useState('');
   const [pplFilterValue, setPPLFilterValue] = useState('');
@@ -214,14 +208,14 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
   };
 
   const onDatePickerChange = (timeProps: OnTimeChangeProps) => {
-    const updatedRanges = prependRecentlyUsedRange(
+    onTimeChange(
       timeProps.start,
       timeProps.end,
-      recentlyUsedRanges
+      recentlyUsedRanges,
+      setRecentlyUsedRanges,
+      setStartTime,
+      setEndTime
     );
-    dispatch(updatePanel({ ...panel, timeRange: { from: timeProps.start, to: timeProps.end } }));
-
-    setRecentlyUsedRanges(updatedRanges.slice(0, 9));
     onRefreshFilters(timeProps.start, timeProps.end);
   };
 
@@ -643,8 +637,8 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
               <EuiFlexItem grow={false}>
                 <EuiSuperDatePicker
                   dateFormat={uiSettingsService.get('dateFormat')}
-                  start={panel.timeRange.from}
-                  end={panel.timeRange.to}
+                  start={startTime}
+                  end={endTime}
                   onTimeChange={onDatePickerChange}
                   recentlyUsedRanges={recentlyUsedRanges}
                   isDisabled={dateDisabled}

--- a/public/components/custom_panels/home.tsx
+++ b/public/components/custom_panels/home.tsx
@@ -161,54 +161,6 @@ export const Home = ({
     // });
   };
 
-  // Clones an existing Custom Panel, return new Custom Panel id
-  const cloneCustomPanel = async (
-    clonedCustomPanelName: string,
-    clonedCustomPanelId: string
-  ): Promise<string> => {
-    if (!isNameValid(clonedCustomPanelName)) {
-      setToast('Invalid Operational Panel name', 'danger');
-      return Promise.reject();
-    }
-
-    const fetchPanelFn = isUuid(clonedCustomPanelId) ? fetchSavedObjectPanel : fetchLegacyPanel;
-
-    try {
-      // const panelToClone = await fetchPanelfn(clonedCustomPanelId)
-      // const newPanel: PanelType = {
-      //   ...panelToClone,
-      //   title: clonedCustomPanelName,
-      //   dateCreated: new Date().getTime(),
-      //   dateModified: new Date().getTime()
-      // }
-      // const clonedPanel: CustomPanelType = await coreRefs.savedObjectsClient!.create(
-      //   CUSTOM_PANELS_SAVED_OBJECT_TYPE, newPanel, { id: panelToClone.id }
-      // )
-      // setcustomPanelData((prevCustomPanelData) => {
-      //   const newPanelData = [
-      //     ...prevCustomPanelData,
-      //     {
-      //       id: clonedPanel.id,
-      //       title: clonedCustomPanelName,
-      //       dateCreated: clonedPanel.dateCreated,
-      //       dateModified: clonedPanel.dateModified,
-      //     },
-      //   ];
-      //   console.log("setcustomPanelData", newPanelData)
-      //   return newPanelData
-      // });
-      // setToast(`Operational Panel "${clonedCustomPanelName}" successfully created!`);
-      // return clonedPanel.id;
-    } catch (err) {
-      setToast(
-        'Error cloning Operational Panel, please make sure you have the correct permission.',
-        'danger'
-      );
-    }
-
-    console.error(err.body.message);
-  };
-
   const deletePanelSO = (customPanelIdList: string[]) => {
     const soPanelIds = customPanelIdList.filter((id) => id.match(uuidRx));
     return Promise.all(
@@ -340,7 +292,6 @@ export const Home = ({
                 createCustomPanel={createCustomPanel}
                 setBreadcrumbs={chrome.setBreadcrumbs}
                 parentBreadcrumbs={customPanelBreadCrumbs}
-                cloneCustomPanel={cloneCustomPanel}
                 deleteCustomPanelList={deleteCustomPanelList}
                 addSamplePanels={addSamplePanels}
               />
@@ -357,7 +308,6 @@ export const Home = ({
                 panelId={props.match.params.id}
                 chrome={chrome}
                 parentBreadcrumbs={customPanelBreadCrumbs}
-                cloneCustomPanel={cloneCustomPanel}
                 deleteCustomPanel={deleteCustomPanel}
                 setToast={setToast}
                 onEditClick={onEditClick}
@@ -373,7 +323,6 @@ export const Home = ({
                 chrome={chrome}
                 parentBreadcrumbs={customPanelBreadCrumbs}
                 // renameCustomPanel={renameCustomPanel}
-                cloneCustomPanel={cloneCustomPanel}
                 deleteCustomPanel={deleteCustomPanel}
                 setToast={setToast}
                 onEditClick={onEditClick}

--- a/public/components/custom_panels/redux/panel_slice.ts
+++ b/public/components/custom_panels/redux/panel_slice.ts
@@ -90,16 +90,18 @@ const fetchCustomPanels = async () => {
   const panels$: Observable<CustomPanelListType> = concat(
     fetchSavedObjectPanels$(),
     fetchObservabilityPanels$()
-  ).pipe(map((res) => {
-    console.log("fetchCustomPanels", res);
-    return res as CustomPanelListType
-  }));
+  ).pipe(
+    map((res) => {
+      console.log('fetchCustomPanels', res);
+      return res as CustomPanelListType;
+    })
+  );
 
   return panels$.pipe(toArray()).toPromise();
 };
 
 export const fetchPanels = () => async (dispatch, getState) => {
-  const panels = await fetchCustomPanels()
+  const panels = await fetchCustomPanels();
   console.log('fetchPanels', { panels });
   dispatch(setPanelList(panels));
 };
@@ -112,31 +114,27 @@ export const fetchPanel = (id) => async (dispatch, getState) => {
 
 export const fetchVisualization = () => (dispatch, getState) => {};
 
-const updateLegacyPanel = (panel: CustomPanelType) => coreRefs.http!
-  .post(`${CUSTOM_PANELS_API_PREFIX}/panels/update`, {
+const updateLegacyPanel = (panel: CustomPanelType) =>
+  coreRefs.http!.post(`${CUSTOM_PANELS_API_PREFIX}/panels/update`, {
     body: JSON.stringify({ panelId: panel.id, panel: panel as PanelType }),
   });
 
 const updateSavedObjectPanel = (panel: CustomPanelType) => savedObjectPanelsClient.update(panel);
 
-
 const uuidRx = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
 
 const isUuid = (id) => !!id.match(uuidRx);
 
-
 export const updatePanel = (panel: CustomPanelType) => async (dispatch, getState) => {
   try {
-    if (isUuid(panel.id))
-      await updateSavedObjectPanel(panel)
-    else
-      await updateLegacyPanel(panel)
+    if (isUuid(panel.id)) await updateSavedObjectPanel(panel);
+    else await updateLegacyPanel(panel);
 
     dispatch(setPanel(panel));
     const panelList = getState().customPanel.panelList.map((p) => (p.id === panel.id ? panel : p));
     dispatch(setPanelList(panelList));
   } catch (err) {
-    console.log("Error updating panel", { err, panel })
+    console.log('Error updating panel', { err, panel });
   }
 };
 
@@ -147,11 +145,11 @@ export const deletePanel = (id) => async (dispatch, getState) => {
 };
 
 export const createPanel = (panel) => async (dispatch, getState) => {
-  const newPanel = await savedObjectPanelsClient.create(panel);
-  const panelList = getState().panelList;
+  const newSOPanel = await savedObjectPanelsClient.create(panel);
+  const newPanel = savedObjectToCustomPanel(newSOPanel);
+  const panelList = getState().customPanel.panelList;
   dispatch(setPanelList([...panelList, newPanel]));
 };
-
 
 const saveRenamedPanel = async (id, name) => {
   const renamePanelObject = {
@@ -174,17 +172,20 @@ const saveRenamedPanelSO = async (id, name) => {
 };
 
 // Renames an existing CustomPanel
-export const renameCustomPanel = (editedCustomPanelName: string, id: string) => async (dispatch, getState) => {
-  console.log("renameCustomPanel dispatched", { editedCustomPanelName, id })
+export const renameCustomPanel = (editedCustomPanelName: string, id: string) => async (
+  dispatch,
+  getState
+) => {
+  console.log('renameCustomPanel dispatched', { editedCustomPanelName, id });
 
   if (!isNameValid(editedCustomPanelName)) {
     console.log('Invalid Custom Panel name', 'danger');
     return Promise.reject();
   }
 
-  const panel = getState().customPanel.panelList.find(p => p.id === id)
-  const updatedPanel = { ...panel, title: editedCustomPanelName }
-  dispatch(updatePanel(updatedPanel))
+  const panel = getState().customPanel.panelList.find((p) => p.id === id);
+  const updatedPanel = { ...panel, title: editedCustomPanelName };
+  dispatch(updatePanel(updatedPanel));
 
   // try {
   //   // await savePanelFn(editedCustomPanelId, editedCustomPanelName);

--- a/public/components/custom_panels/redux/panel_slice.ts
+++ b/public/components/custom_panels/redux/panel_slice.ts
@@ -176,8 +176,6 @@ export const renameCustomPanel = (editedCustomPanelName: string, id: string) => 
   dispatch,
   getState
 ) => {
-  console.log('renameCustomPanel dispatched', { editedCustomPanelName, id });
-
   if (!isNameValid(editedCustomPanelName)) {
     console.log('Invalid Custom Panel name', 'danger');
     return Promise.reject();

--- a/public/components/event_analytics/home/home.tsx
+++ b/public/components/event_analytics/home/home.tsx
@@ -197,7 +197,7 @@ const EventAnalyticsHome = (props: IHomeProps) => {
     await dispatchInitialData(newTabId);
 
     // redirect to explorer
-    history.push('/');
+    history.push('/explorer');
   };
 
   const handleQueryChange = async (query: string) => setSearchQuery(query);

--- a/public/components/event_analytics/index.tsx
+++ b/public/components/event_analytics/index.tsx
@@ -82,14 +82,14 @@ export const EventAnalytics = ({
       <HashRouter>
         <Switch>
           <Route
-            path={[`/:id`]}
+            path={[`/explorer/:id`, '/explorer']}
             render={(routerProps) => {
               chrome.setBreadcrumbs([
                 ...parentBreadcrumbs,
                 eventAnalyticsBreadcrumb,
                 {
                   text: 'Explorer',
-                  href: `#/event_analytics/explorer`,
+                  href: `#/`,
                 },
               ]);
               return (


### PR DESCRIPTION
### Description
1. Open Observability Dashboards
2. Select a Dashboard that is on Saved Objects (URL is a UUID)
3. Click "Actions" then "Duplicate"
Action does not complete.  Browser console reports errors.

ASANA-1204395481625544

### Fixes
* Logs/Explorer navigation
* Panels Table - Duplication Action
* 3_panels.spec.ts E2E specs for Duplication Action, also Visualization test.

### NOTE

This is an incremental PR.
Known issues that will be resolved in follow-on PRs :
* Toast on Panels Table and PanelViewSO
* Panel Duplication on PanelView (Legacy)
* E2E Test Suite

Changes are partial fix of overall current WIP of Dashboard-List-Integration/Left-Nav.
Please see test results for 3_panels.spec - "Testing panels table " "Duplicates a saved objects panel"

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
