### PR TITLE
Stub router for integrations project

### DIFF
--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -74,13 +74,7 @@ export const PPL_NEWLINE_REGEX = /[\n\r]+/g;
 
 // Observability plugin URI
 const BASE_OBSERVABILITY_URI = '/_plugins/_observability';
-const BASE_INTEGRATIONS_URI = '/_plugins/_integrations';
-export const OPENSEARCH_INTEGRATIONS_API = {
-  OBJECT: `${BASE_INTEGRATIONS_URI}/object`,
-  ALL: `${BASE_INTEGRATIONS_URI}/store/list_all`,
-  ADDED: `${BASE_INTEGRATIONS_URI}/store/list_added`,
-  ADDED_POP: `${BASE_INTEGRATIONS_URI}/store/list_added_pop`,
-};
+const BASE_INTEGRATIONS_URI = '/_plugins/_integrations'; // Used later in front-end for routing
 export const OPENSEARCH_PANELS_API = {
   OBJECT: `${BASE_OBSERVABILITY_URI}/object`,
 };

--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -13,6 +13,7 @@ export const DSL_SEARCH = '/search';
 export const DSL_CAT = '/cat.indices';
 export const DSL_MAPPING = '/indices.getFieldMapping';
 export const OBSERVABILITY_BASE = '/api/observability';
+export const INTEGRATIONS_BASE = '/api/integrations';
 export const EVENT_ANALYTICS = '/event_analytics';
 export const SAVED_OBJECTS = '/saved_objects';
 export const SAVED_QUERY = '/query';
@@ -51,6 +52,10 @@ export const observabilityPanelsID = 'observability-dashboards';
 export const observabilityPanelsTitle = 'Dashboards';
 export const observabilityPanelsPluginOrder = 5095;
 
+export const observabilityIntegrationsID = 'observability-integrations';
+export const observabilityIntegrationsTitle = 'Integrations';
+export const observabilityIntegrationsPluginOrder = 5096;
+
 // Shared Constants
 export const SQL_DOCUMENTATION_URL = 'https://opensearch.org/docs/latest/search-plugins/sql/index/';
 export const PPL_DOCUMENTATION_URL =
@@ -69,6 +74,13 @@ export const PPL_NEWLINE_REGEX = /[\n\r]+/g;
 
 // Observability plugin URI
 const BASE_OBSERVABILITY_URI = '/_plugins/_observability';
+const BASE_INTEGRATIONS_URI = '/_plugins/_integrations';
+export const OPENSEARCH_INTEGRATIONS_API = {
+  OBJECT: `${BASE_INTEGRATIONS_URI}/object`,
+  ALL: `${BASE_INTEGRATIONS_URI}/store/list_all`,
+  ADDED: `${BASE_INTEGRATIONS_URI}/store/list_added`,
+  ADDED_POP: `${BASE_INTEGRATIONS_URI}/store/list_added_pop`,
+};
 export const OPENSEARCH_PANELS_API = {
   OBJECT: `${BASE_OBSERVABILITY_URI}/object`,
 };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "@reduxjs/toolkit": "^1.6.1",
     "ag-grid-community": "^27.3.0",
     "ag-grid-react": "^27.3.0",
+    "ajv": "^8.11.0",
     "antlr4": "4.8.0",
     "antlr4ts": "^0.5.0-alpha.4",
+    "mime": "^3.0.0",
     "performance-now": "^2.1.0",
     "plotly.js-dist": "^2.2.0",
     "postinstall": "^0.7.4",
@@ -41,6 +43,7 @@
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
     "@types/enzyme-adapter-react-16": "^1.0.6",
+    "@types/mime": "^3.0.1",
     "@types/react-plotly.js": "^2.5.0",
     "@types/react-test-renderer": "^16.9.1",
     "antlr4ts-cli": "^0.5.0-alpha.4",
@@ -50,6 +53,7 @@
     "husky": "6.0.0",
     "jest-dom": "^4.0.0",
     "lint-staged": "^13.1.0",
+    "mock-fs": "^4.12.0",
     "ts-jest": "^29.1.0"
   },
   "resolutions": {

--- a/server/adaptors/integrations/integrations_adaptor.ts
+++ b/server/adaptors/integrations/integrations_adaptor.ts
@@ -20,13 +20,13 @@ export interface IntegrationsAdaptor {
     dataSource: string
   ) => Promise<IntegrationInstance>;
 
-  deleteIntegrationInstance: (id: string) => Promise<any>;
+  deleteIntegrationInstance: (id: string) => Promise<unknown>;
 
   getStatic: (templateName: string, path: string) => Promise<Buffer>;
 
   getSchemas: (
     templateName: string
-  ) => Promise<{ mappings: { [key: string]: any }; schemas: { [key: string]: any } }>;
+  ) => Promise<{ mappings: { [key: string]: unknown }; schemas: { [key: string]: unknown } }>;
 
