### PR TITLE
Replace metrics panel-separator with ResizableContainer

### DIFF
--- a/public/components/metrics/index.tsx
+++ b/public/components/metrics/index.tsx
@@ -9,6 +9,7 @@ import {
   EuiGlobalToastList,
   EuiPage,
   EuiPageBody,
+  EuiResizableContainer,
   htmlIdGenerator,
   OnTimeChangeProps,
   ShortDate,
@@ -187,47 +188,39 @@ export const Home = ({
                     setSearch={setSearch}
                   />
                   <div className="dscAppContainer">
-                    <div
-                      className={`col-md-2 dscSidebar__container dscCollapsibleSidebar ${sidebarClassName}`}
-                    >
-                      <div className="">
-                        {!isSidebarClosed && (
-                          <Sidebar http={http} pplService={pplService} search={search} />
-                        )}
-                        <EuiButtonIcon
-                          iconType={isSidebarClosed ? 'menuRight' : 'menuLeft'}
-                          iconSize="m"
-                          size="s"
-                          onClick={() => onSideBarClick()}
-                          data-test-subj="collapseSideBarButton"
-                          aria-controls="discover-sidebar"
-                          aria-expanded={isSidebarClosed ? 'false' : 'true'}
-                          aria-label="Toggle sidebar"
-                          className="dscCollapsibleSidebar__collapseButton"
-                        />
-                      </div>
-                    </div>
-                    <div className={`dscWrapper ${mainSectionClassName}`}>
-                      {selectedMetrics.length > 0 ? (
-                        <MetricsGrid
-                          http={http}
-                          chrome={chrome}
-                          panelVisualizations={panelVisualizations}
-                          setPanelVisualizations={setPanelVisualizations}
-                          editMode={editMode}
-                          pplService={pplService}
-                          startTime={startTime}
-                          endTime={endTime}
-                          moveToEvents={onEditClick}
-                          onRefresh={onRefresh}
-                          editActionType={editActionType}
-                          setEditActionType={setEditActionType}
-                          spanParam={spanValue + resolutionValue}
-                        />
-                      ) : (
-                        <EmptyMetricsView />
+                    <EuiResizableContainer>
+                      {(EuiResizablePanel, EuiResizableButton) => (
+                        <>
+                          <EuiResizablePanel mode="collapsible" initialSize={20} minSize="10%">
+                            <Sidebar http={http} pplService={pplService} search={search} />
+                          </EuiResizablePanel>
+
+                          <EuiResizableButton />
+
+                          <EuiResizablePanel mode="main" initialSize={80} minSize="50px">
+                            {selectedMetrics.length > 0 ? (
+                              <MetricsGrid
+                                http={http}
+                                chrome={chrome}
+                                panelVisualizations={panelVisualizations}
+                                setPanelVisualizations={setPanelVisualizations}
+                                editMode={editMode}
+                                pplService={pplService}
+                                startTime={startTime}
+                                endTime={endTime}
+                                moveToEvents={onEditClick}
+                                onRefresh={onRefresh}
+                                editActionType={editActionType}
+                                setEditActionType={setEditActionType}
+                                spanParam={spanValue + resolutionValue}
+                              />
+                            ) : (
+                              <EmptyMetricsView />
+                            )}
+                          </EuiResizablePanel>
+                        </>
                       )}
-                    </div>
+                    </EuiResizableContainer>
                   </div>
                 </EuiPageBody>
               </EuiPage>


### PR DESCRIPTION
### Description
Replace Metrics panel-separator (vertical) with ResizeableContainer slider.


https://github.com/opensearch-project/dashboards-observability/assets/11318/a99eb85c-e371-4853-b85b-08f596c0fb54



### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
