### PR TITLE
Adds cypress watch and reload plugin

### DIFF
--- a/.cypress/plugins/index.js
+++ b/.cypress/plugins/index.js
@@ -24,4 +24,7 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  require('cypress-watch-and-reload/plugins')(config)
+
+  return config
 }


### PR DESCRIPTION
### Description
Adds back cypress watch and reload, yarn cypress:open does not work without it

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
