### PR TITLE
fix name change bug and modify test to test behavior

### DIFF
--- a/.cypress/integration/9_integrations.spec.js
+++ b/.cypress/integration/9_integrations.spec.js
@@ -62,10 +62,12 @@ describe('Tests the add nginx integration instance flow', () => {
     cy.get('[data-test-subj="new-instance-name"]').should('have.value', 'nginx');
     cy.get('[data-test-subj="createInstanceButton"]').should('be.disabled')
     cy.get('[data-test-subj="addIntegrationFlyoutTitle"]').should('exist')
+    // Modifies the name of the integration
+    cy.get('[data-test-subj="new-instance-name"]').type(testInstance.substring(5));
     // validates the created sample index
     cy.get('[data-test-subj="data-source-name"]').type('ss4o_logs-nginx-sample-sample');
-    cy.get('[data-test-subj="validateIndex"]').click()
-    cy.get('[data-test-subj="new-instance-name"]').type(testInstance.substring(5));
+    cy.get('[data-test-subj="validateIndex"]').click();
+    cy.get('.euiToastHeader__title').should('contain', 'valid');
     cy.get('[data-test-subj="createInstanceButton"]').click();
     cy.get('.euiToastHeader__title').should('contain', 'successfully');
   })

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -173,7 +173,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
     }
     const [dataSourceMappings, integrationMappings] = await Promise.all([
       fetchDataSourceMappings(targetDataSource),
-      fetchIntegrationMappings(name),
+      fetchIntegrationMappings(integrationName),
     ]);
     if (!dataSourceMappings) {
       validationErrors.push('Provided data stream could not be retrieved');


### PR DESCRIPTION
### Description
Fix Bug where integration cannot be created from UI if the name of the integration instance is changed prior to validating data source mappings.

### Issues Resolved
Fix: #712 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
