### PR TITLE
[BugFix] Application Analytics - Save Visualization Missing Index

### DIFF
--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -74,6 +74,7 @@ import {
 } from '../../../../common/types/explorer';
 import {
   buildQuery,
+  buildRawQuery,
   getIndexPatternFromRawQuery,
   uiSettingsService,
 } from '../../../../common/utils';
@@ -739,7 +740,7 @@ export const Explorer = ({
     savingTitle: string
   ) => {
     return {
-      query: queryState[RAW_QUERY],
+      query: buildRawQuery(query, appBaseQuery),
       fields: fields[SELECTED_FIELDS],
       dateRange: queryState[SELECTED_DATE_RANGE],
       name: savingTitle,


### PR DESCRIPTION
### Description
[Describe what this change achieves]
When saving a visualization from Application → Log Events / Visualizations it states it is saved correctly but appears on the panel page with the error "Issue in building final query" missing index. If you go to edit it from panels it opens up the visual as expected. Looking at the network request in panels the query is missing the source part. Appears to be a side effect of https://github.com/opensearch-project/dashboards-observability/pull/449
Using the helper function buildRawQuery fixes it.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
