### PR TITLE
Remove styling causing issue for banner in advanced settings

### DIFF
--- a/public/components/event_analytics/explorer/explorer.scss
+++ b/public/components/event_analytics/explorer/explorer.scss
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#opensearch-dashboards-body {
-  overflow-y: hidden;
-}
-
 .liveStream {
   margin : 8px;
   height: 40px;

--- a/public/components/metrics/index.scss
+++ b/public/components/metrics/index.scss
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#opensearch-dashboards-body {
-  overflow-y: hidden;
-}
-
 .liveStream {
   margin : 8px;
   height: 40px;


### PR DESCRIPTION
### Description
Issue: 
in advanced setting page of Core Dashboard, if you made a change, a banner should show up on the bottom of the page

<img width="569" alt="Screenshot 2023-05-25 at 5 44 43 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/80358241/1a87488c-cb70-4861-9892-452fd7e49c1d">

but currently in main, it is missing.

**Root cause**:
Changes in main of dashboard core moved that banner code from a sibling div to under the main body with an id of '#opensearch-dashboards-body'. Observability also refer to this id for its own styling previously affecting that banner.

Versions like 2.7 which do not see such bug have DOM structure like

<img width="1210" alt="Screenshot 2023-05-25 at 4 31 56 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/80358241/a6fafb29-cfbb-41e7-a259-12ac810b7726">
<br><br>
where banner section with 'label Page level controls' locates out side of 'opensearch-dashboards-body' whereas in main:
<br><br>
<img width="1772" alt="Screenshot 2023-05-25 at 4 32 23 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/80358241/01192a03-1f36-49d5-8af6-b6788910624e">
<br><br>
It got moved to under body div. <br><br>

**Fix** 

Removed styling which didn't have actual effect currently for observability but affecting that banner. Also moving forward, observability will add wrapper / its own class name to avoid possible global styling.

### Issues Resolved

https://github.com/opensearch-project/dashboards-observability/issues/484

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
