### PR TITLE
Make integration category and template lists dynamic

### DIFF
--- a/common/constants/integrations.ts
+++ b/common/constants/integrations.ts
@@ -7,5 +7,3 @@ export const OPENSEARCH_DOCUMENTATION_URL = 'https://opensearch.org/docs/latest/
 export const ASSET_FILTER_OPTIONS = ['index-pattern', 'search', 'visualization', 'dashboard'];
 // TODO get this list dynamically from the API
 export const INTEGRATION_TEMPLATE_OPTIONS = ['nginx'];
-// TODO get this list dynamically from the API
-export const INTEGRATION_CATEOGRY_OPTIONS = ['communication', 'http', 'cloud', 'container', 'logs'];

--- a/common/constants/integrations.ts
+++ b/common/constants/integrations.ts
@@ -5,5 +5,3 @@
 
 export const OPENSEARCH_DOCUMENTATION_URL = 'https://opensearch.org/docs/latest/integrations/index';
 export const ASSET_FILTER_OPTIONS = ['index-pattern', 'search', 'visualization', 'dashboard'];
-// TODO get this list dynamically from the API
-export const INTEGRATION_TEMPLATE_OPTIONS = ['nginx'];

--- a/public/components/integrations/components/added_integration_table.tsx
+++ b/public/components/integrations/components/added_integration_table.tsx
@@ -18,10 +18,6 @@ import {
 import _ from 'lodash';
 import React, { useState } from 'react';
 import { AddedIntegrationsTableProps } from './added_integration_overview_page';
-import {
-  ASSET_FILTER_OPTIONS,
-  INTEGRATION_TEMPLATE_OPTIONS,
-} from '../../../../common/constants/integrations';
 import { DeleteModal } from '../../../../public/components/common/helpers/delete_modal';
 import { INTEGRATIONS_BASE } from '../../../../common/constants/shared';
 import { useToast } from '../../../../public/components/common/toast';
@@ -103,7 +99,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
       });
   }
 
-  const getModal = (integrationInstanceId, name) => {
+  const getModal = (integrationInstanceId: string, name: string) => {
     setModalLayout(
       <DeleteModal
         onConfirm={() => {
@@ -120,20 +116,22 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
     setIsModalVisible(true);
   };
 
+  const integTemplateNames = [...new Set(integrations.map((i) => i.templateName))].sort();
+
   const search = {
     box: {
       incremental: true,
     },
     filters: [
       {
-        type: 'field_value_selection',
+        type: 'field_value_selection' as const,
         field: 'templateName',
         name: 'Type',
         multiSelect: false,
-        options: INTEGRATION_TEMPLATE_OPTIONS.map((i) => ({
-          value: i,
-          name: i,
-          view: i,
+        options: integTemplateNames.map((name) => ({
+          name,
+          value: name,
+          view: name,
         })),
       },
     ],

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -16,7 +16,6 @@ import {
 } from '@elastic/eui';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
-import { INTEGRATION_CATEOGRY_OPTIONS } from '../../../../common/constants/integrations';
 import { IntegrationHeader } from './integration_header';
 import { AvailableIntegrationsTable } from './available_integration_table';
 import { AvailableIntegrationsCardView } from './available_integration_card_view';

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -75,32 +75,18 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
     setIsPopoverOpen(false);
   };
 
-  const [items, setItems] = useState(
-    INTEGRATION_CATEOGRY_OPTIONS.map((x) => {
-      return { name: x };
-    })
-  );
+  const [items, setItems] = useState([] as Array<{ name: string; checked: boolean }>);
 
-  function updateItem(index) {
+  function updateItem(index: number) {
     if (!items[index]) {
       return;
     }
-
     const newItems = [...items];
-
-    switch (newItems[index].checked) {
-      case 'on':
-        newItems[index].checked = undefined;
-        break;
-
-      default:
-        newItems[index].checked = 'on';
-    }
-
+    newItems[index].checked = !items[index].checked;
     setItems(newItems);
   }
 
-  const helper = items.filter((item) => item.checked === 'on').map((x) => x.name);
+  const helper = items.filter((item) => item.checked).map((x) => x.name);
 
   const button = (
     <EuiFilterButton
@@ -108,8 +94,8 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
       onClick={onButtonClick}
       isSelected={isPopoverOpen}
       numFilters={items.length}
-      hasActiveFilters={!!items.find((item) => item.checked === 'on')}
-      numActiveFilters={items.filter((item) => item.checked === 'on').length}
+      hasActiveFilters={!!items.find((item) => item.checked)}
+      numActiveFilters={items.filter((item) => item.checked).length}
     >
       Categories
     </EuiFilterButton>
@@ -126,7 +112,20 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
   }, []);
 
   async function handleDataRequest() {
-    http.get(`${INTEGRATIONS_BASE}/repository`).then((exists) => setData(exists.data));
+    http.get(`${INTEGRATIONS_BASE}/repository`).then((exists) => {
+      setData(exists.data);
+
+      let newItems = exists.data.hits
+        .flatMap((hit: { components: Array<{ name: string }> }) => hit.components)
+        .map((component: { name: string }) => component.name);
+      newItems = [...new Set(newItems)].sort().map((newItem) => {
+        return {
+          name: newItem,
+          checked: false,
+        };
+      });
+      setItems(newItems);
+    });
   }
 
   async function addIntegrationRequest(name: string) {
@@ -163,7 +162,7 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
           <div className="ouiFilterSelect__items">
             {items.map((item, index) => (
               <EuiFilterSelectItem
-                checked={item.checked}
+                checked={item.checked ? 'on' : 'off'}
                 key={index}
                 onClick={() => updateItem(index)}
               >


### PR DESCRIPTION
### Description
Removes instance of hardcoded integration categories list. Also removes an unrelated hardcoded template list that results in a very similar bug in the added integration list.

### Issues Resolved
Resolves #780 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
