### PR TITLE
[Dashboard listing] update edit url and view url

### DIFF
--- a/.cypress/integration/3_panels.spec.ts
+++ b/.cypress/integration/3_panels.spec.ts
@@ -211,6 +211,15 @@ describe('Testing panels table', () => {
       cy.location('pathname').should('eq', '/app/observability-dashboards');
       cy.location('hash').should('include', '/edit');
     });
+
+    it('Redirects to observability dashboard from OSD dashboards with create', () => {
+      moveToOsdDashboards();
+      cy.location('pathname').should('eq', '/app/dashboards');
+      cy.get('div#createMenuPopover').click();
+      cy.get('[data-test-subj="contextMenuItem-observability-panel"]').click();
+      cy.location('pathname').should('eq', '/app/observability-dashboards');
+      cy.location('hash').should('include', '/create');
+    });
   });
 
   it('Searches existing panel', () => {

--- a/.cypress/integration/3_panels.spec.ts
+++ b/.cypress/integration/3_panels.spec.ts
@@ -5,18 +5,15 @@
 
 /// <reference types="cypress" />
 
+import { suppressResizeObserverIssue } from '../utils/constants';
 import {
   delay,
-  TEST_PANEL,
-  PPL_VISUALIZATIONS,
-  PPL_VISUALIZATIONS_NAMES,
   NEW_VISUALIZATION_NAME,
   PPL_FILTER,
-  SAMPLE_PANEL,
-  SAMPLE_VISUALIZATIONS_NAMES,
+  PPL_VISUALIZATIONS,
+  PPL_VISUALIZATIONS_NAMES,
+  TEST_PANEL,
 } from '../utils/panel_constants';
-
-import { suppressResizeObserverIssue } from '../utils/constants';
 
 describe('Adding sample data and visualization', () => {
   it('Adds sample flights data for visualization paragraph', () => {
@@ -195,6 +192,25 @@ describe('Testing panels table', () => {
       cy.get('button[data-test-subj="popoverModal__deleteButton"]').click();
       cy.get('h2[data-test-subj="customPanels__noPanelsHome"]').should('exist');
     });
+
+    it('Redirects to observability dashboard from OSD dashboards', () => {
+      moveToOsdDashboards();
+      cy.location('pathname').should('eq', '/app/dashboards');
+      cy.get('[data-test-subj="dashboardListingTitleLink-Test-Panel"]').click();
+      cy.location('pathname').should('eq', '/app/observability-dashboards');
+    });
+
+    it('Redirects to observability dashboard from OSD dashboards with edit', () => {
+      moveToOsdDashboards();
+      cy.location('pathname').should('eq', '/app/dashboards');
+      cy.get('[data-test-subj="dashboardListingTitleLink-Test-Panel"]')
+        .closest('tr')
+        .get('span.euiToolTipAnchor > button.euiButtonIcon')
+        .eq(0)
+        .click();
+      cy.location('pathname').should('eq', '/app/observability-dashboards');
+      cy.location('hash').should('include', '/edit');
+    });
   });
 
   it('Searches existing panel', () => {
@@ -274,7 +290,7 @@ describe('Testing a panel', () => {
 
     cy.get(`input.euiFieldText[value="${TEST_PANEL} (copy)"]`)
       .focus()
-      .clear({force: true})
+      .clear({ force: true })
       .focus()
       .type('Renamed Panel', {
         delay: 200,
@@ -347,9 +363,9 @@ describe('Testing a panel', () => {
 
     cy.get('h5[data-test-subj="visualizationHeader"]')
       .contains(PPL_VISUALIZATIONS_NAMES[1])
-      .trigger('mousedown', {which: 1})
-      .trigger('mousemove', {clientX: 1100, clientY: 0})
-      .trigger('mouseup', {force: true});
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', { clientX: 1100, clientY: 0 })
+      .trigger('mouseup', { force: true });
 
     cy.get('button[data-test-subj="savePanelButton"]').click();
     cy.wait(delay * 3);
@@ -364,9 +380,9 @@ describe('Testing a panel', () => {
 
     cy.get('.react-resizable-handle')
       .eq(1)
-      .trigger('mousedown', {which: 1})
-      .trigger('mousemove', {clientX: 2000, clientY: 800})
-      .trigger('mouseup', {force: true});
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', { clientX: 2000, clientY: 800 })
+      .trigger('mouseup', { force: true });
 
     cy.get('button[data-test-subj="savePanelButton"]').click();
     cy.wait(delay * 3);
@@ -481,7 +497,7 @@ describe('Testing a panel', () => {
     cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]').trigger('mouseover').click();
     cy.wait(1000);
     cy.get('[data-test-subj="eventExplorer__querySaveName"]')
-      .clear({force: true})
+      .clear({ force: true })
       .type(NEW_VISUALIZATION_NAME, {
         delay: 200,
       });
@@ -534,6 +550,11 @@ describe('Clean up all test data', () => {
     cy.get('.euiTextAlign').contains('No Operational Panels').should('exist');
   });
 });
+
+const moveToOsdDashboards = () => {
+  cy.visit(`${Cypress.env('opensearchDashboards')}/app/dashboards#/`);
+  cy.wait(delay * 3);
+};
 
 const moveToEventsHome = () => {
   cy.visit(`${Cypress.env('opensearchDashboards')}/app/observability-logs#/`);
@@ -615,7 +636,8 @@ const eraseTestPanels = () => {
   eraseLegacyPanels();
   eraseSavedObjectPaenls();
 };
-const uuidRx = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/;
+const uuidRx =
+  /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/;
 
 const clickCreatePanelButton = () =>
   cy.get('a[data-test-subj="customPanels__createNewPanels"]').click();

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -255,7 +255,6 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
   }, [panel]);
 
   const cancelEdit = () => {
-    console.log('cancelEdits');
     dispatch(fetchPanel(panelId));
     setIsEditing(false);
   };

--- a/public/components/trace_analytics/requests/dashboard_request_handler.ts
+++ b/public/components/trace_analytics/requests/dashboard_request_handler.ts
@@ -191,10 +191,7 @@ export const handleJaegerDashboardRequest = async (
       return map;
     })
     .catch((error) => {
-      console.log("error here")
-      console.error(error)
-      
-      setToast('hello')
+      console.error(error);
     });
 
   await handleDslRequest(http, DSL, getJaegerDashboardQuery(), mode, true, setShowTimeoutToast)

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -83,7 +83,6 @@ export class ObservabilityPlugin
     core: CoreSetup<AppPluginStartDependencies>,
     setupDeps: SetupDependencies
   ): ObservabilitySetup {
-    console.log('core: ', core, ', setupDeps: ', setupDeps);
     uiSettingsService.init(core.uiSettings, core.notifications);
     const pplService = new PPLService(core.http);
     const qm = new QueryManager();
@@ -107,16 +106,16 @@ export class ObservabilityPlugin
     // if (window.location.pathname.includes('application_analytics')) {
     //   window.location.assign(convertLegacyAppAnalyticsUrl(window.location));
     // }
-
+    const BASE_URL = core.http.basePath.prepend('/app/observability-dashboards#');
     setupDeps.dashboard.registerDashboardProvider({
       appId: 'observability-panel',
       savedObjectsType: 'observability-panel',
       savedObjectsName: 'Observability',
-      editUrlPathFn: (obj: SavedObject) => `/app/observability-dashboards#/${obj.id}/edit`,
-      viewUrlPathFn: (obj: SavedObject) => `/app/observability-dashboards#/${obj.id}`,
+      editUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}/edit`,
+      viewUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}`,
       createLinkText: 'Observability Dashboard',
       createSortText: 'Observability Dashboard',
-      createUrl: '/app/observability-dashboards#/create',
+      createUrl: `${BASE_URL}/create`,
     });
 
     const OBSERVABILITY_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze({
@@ -130,7 +129,6 @@ export class ObservabilityPlugin
     });
 
     const appMountWithStartPage = (startPage: string) => async (params: AppMountParameters) => {
-      console.log('start page: ', startPage);
       const { Observability } = await import('./components/index');
       const [coreStart, depsStart] = await core.getStartServices();
       const dslService = new DSLService(coreStart.http);

--- a/public/services/saved_objects/saved_object_savers/ppl/save_as_new_query.ts
+++ b/public/services/saved_objects/saved_object_savers/ppl/save_as_new_query.ts
@@ -24,7 +24,6 @@ export class SaveAsNewQuery extends SavedQuerySaver {
     const { batch, dispatch, changeQuery, updateTabName } = this.dispatchers;
     const { tabId, history, notifications, showPermissionErrorToast } = this.saveContext;
     const { name } = this.saveParams;
-    console.log('this.saveParams: ', this.saveParams);
     this.saveClient
       .create({ ...this.saveParams })
       .then((res: any) => {


### PR DESCRIPTION
### Description
Update to include BASE_URL if basePath is defined. Since create url is just a direct nav and needs the basePath when passing props to the provider, the source code no longer appends the basePath to keep these URLs consistent.

A feature should consolidate the basePaths in the dashboard listing service so that createUrl also adds the base path. At which point we no longer need the base path.

Also removed some rogue console logs and setToast.

Core PR:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3922

### Issues Resolved
n/a

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
