### PR TITLE
fix integration json loading parser so that it will trim unneeded emp…

### DIFF
--- a/server/adaptors/integrations/repository/integration.ts
+++ b/server/adaptors/integrations/repository/integration.ts
@@ -211,7 +211,7 @@ export class Integration {
       );
       try {
         const ndjson = await fs.readFile(sobjPath, { encoding: 'utf-8' });
-        const asJson = '[' + ndjson.replace(/\n/g, ',') + ']';
+        const asJson = '[' + ndjson.trim().replace(/\n/g, ',') + ']';
         const parsed = JSON.parse(asJson);
         result.savedObjects = parsed;
       } catch (err: any) {


### PR DESCRIPTION
trim empty spaces from the ndjson file and match the existing behavior of the savedObject import dashboard that works even when empty spaces appear in the ndjson file

### Description
Integration loading of a dashboard fails when empty spaces appear in the ndjson file

This works well in the savedObject import api

### What is the expected behavior?
Success loading the ndjson dashboard even if it has empty lines - fix the integration parser to trim the ndjson

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/757

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
