### PR TITLE
revert integrations change metrics

### DIFF
--- a/server/common/metrics/constants.ts
+++ b/server/common/metrics/constants.ts
@@ -11,16 +11,18 @@ export const INTERVAL = 60;
 export const CAPACITY = (WINDOW / INTERVAL) * 2;
 export const MILLIS_MULTIPLIER = 1000;
 
-export const COMPONENTS = [
-  'application_analytics',
-  'operational_panels',
-  'event_analytics',
-  'notebooks',
-  'trace_analytics',
-  'metrics_analytics',
-  'integrations',
-] as const;
-export const REQUESTS = ['create', 'get', 'update', 'delete'] as const;
+const commonRequests = ['create', 'get', 'update', 'delete', 'add_samples'] as const;
+
+// object of each component and its specific requests
+export const COMPONENTS = {
+  application_analytics: commonRequests,
+  operational_panels: [...commonRequests, 'fetch_visualization'],
+  event_analytics: commonRequests,
+  notebooks: [...commonRequests, 'run_sql_query', 'run_ppl_query', 'fetch_visualization'],
+  trace_analytics: commonRequests,
+  metrics_analytics: commonRequests,
+  integrations: commonRequests,
+} as const;
 
 export const GLOBAL_BASIC_COUNTER: CounterType = (() => {
   const counter = {} as CounterType;


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/dashboards-observability/pull/638
metrics constant file was broken due to this PR, there was this typescript error that was ignored. we should make CI fail on typescript errors
```
Diagnostics:
Property 'forEach' does not exist on type '"application_analytics" | "operational_panels" | "event_analytics" | "notebooks" | "trace_analytics" | "metrics_analytics" | "integrations"'.
  Property 'forEach' does not exist on type '"application_analytics"'. [2339]
```
This PR fixes the metrics constant file by restoring the previous version, probably broken due to merge conflict

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
