### PR TITLE
Fix re-direct links for visualizations in notebooks, metrics

### DIFF
--- a/public/components/metrics/index.tsx
+++ b/public/components/metrics/index.tsx
@@ -30,6 +30,7 @@ import { MetricsGrid } from './view/metrics_grid';
 import { metricsLayoutSelector, selectedMetricsSelector } from './redux/slices/metrics_slice';
 import { resolutionOptions } from '../../../common/constants/metrics';
 import SavedObjects from '../../services/saved_objects/event_analytics/saved_objects';
+import { observabilityLogsID } from '../../../common/constants/shared';
 
 interface MetricsProps {
   http: CoreStart['http'];
@@ -82,7 +83,8 @@ export const Home = ({
     setToasts([...toasts, { id: new Date().toISOString(), title, text, color } as Toast]);
   };
 
-  const onRefreshFilters = (startTime: ShortDate, endTime: ShortDate) => { // eslint-disable-line
+  const onRefreshFilters = (startTime: ShortDate, endTime: ShortDate) => {
+    // eslint-disable-line
     if (spanValue < 1) {
       setToast('Please add a valid span interval', 'danger');
       return;
@@ -103,7 +105,7 @@ export const Home = ({
   };
 
   const onEditClick = (savedVisualizationId: string) => {
-    window.location.assign(`#/${savedVisualizationId}`);
+    window.location.assign(`${observabilityLogsID}#/explorer/${savedVisualizationId}`);
   };
 
   const onSideBarClick = () => {

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -31,6 +31,7 @@ import { Input, Prompt } from '@nteract/presentational-components';
 import { uiSettingsService } from '../../../../../common/utils';
 import React, { useState } from 'react';
 import { ParaType } from '../../../../../common/types/notebooks';
+import { observabilityLogsID } from '../../../../../common/constants/shared';
 
 /*
  * "ParaInput" component is used by notebook to populate paragraph inputs for an open notebook.
@@ -118,7 +119,7 @@ export const ParaInput = (props: {
     const renderOption = (option: EuiComboBoxOptionOption, searchValue: string) => {
       let visURL = `visualize#/edit/${option.key}?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'${props.startTime}',to:'${props.endTime}'))`;
       if (option.className === 'OBSERVABILITY_VISUALIZATION') {
-        visURL = `#/event_analytics/explorer/${option.key}`;
+        visURL = `${observabilityLogsID}#/explorer/${option.key}`;
       }
       return (
         <EuiLink href={visURL} target="_blank">


### PR DESCRIPTION
### Description
Links re-dircting to explorer page

### Issues Resolved
Fix re-direct links for visualizations in notebooks, metrics


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
