### PR TITLE
Fix delete failure when no osd item selected

### DIFF
--- a/public/services/saved_objects/saved_object_client/saved_objects_actions.ts
+++ b/public/services/saved_objects/saved_object_client/saved_objects_actions.ts
@@ -103,7 +103,7 @@ export class SavedObjectsActions {
 
     const remainingObjectIds = [
       ...new Set(
-        idMap.non_osd.concat(
+        idMap.non_osd?.concat(
           Object.entries(responses.deleteResponseList)
             .filter(([_, status]) => status !== 'OK')
             .map(([id, _]) => id)


### PR DESCRIPTION
### Description
Need to add unit tests. When no osd items, the map key does not exist, and .concat() will fail

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