-  getAssets: (templateName: string) => Promise<{ savedObjects?: any }>;
+  getAssets: (templateName: string) => Promise<{ savedObjects?: unknown }>;
 }

--- a/server/adaptors/integrations/integrations_adaptor.ts
+++ b/server/adaptors/integrations/integrations_adaptor.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface IntegrationsAdaptor {
+  getIntegrationTemplates: (
+    query?: IntegrationTemplateQuery
+  ) => Promise<IntegrationTemplateSearchResult>;
+
+  getIntegrationInstances: (
+    query?: IntegrationInstanceQuery
+  ) => Promise<IntegrationInstancesSearchResult>;
+
+  getIntegrationInstance: (query?: IntegrationInstanceQuery) => Promise<IntegrationInstanceResult>;
+
+  loadIntegrationInstance: (
+    templateName: string,
+    name: string,
+    dataSource: string
+  ) => Promise<IntegrationInstance>;
+
+  deleteIntegrationInstance: (id: string) => Promise<any>;
+
+  getStatic: (templateName: string, path: string) => Promise<Buffer>;
+
+  getSchemas: (
+    templateName: string
+  ) => Promise<{ mappings: { [key: string]: any }; schemas: { [key: string]: any } }>;
+
+  getAssets: (templateName: string) => Promise<{ savedObjects?: any }>;
+}

