### PR TITLE
BugFix: Visuals from Applications available in Dashboards

### DIFF
--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -336,18 +336,6 @@ export const VisaulizationFlyoutSO = ({
       .then((res) => {
         if (res.visualizations.length > 0) {
           setSavedVisualizations(res.visualizations);
-          // const filterAppVis = res.visualizations.filter((vis: SavedVisualizationType) => {
-          //   return appId
-          //     ? vis.hasOwnProperty('application_id')
-          //       ? vis.application_id === appId
-          //       : false
-          //     : !vis.hasOwnProperty('application_id');
-          // });
-          // setVisualizationOptions(
-          //   filterAppVis.map((visualization: SavedVisualizationType) => {
-          //     return { value: visualization.id, text: visualization.name };
-          //   })
-          // );
           setVisualizationOptions(
             res.visualizations.map((visualization: SavedVisualizationType) => {
               return { value: visualization.id, text: visualization.name };

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -173,13 +173,15 @@ export const VisaulizationFlyoutSO = ({
     if (!isInputValid()) return;
 
     if (isFlyoutReplacement) {
-      dispatch(replaceVizInPanel(panel, replaceVisualizationId, selectValue, newVisualizationTitle));
+      dispatch(
+        replaceVizInPanel(panel, replaceVisualizationId, selectValue, newVisualizationTitle)
+      );
     } else {
-        const visualizationsWithNewPanel = addVisualizationPanel({
-          savedVisualizationId: selectValue,
-          onSuccess: `Visualization ${newVisualizationTitle} successfully added!`,
-          onFailure: `Error in adding ${newVisualizationTitle} visualization to the panel`
-        });
+      const visualizationsWithNewPanel = addVisualizationPanel({
+        savedVisualizationId: selectValue,
+        onSuccess: `Visualization ${newVisualizationTitle} successfully added!`,
+        onFailure: `Error in adding ${newVisualizationTitle} visualization to the panel`,
+      });
     }
     closeFlyout();
   };
@@ -334,15 +336,20 @@ export const VisaulizationFlyoutSO = ({
       .then((res) => {
         if (res.visualizations.length > 0) {
           setSavedVisualizations(res.visualizations);
-          const filterAppVis = res.visualizations.filter((vis: SavedVisualizationType) => {
-            return appId
-              ? vis.hasOwnProperty('application_id')
-                ? vis.application_id === appId
-                : false
-              : !vis.hasOwnProperty('application_id');
-          });
+          // const filterAppVis = res.visualizations.filter((vis: SavedVisualizationType) => {
+          //   return appId
+          //     ? vis.hasOwnProperty('application_id')
+          //       ? vis.application_id === appId
+          //       : false
+          //     : !vis.hasOwnProperty('application_id');
+          // });
+          // setVisualizationOptions(
+          //   filterAppVis.map((visualization: SavedVisualizationType) => {
+          //     return { value: visualization.id, text: visualization.name };
+          //   })
+          // );
           setVisualizationOptions(
-            filterAppVis.map((visualization: SavedVisualizationType) => {
+            res.visualizations.map((visualization: SavedVisualizationType) => {
               return { value: visualization.id, text: visualization.name };
             })
           );

--- a/public/components/event_analytics/home/home.tsx
+++ b/public/components/event_analytics/home/home.tsx
@@ -119,12 +119,6 @@ const EventAnalyticsHome = (props: IHomeProps) => {
       sortOrder: 'desc',
       fromIndex: 0,
     });
-    // const nonAppObjects = observabilityObjects.observabilityObjectList.filter(
-    //   (object: ObservabilitySavedObject) =>
-    //     (object.savedVisualization && !object.savedVisualization.application_id) ||
-    //     object.savedQuery
-    // );
-    // setSavedHistories(nonAppObjects);
     setSavedHistories(observabilityObjects.observabilityObjectList);
   };
 

--- a/public/components/event_analytics/home/home.tsx
+++ b/public/components/event_analytics/home/home.tsx
@@ -119,12 +119,13 @@ const EventAnalyticsHome = (props: IHomeProps) => {
       sortOrder: 'desc',
       fromIndex: 0,
     });
-    const nonAppObjects = observabilityObjects.observabilityObjectList.filter(
-      (object: ObservabilitySavedObject) =>
-        (object.savedVisualization && !object.savedVisualization.application_id) ||
-        object.savedQuery
-    );
-    setSavedHistories(nonAppObjects);
+    // const nonAppObjects = observabilityObjects.observabilityObjectList.filter(
+    //   (object: ObservabilitySavedObject) =>
+    //     (object.savedVisualization && !object.savedVisualization.application_id) ||
+    //     object.savedQuery
+    // );
+    // setSavedHistories(nonAppObjects);
+    setSavedHistories(observabilityObjects.observabilityObjectList);
   };
 
   const deleteHistoryList = async () => {


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Allowed saved visuals from applications to be viewable from the logs home screen and for them to be added to dashboards.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
