### PR TITLE
fixes edit mode callback bug in Saved Object Panels

### DIFF
--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -55,17 +55,14 @@ import { PanelGridSO } from './panel_modules/panel_grid/panel_grid_so';
 import { VisaulizationFlyoutSO } from './panel_modules/visualization_flyout/visualization_flyout_so';
 import {
   clonePanel,
-  createPanel,
   deletePanels,
   fetchPanel,
-  newPanelTemplate,
   selectPanel,
   setPanel,
-  setPanelEt,
-  setPanelId,
-  setPanelSt,
   updatePanel,
 } from './redux/panel_slice';
+import PPLService from '../../services/requests/ppl';
+import DSLService from '../../services/requests/dsl';
 
 /*
  * "CustomPanelsView" module used to render an Observability Dashboard
@@ -277,21 +274,10 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
   };
 
   // toggle between panel edit mode
-
-  const startEdit = () => {
-    setIsEditing(true);
-  };
-
-  const applyEdits = useCallback(() => {
-    dispatch(updatePanel(panel));
-    setIsEditing(false);
-    setEditActionType('save');
-  }, [panel]);
-
-  const cancelEdit = () => {
-    console.log('cancelEdits');
-    dispatch(fetchPanel(panelId));
-    setIsEditing(false);
+  const editPanel = (editType: string) => {
+    setIsEditing(!isEditing);
+    if (editType === 'cancel') dispatch(fetchPanel(panelId));
+    setEditActionType(editType);
   };
 
   const closeFlyout = () => {
@@ -407,23 +393,23 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
       data-test-subj="cancelPanelButton"
       iconType="cross"
       color="danger"
-      onClick={cancelEdit}
+      onClick={() => editPanel('cancel')}
     >
       Cancel
     </EuiButton>
   );
 
   const saveButton = (
-    <EuiButton data-test-subj="savePanelButton" iconType="save" onClick={applyEdits}>
+    <EuiButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
       Save
     </EuiButton>
   );
 
   const editButton = (
     <EuiButton
-      data-test-subj="editPanelButton"
+      data-test-subj="lButton"
       iconType="pencil"
-      onClick={startEdit}
+      onClick={() => editPanel('edit')}
       disabled={editDisabled}
     >
       Edit

--- a/public/components/custom_panels/panel_modules/panel_grid/panel_grid_so.tsx
+++ b/public/components/custom_panels/panel_modules/panel_grid/panel_grid_so.tsx
@@ -153,17 +153,14 @@ export const PanelGridSO = (props: PanelGridProps) => {
   };
 
   // Save Visualization Layouts when not in edit mode anymore (after users saves the panel)
-  const saveVisualizationLayouts = useCallback(
-    async (panelID: string, visualizationParams: any) => {
-      const newVisualizations = updateLayout(panel.visualizations, visualizationParams);
-      const updateRes = await coreRefs.savedObjectsClient?.update('observability-panel', panelID, {
-        ...panel,
-        visualizations: newVisualizations,
-      });
-      setPanelVisualizations(updateRes?.attributes?.visualizations || []);
-    },
-    [panel]
-  );
+  const saveVisualizationLayouts = async (panelID: string, visualizationParams: any) => {
+    const newVisualizations = updateLayout(panel.visualizations, visualizationParams);
+    const updateRes = await coreRefs.savedObjectsClient?.update('observability-panel', panelID, {
+      ...panel,
+      visualizations: newVisualizations,
+    });
+    setPanelVisualizations(updateRes?.attributes?.visualizations || []);
+  };
 
   // Update layout whenever user edit gets completed
   useEffect(() => {

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -32,9 +32,8 @@ import {
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
-import _, { isError } from 'lodash';
+import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { useDispatch, useSelector } from 'react-redux';
 import { FlyoutContainers } from '../../../common/flyout_containers';
 import {
@@ -46,23 +45,17 @@ import {
 import { convertDateTime } from '../../helpers/utils';
 import PPLService from '../../../../services/requests/ppl';
 import { CoreStart } from '../../../../../../../src/core/public';
-import { CUSTOM_PANELS_API_PREFIX } from '../../../../../common/constants/custom_panels';
 import {
-  BoxType,
-  PplResponse,
+  PPLResponse,
   SavedVisualizationType,
   VisualizationType,
   VizContainerError,
 } from '../../../../../common/types/custom_panels';
 import './visualization_flyout.scss';
 import { uiSettingsService } from '../../../../../common/utils';
-import { ILegacyScopedClusterClient } from '../../../../../../../src/core/server';
 import { replaceVizInPanel, selectPanel } from '../../redux/panel_slice';
 import { SavedObjectsActions } from '../../../../services/saved_objects/saved_object_client/saved_objects_actions';
-import {
-  ObservabilitySavedObject,
-  ObservabilitySavedVisualization,
-} from '../../../../services/saved_objects/saved_object_client/types';
+import { ObservabilitySavedVisualization } from '../../../../services/saved_objects/saved_object_client/types';
 import { SAVED_VISUALIZATION } from '../../../../../common/constants/explorer';
 
 /*
@@ -128,7 +121,7 @@ export const VisaulizationFlyoutSO = ({
   const [newVisualizationTimeField, setNewVisualizationTimeField] = useState('');
   const [previewMetaData, setPreviewMetaData] = useState<SavedVisualizationType>();
   const [pplQuery, setPPLQuery] = useState('');
-  const [previewData, setPreviewData] = useState<PplResponse>({} as PplResponse);
+  const [previewData, setPreviewData] = useState<PPLResponse>({} as PPLResponse);
   const [previewArea, setPreviewArea] = useState(<></>);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [isPreviewError, setIsPreviewError] = useState({} as VizContainerError);
@@ -189,43 +182,11 @@ export const VisaulizationFlyoutSO = ({
     if (!isInputValid()) return;
 
     if (isFlyoutReplacement) {
-      // http
-      //   .post(`${CUSTOM_PANELS_API_PREFIX}/visualizations/replace`, {
-      //     body: JSON.stringify({
-      //       panelId,
-      //       savedVisualizationId: selectValue,
-      //       oldVisualizationId: replaceVisualizationId,
-      //     }),
-      //   })
-      //   .then(async (res) => {
-      //     setPanelVisualizations(res.visualizations);
-      //     setToast(`Visualization ${newVisualizationTitle} successfully added!`, 'success');
-      //   })
-      //   .catch((err) => {
-      //     setToast(`Error in adding ${newVisualizationTitle} visualization to the panel`, 'danger');
-      //     console.error(err);
-      //   });
       dispatch(replaceVizInPanel(panel, replaceVisualizationId, selectValue));
     } else {
       const visualizationsWithNewPanel = addVisualizationPanel({
         savedVisualizationId: selectValue,
       });
-
-      // http
-      //   .post(`${CUSTOM_PANELS_API_PREFIX}/visualizations`, {
-      //     body: JSON.stringify({
-      //       panelId,
-      //       savedVisualizationId: selectValue,
-      //     }),
-      //   })
-      //   .then(async (res) => {
-      //     setPanelVisualizations(res.visualizations);
-      //     setToast(`Visualization ${newVisualizationTitle} successfully added!`, 'success');
-      //   })
-      //   .catch((err) => {
-      //     setToast(`Error in adding ${newVisualizationTitle} visualization to the panel`, 'danger');
-      //     console.error(err);
-      //   });
     }
     closeFlyout();
   };


### PR DESCRIPTION
### Description
Fixes edit mode callback bug in Saved Object Panels. The bug occurs when a user hits the edit followed by save button, before response is made by the callback. 

### Issues Resolved
* Reverted legacy style edit mode -> Callback updates visualization -> Forces a reload
* Removed unused headers and some commented code.  

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
