### PR TITLE
Fix doc viewer flyout styling in explorer

### DIFF
--- a/public/components/event_analytics/explorer/events_views/doc_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/doc_flyout.tsx
@@ -123,14 +123,16 @@ export const DocFlyout = ({
 
   const flyoutBody = (
     <EuiFlyoutBody>
-      {populateDataGrid(
-        explorerFields,
-        getHeaders(explorerFields.queriedFields, DEFAULT_COLUMNS.slice(1), true),
-        <tr className="osdDocTable__row">{memorizedTds}</tr>,
-        getHeaders(explorerFields.selectedFields, DEFAULT_COLUMNS.slice(1), true),
-        <tr className="osdDocTable__row">{memorizedTds}</tr>
-      )}
-      <DocViewer http={http} hit={doc} openTraces={openTraces} />
+      <div className="obsExplorer">
+        {populateDataGrid(
+          explorerFields,
+          getHeaders(explorerFields.queriedFields, DEFAULT_COLUMNS.slice(1), true),
+          <tr className="osdDocTable__row">{memorizedTds}</tr>,
+          getHeaders(explorerFields.selectedFields, DEFAULT_COLUMNS.slice(1), true),
+          <tr className="osdDocTable__row">{memorizedTds}</tr>
+        )}
+        <DocViewer http={http} hit={doc} openTraces={openTraces} />
+      </div>
     </EuiFlyoutBody>
   );
 

--- a/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
@@ -124,9 +124,11 @@ export const SurroundingFlyout = ({
   };
 
   const loadButton = (typeOfDocs: 'new' | 'old') => {
-    typeOfDocs === 'new'
-      ? loadData(typeOfDocs, numNewEvents + 5)
-      : loadData(typeOfDocs, valueOldEvents + 5);
+    if (typeOfDocs === 'new') {
+      loadData(typeOfDocs, numNewEvents + 5);
+    } else {
+      loadData(typeOfDocs, valueOldEvents + 5);
+    }
   };
 
   const handleKeyDown = (
@@ -139,11 +141,11 @@ export const SurroundingFlyout = ({
   };
 
   const onChangeNewEvents = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNumNewEvents(parseInt(e.target.value));
+    setNumNewEvents(parseInt(e.target.value, 10));
   };
 
   const onChangeOldEvents = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNumOldEvents(parseInt(e.target.value));
+    setNumOldEvents(parseInt(e.target.value, 10));
   };
 
   const flyoutHeader = (
@@ -227,35 +229,37 @@ export const SurroundingFlyout = ({
 
   const flyoutBody = (
     <EuiFlyoutBody>
-      {getInputForm('arrowUp', onChangeNewEvents, numNewEvents, 'new')}
-      <EuiSpacer size="s" />
-      <div>
-        {newEventsError !== '' && (
-          <EuiCallOut iconType="bolt" title={newEventsError} color="warning" />
+      <div className="obsExplorer">
+        {getInputForm('arrowUp', onChangeNewEvents, numNewEvents, 'new')}
+        <EuiSpacer size="s" />
+        <div>
+          {newEventsError !== '' && (
+            <EuiCallOut iconType="bolt" title={newEventsError} color="warning" />
+          )}
+        </div>
+        {populateDataGrid(
+          explorerFields,
+          getHeaders(explorerFields.queriedFields, DEFAULT_COLUMNS.slice(1), true),
+          <>
+            {newEventsData}
+            <tr className="osdDocTable__row selected-event-row">{memorizedTds}</tr>
+            {oldEventsData}
+          </>,
+          getHeaders(explorerFields.selectedFields, DEFAULT_COLUMNS.slice(1), true),
+          <>
+            {newEventsData}
+            <tr className="osdDocTable__row selected-event-row">{memorizedTds}</tr>
+            {oldEventsData}
+          </>
         )}
+        <div>
+          {oldEventsError !== '' && (
+            <EuiCallOut iconType="bolt" title={oldEventsError} color="warning" />
+          )}
+        </div>
+        <EuiSpacer size="s" />
+        {getInputForm('arrowDown', onChangeOldEvents, valueOldEvents, 'old')}
       </div>
-      {populateDataGrid(
-        explorerFields,
-        getHeaders(explorerFields.queriedFields, DEFAULT_COLUMNS.slice(1), true),
-        <>
-          {newEventsData}
-          <tr className="osdDocTable__row selected-event-row">{memorizedTds}</tr>
-          {oldEventsData}
-        </>,
-        getHeaders(explorerFields.selectedFields, DEFAULT_COLUMNS.slice(1), true),
-        <>
-          {newEventsData}
-          <tr className="osdDocTable__row selected-event-row">{memorizedTds}</tr>
-          {oldEventsData}
-        </>
-      )}
-      <div>
-        {oldEventsError !== '' && (
-          <EuiCallOut iconType="bolt" title={oldEventsError} color="warning" />
-        )}
-      </div>
-      <EuiSpacer size="s" />
-      {getInputForm('arrowDown', onChangeOldEvents, valueOldEvents, 'old')}
     </EuiFlyoutBody>
   );
 


### PR DESCRIPTION
### Description
Fix doc viewer flyout styling in explorer

### Issues Resolved
Surrounding & Doc flyout use now class `obsExplorer` as parent div.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
