### PR TITLE
Add prebuild step to embed the Observability schema mapping files in …

### DIFF
--- a/fetch_schema_mappings.js
+++ b/fetch_schema_mappings.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Configure the folder paths
+const tempFolderPath = './temp';
+const remoteFolderPath = 'schema/observability';
+const localFolderPath = './dashboards-observability/server/adaptors/integrations/__data__/schema';
+
+// Remove the existing temp folder if it exists
+if (fs.existsSync(tempFolderPath)) {
+    console.log('Removing existing temp folder...');
+    execSync(`rm -rf ${tempFolderPath}`);
+}
+
+// Remove the existing local folder if it exists
+if (fs.existsSync(localFolderPath)) {
+    console.log('Removing existing local folder...');
+    execSync(`rm -rf ${localFolderPath}`);
+}
+
+console.log('Cloning the remote repository to the temp folder...');
+// Clone the remote repository to the temp folder
+execSync(`git clone --depth 1 https://github.com/opensearch-project/opensearch-catalog ${tempFolderPath}`);
+
+console.log('Copying files from temp folder to destination folder...');
+// Copy files from the temp folder to the destination folder
+copyFiles(path.join(tempFolderPath, remoteFolderPath), localFolderPath);
+
+console.log('Removing the temp folder...');
+// Remove the temp folder
+execSync(`rm -rf ${tempFolderPath}`);
+
+console.log('Files copied successfully.');
+
+// Copy files recursively from the source folder to the destination folder
+function copyFiles(sourceFolderPath, destinationFolderPath) {
+    if (!fs.existsSync(destinationFolderPath)) {
+        fs.mkdirSync(destinationFolderPath, { recursive: true });
+    }
+
+    const files = fs.readdirSync(sourceFolderPath);
+
+    for (const file of files) {
+        const sourceFilePath = path.join(sourceFolderPath, file);
+        const destinationFilePath = path.join(destinationFolderPath, file);
+
+        const stat = fs.statSync(sourceFilePath);
+
+        if (stat.isFile() && file.endsWith('.mapping')) {
+            console.log(`Copying file: ${sourceFilePath} to ${destinationFilePath}`);
+            fs.copyFileSync(sourceFilePath, destinationFilePath);
+        } else if (stat.isDirectory()) {
+            const nestedDestinationFolderPath = path.join(destinationFolderPath, file);
+            console.log(`Creating directory: ${nestedDestinationFolderPath}`);
+            fs.mkdirSync(nestedDestinationFolderPath, { recursive: true });
+            copyFiles(sourceFilePath, nestedDestinationFolderPath);
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "osd": "node ../../scripts/osd",
+    "prebuild": "node fetch_schema_mappings.js",
     "build": "yarn plugin-helpers build",
     "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",
     "cypress:run": "TZ=America/Los_Angeles cypress run",


### PR DESCRIPTION
### Description
Add prebuild step to embed the Observability schema mapping files in the code from the remote catalog repository using the main branch

source repo: https://github.com/opensearch-project/opensearch-catalog
target folder: `./dashboards-observability/server/adaptors/integrations/__data__/schema`

### Issues Resolved
- https://github.com/opensearch-project/dashboards-observability/issues/542

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