--- a/server/adaptors/integrations/types.ts
+++ b/server/adaptors/integrations/types.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+interface IntegrationTemplate {
+  name: string;
+  version: string;
+  displayName?: string;
+  integrationType: string;
+  license: string;
+  type: string;
+  author?: string;
+  description?: string;
+  sourceUrl?: string;
+  statics?: {
+    logo?: StaticAsset;
+    gallery?: StaticAsset[];
+    darkModeLogo?: StaticAsset;
+    darkModeGallery?: StaticAsset[];
+  };
+  components: IntegrationComponent[];
+  assets: {
+    savedObjects?: {
+      name: string;
+      version: string;
+    };
+  };
+}
+
+interface StaticAsset {
+  annotation?: string;
+  path: string;
+}
+
+interface IntegrationComponent {
+  name: string;
+  version: string;
+}
+
+interface DisplayAsset {
+  body: string;
+}
+
+interface IntegrationTemplateSearchResult {
+  hits: IntegrationTemplate[];
+}
+
+interface IntegrationTemplateQuery {
+  name?: string;
+}
+
+interface IntegrationInstance {
+  name: string;
+  templateName: string;
+  dataSource: {
+    sourceType: string;
+    dataset: string;
+    namespace: string;
+  };
+  creationDate: string;
+  assets: AssetReference[];
+}
+
+interface IntegrationInstanceResult extends IntegrationInstance {
+  id: string;
+  status: string;
+}
+
+interface AssetReference {
+  assetType: string;
+  assetId: string;
+  isDefaultAsset: boolean;
+  description: string;
+}
+
+interface IntegrationInstancesSearchResult {
+  hits: IntegrationInstanceResult[];
+}
+
+interface IntegrationInstanceQuery {
+  added?: boolean;
+  id?: string;
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -20,16 +20,16 @@ import { registerSqlRoute } from './notebooks/sqlRouter';
 import { registerEventAnalyticsRouter } from './event_analytics/event_analytics_router';
 import { registerAppAnalyticsRouter } from './application_analytics/app_analytics_router';
 import { registerMetricsRoute } from './metrics/metrics_rounter';
-
+import { registerIntegrationsRoute } from './integrations/integrations_router';
 
 export function setupRoutes({ router, client }: { router: IRouter; client: ILegacyClusterClient }) {
   PanelsRouter(router);
   VisualizationsRouter(router);
   registerPplRoute({ router, facet: new PPLFacet(client) });
-  registerDslRoute({ router, facet: new DSLFacet(client)});
+  registerDslRoute({ router, facet: new DSLFacet(client) });
   registerEventAnalyticsRouter({ router, savedObjectFacet: new SavedObjectFacet(client) });
   registerAppAnalyticsRouter(router);
-  
+
   // TODO remove trace analytics route when DSL route for autocomplete is added
   registerTraceAnalyticsDslRouter(router);
 
@@ -41,4 +41,5 @@ export function setupRoutes({ router, client }: { router: IRouter; client: ILega
   registerSqlRoute(router, queryService);
 
   registerMetricsRoute(router);
-};
+  registerIntegrationsRoute(router);
+}

--- a/server/routes/integrations/__tests__/integrations_router.test.ts
+++ b/server/routes/integrations/__tests__/integrations_router.test.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { OpenSearchDashboardsResponseFactory } from '../../../../../../src/core/server/http/router';
 import { handleWithCallback } from '../integrations_router';
 import { IntegrationsAdaptor } from 'server/adaptors/integrations/integrations_adaptor';

--- a/server/routes/integrations/__tests__/integrations_router.test.ts
+++ b/server/routes/integrations/__tests__/integrations_router.test.ts
@@ -1,23 +1,24 @@
-import { DeepPartial } from 'redux';
 import { OpenSearchDashboardsResponseFactory } from '../../../../../../src/core/server/http/router';
 import { handleWithCallback } from '../integrations_router';
 import { IntegrationsAdaptor } from 'server/adaptors/integrations/integrations_adaptor';
 
-jest
-  .mock('../../../../../../src/core/server', () => jest.fn())
-  .mock('../../../../../../src/core/server/http/router', () => jest.fn());
+describe('handleWithCallback', () => {
+  let adaptorMock: jest.Mocked<IntegrationsAdaptor>;
+  let responseMock: jest.Mocked<OpenSearchDashboardsResponseFactory>;
 
-describe('Data wrapper', () => {
-  const adaptorMock: Partial<IntegrationsAdaptor> = {};
-  const responseMock: DeepPartial<OpenSearchDashboardsResponseFactory> = {
-    custom: jest.fn((data) => data),
-    ok: jest.fn((data) => data),
-  };
+  beforeEach(() => {
+    adaptorMock = {} as any;
+    responseMock = {
+      custom: jest.fn((data) => data),
+      ok: jest.fn((data) => data),
+    } as any;
+  });
 
   it('retrieves data from the callback method', async () => {
     const callback = jest.fn((_) => {
       return { test: 'data' };
     });
+
     const result = await handleWithCallback(
       adaptorMock as IntegrationsAdaptor,
       responseMock as OpenSearchDashboardsResponseFactory,
@@ -33,6 +34,7 @@ describe('Data wrapper', () => {
     const callback = jest.fn((_) => {
       throw new Error('test error');
     });
+
     const result = await handleWithCallback(
       adaptorMock as IntegrationsAdaptor,
       responseMock as OpenSearchDashboardsResponseFactory,

--- a/server/routes/integrations/__tests__/integrations_router.test.ts
+++ b/server/routes/integrations/__tests__/integrations_router.test.ts
@@ -1,0 +1,46 @@
+import { DeepPartial } from 'redux';
+import { OpenSearchDashboardsResponseFactory } from '../../../../../../src/core/server/http/router';
+import { handleWithCallback } from '../integrations_router';
+import { IntegrationsAdaptor } from 'server/adaptors/integrations/integrations_adaptor';
+
+jest
+  .mock('../../../../../../src/core/server', () => jest.fn())
+  .mock('../../../../../../src/core/server/http/router', () => jest.fn());
+
+describe('Data wrapper', () => {
+  const adaptorMock: Partial<IntegrationsAdaptor> = {};
+  const responseMock: DeepPartial<OpenSearchDashboardsResponseFactory> = {
+    custom: jest.fn((data) => data),
+    ok: jest.fn((data) => data),
+  };
+
+  it('retrieves data from the callback method', async () => {
+    const callback = jest.fn((_) => {
+      return { test: 'data' };
+    });
+    const result = await handleWithCallback(
+      adaptorMock as IntegrationsAdaptor,
+      responseMock as OpenSearchDashboardsResponseFactory,
+      callback
+    );
+
+    expect(callback).toHaveBeenCalled();
+    expect(responseMock.ok).toHaveBeenCalled();
+    expect(result.body.data).toEqual({ test: 'data' });
+  });
+
+  it('passes callback errors through', async () => {
+    const callback = jest.fn((_) => {
+      throw new Error('test error');
+    });
+    const result = await handleWithCallback(
+      adaptorMock as IntegrationsAdaptor,
+      responseMock as OpenSearchDashboardsResponseFactory,
+      callback
+    );
+
+    expect(callback).toHaveBeenCalled();
+    expect(responseMock.custom).toHaveBeenCalled();
+    expect(result.body).toEqual('test error');
+  });
+});

--- a/server/routes/integrations/integrations_router.ts
+++ b/server/routes/integrations/integrations_router.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import * as mime from 'mime';
+import { IRouter, RequestHandlerContext } from '../../../../../src/core/server';
+import { INTEGRATIONS_BASE } from '../../../common/constants/shared';
+import { IntegrationsAdaptor } from '../../adaptors/integrations/integrations_adaptor';
+import {
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+} from '../../../../../src/core/server/http/router';
+
+/**
+ * Handle an `OpenSearchDashboardsRequest` using the provided `callback` function.
+ * This is a convenience method that handles common error handling and response formatting.
+ * The callback must accept a `IntegrationsAdaptor` as its first argument.
+ *
+ * If the callback throws an error,
+ * the `OpenSearchDashboardsResponse` will be formatted using the error's `statusCode` and `message` properties.
+ * Otherwise, the callback's return value will be formatted in a JSON object under the `data` field.
+ *
+ * @param {IntegrationsAdaptor} adaptor The adaptor instance to use for making requests.
+ * @param {OpenSearchDashboardsResponseFactory} response The factory to use for creating responses.
+ * @callback callback A callback that will invoke a request on a provided adaptor.
+ * @returns {Promise<OpenSearchDashboardsResponse>} An `OpenSearchDashboardsResponse` with the return data from the callback.
+ */
+export const handleWithCallback = async (
+  adaptor: IntegrationsAdaptor,
+  response: OpenSearchDashboardsResponseFactory,
+  callback: (a: IntegrationsAdaptor) => any
+): Promise<any> => {
+  try {
+    const data = await callback(adaptor);
+    return response.ok({
+      body: {
+        data,
+      },
+    });
+  } catch (err: any) {
+    console.error(`handleWithCallback: callback failed with error "${err.message}"`);
+    return response.custom({
+      statusCode: err.statusCode || 500,
+      body: err.message,
+    });
+  }
+};
+
+const getAdaptor = (
+  context: RequestHandlerContext,
+  _request: OpenSearchDashboardsRequest
+): IntegrationsAdaptor => {
+  // Stub
+  return {} as IntegrationsAdaptor;
+};
+
+export function registerIntegrationsRoute(router: IRouter) {
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/repository`,
+      validate: false,
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) =>
+        a.getIntegrationTemplates()
+      );
+    }
+  );
+
+  router.post(
+    {
+      path: `${INTEGRATIONS_BASE}/store/{templateName}`,
+      validate: {
+        params: schema.object({
+          templateName: schema.string(),
+        }),
+        body: schema.object({
+          name: schema.string(),
+          dataSource: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) => {
+        return a.loadIntegrationInstance(
+          request.params.templateName,
+          request.body.name,
+          request.body.dataSource
+        );
+      });
+    }
+  );
+
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/repository/{name}`,
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(
+        adaptor,
+        response,
+        async (a: IntegrationsAdaptor) =>
+          (
+            await a.getIntegrationTemplates({
+              name: request.params.name,
+            })
+          ).hits[0]
+      );
+    }
+  );
+
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/repository/{id}/static/{path}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+          path: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      try {
+        const result = await adaptor.getStatic(request.params.id, request.params.path);
+        return response.ok({
+          headers: {
+            'Content-Type': mime.getType(request.params.path),
+          },
+          body: result,
+        });
+      } catch (err: any) {
+        return response.custom({
+          statusCode: err.statusCode ? err.statusCode : 500,
+          body: err.message,
+        });
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/repository/{id}/schema`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) =>
+        a.getSchemas(request.params.id)
+      );
+    }
+  );
+
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/repository/{id}/assets`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) =>
+        a.getAssets(request.params.id)
+      );
+    }
+  );
+
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/store`,
+      validate: false,
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) =>
+        a.getIntegrationInstances({})
+      );
+    }
+  );
+
+  router.delete(
+    {
+      path: `${INTEGRATIONS_BASE}/store/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) =>
+        a.deleteIntegrationInstance(request.params.id)
+      );
+    }
+  );
+
+  router.get(
+    {
+      path: `${INTEGRATIONS_BASE}/store/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response): Promise<any> => {
+      const adaptor = getAdaptor(context, request);
+      return handleWithCallback(adaptor, response, async (a: IntegrationsAdaptor) =>
+        a.getIntegrationInstance({
+          id: request.params.id,
+        })
+      );
+    }
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,6 +279,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/mime@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
 "@types/node@*":
   version "16.7.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.2.tgz#0465a39b5456b61a04d98bd5545f8b34be340cb7"
@@ -411,6 +416,16 @@ ajv@^6.10.0, ajv@^6.10.2:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 anser@^1.4.1:
@@ -1839,6 +1854,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.4.0, json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
@@ -2060,6 +2080,11 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.49.0"
 
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2093,6 +2118,11 @@ mkdirp@^0.5.1:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+mock-fs@^4.12.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
+  integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
 
 ms@^2.1.1:
   version "2.1.3"
@@ -2594,6 +2624,11 @@ request-progress@^3.0.0:
   integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
   dependencies:
     throttleit "^1.0.0"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 reselect@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Description
As part of breaking the integrations project into smaller pieces, the first step is to stub the router. On one side, the adaptor implementation will be filled in behind it, while on the other, the front-end can be split up and shared in front of it.

As-is, the router should catch errors and return 500s for every request. Nothing should crash the server.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
