### PR TITLE
[Backport 2.x] Add reporting on-demand menu items back in notebooks (#229)

### DIFF
--- a/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
+++ b/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
@@ -6,7 +6,7 @@
 import {
   contextMenuCreateReportDefinition,
   contextMenuViewReports,
-  generateInContextReport
+  generateInContextReport,
 } from '../reporting_context_menu_helper';
 
 describe('reporting_context_menu_helper tests', () => {
@@ -52,7 +52,8 @@ describe('reporting_context_menu_helper tests', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         status,
-        json: () => Promise.resolve({ filename, fileFormat, data: 'test-data' }),
+        json: () =>
+          Promise.resolve({ filename, fileFormat, data: 'test-data', reportId: 'test-id' }),
         text: () => Promise.resolve({ tenant }),
       })
     );
@@ -65,7 +66,7 @@ describe('reporting_context_menu_helper tests', () => {
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.csv', '__user__', setToast, toggleReportingLoadingModal);
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
+    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
   });
 
   it('generates pdf for global tenant', async () => {
@@ -73,7 +74,7 @@ describe('reporting_context_menu_helper tests', () => {
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.pdf', '', setToast, toggleReportingLoadingModal);
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
+    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
   });
 
   it('generates png for custom tenant', async () => {
@@ -81,15 +82,7 @@ describe('reporting_context_menu_helper tests', () => {
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
-  });
-
-  it('generates png for custom tenant', async () => {
-    const setToast = jest.fn();
-    const toggleReportingLoadingModal = jest.fn();
-    await generateReport(200, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Successfully generated report.', 'success');
+    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
   });
 
   it('handles 404 error', async () => {
@@ -132,7 +125,11 @@ describe('reporting_context_menu_helper tests', () => {
     global.fetch = jest.fn(() => Promise.reject({ status: 500 }));
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
-    await generateInContextReport('csv', { setToast }, toggleReportingLoadingModal);
+    try {
+      await generateInContextReport('csv', { setToast }, toggleReportingLoadingModal);
+    } catch (error) {
+      expect(error.status).toEqual(500);
+    }
     expect(toggleReportingLoadingModal).toBeCalledWith(true);
     expect(setToast).toBeCalledWith('Tenant error', 'danger', 'Failed to get user tenant.');
   });

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -863,6 +863,22 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         title: 'Reporting',
         items: [
           {
+            name: 'Download PDF',
+            icon: <EuiIcon type="download" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              generateInContextReport('pdf', this.props, this.toggleReportingLoadingModal);
+            },
+          },
+          {
+            name: 'Download PNG',
+            icon: <EuiIcon type="download" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              generateInContextReport('png', this.props, this.toggleReportingLoadingModal);
+            },
+          },
+          {
             name: 'Create report definition',
             icon: <EuiIcon type="calendar" />,
             onClick: () => {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>
(cherry picked from commit 0527730d9c7a7743e03061048937c6b3aa611788)

### Description
Add reporting on-demand menu items back in notebooks. Clicking on them will open a new tab of notebooks in output only mode and trigger report generation

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
