### PR TITLE
Re-apply fix for VPC type

### DIFF
--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/aws_vpc_flow-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/aws_vpc_flow-1.0.0.json
@@ -4,7 +4,7 @@
   "displayName": "AWS VPC Flow",
   "description": "AWS VPC Flow log collector",
   "license": "Apache-2.0",
-  "type": "logs",
+  "type": "logs_vpc",
   "author": "Haidong Wang",
   "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/aws_vpc_flow/info",
   "statics": {

--- a/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
@@ -5,7 +5,6 @@
     "description": "Nginx HTTP server collector",
     "license": "Apache-2.0",
     "type": "logs",
-    "link": "https://www.nginx.com/",
     "author": "OpenSearch",
     "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/nginx/info",
     "statics": {

--- a/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
@@ -5,6 +5,7 @@
     "description": "Nginx HTTP server collector",
     "license": "Apache-2.0",
     "type": "logs",
+    "link": "https://www.nginx.com/",
     "author": "OpenSearch",
     "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/nginx/info",
     "statics": {

--- a/server/adaptors/integrations/__test__/local_repository.test.ts
+++ b/server/adaptors/integrations/__test__/local_repository.test.ts
@@ -6,12 +6,24 @@
 import { Repository } from '../repository/repository';
 import { Integration } from '../repository/integration';
 import path from 'path';
+import * as fs from 'fs/promises';
 
 describe('The local repository', () => {
-  it('Should pass shallow validation for all local integrations.', async () => {
-    const repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
-    const integrations: Integration[] = await repository.getIntegrationList();
-    await Promise.all(integrations.map((i) => expect(i.check()).resolves.toBeTruthy()));
+  it('Should only contain valid integration directories or files.', async () => {
+    const directory = path.join(__dirname, '../__data__/repository');
+    const folders = await fs.readdir(directory);
+    await Promise.all(
+      folders.map(async (folder) => {
+        const integPath = path.join(directory, folder);
+        if (!(await fs.lstat(integPath)).isDirectory()) {
+          // If it's not a directory (e.g. a README), skip it
+          return Promise.resolve(null);
+        }
+        // Otherwise, all directories must be integrations
+        const integ = new Integration(integPath);
+        await expect(integ.check()).resolves.toBe(true);
+      })
+    );
   });
 
   it('Should pass deep validation for all local integrations.', async () => {

--- a/server/adaptors/integrations/__test__/local_repository.test.ts
+++ b/server/adaptors/integrations/__test__/local_repository.test.ts
@@ -7,16 +7,26 @@ import { Repository } from '../repository/repository';
 import { Integration } from '../repository/integration';
 import path from 'path';
 
-describe("The local repository", () => {
-    it("Should pass shallow validation for all local integrations.", async () => {
-        let repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
-        let integrations: Integration[] = await repository.getIntegrationList();
-        await Promise.all(integrations.map(i => expect(i.check()).resolves.toBeTruthy()));
-    });
+describe('The local repository', () => {
+  it('Should pass shallow validation for all local integrations.', async () => {
+    const repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
+    const integrations: Integration[] = await repository.getIntegrationList();
+    await Promise.all(integrations.map((i) => expect(i.check()).resolves.toBeTruthy()));
+  });
 
-    it("Should pass deep validation for all local integrations.", async () => {
-        let repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
-        let integrations: Integration[] = await repository.getIntegrationList();
-        await Promise.all(integrations.map(i => expect(i.deepCheck()).resolves.toBeTruthy()));
-    });
+  it('Should pass deep validation for all local integrations.', async () => {
+    const repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
+    const integrations: Integration[] = await repository.getIntegrationList();
+    await Promise.all(integrations.map((i) => expect(i.deepCheck()).resolves.toBeTruthy()));
+  });
+
+  it('Should not have a type that is not imported in the config', async () => {
+    const repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
+    const integrations: Integration[] = await repository.getIntegrationList();
+    for (const integration of integrations) {
+      const config = await integration.getConfig();
+      const components = config!.components.map((x) => x.name);
+      expect(components).toContain(config!.type);
+    }
+  });
 });

--- a/server/adaptors/integrations/__test__/local_repository.test.ts
+++ b/server/adaptors/integrations/__test__/local_repository.test.ts
@@ -6,24 +6,12 @@
 import { Repository } from '../repository/repository';
 import { Integration } from '../repository/integration';
 import path from 'path';
-import * as fs from 'fs/promises';
 
 describe('The local repository', () => {
-  it('Should only contain valid integration directories or files.', async () => {
-    const directory = path.join(__dirname, '../__data__/repository');
-    const folders = await fs.readdir(directory);
-    await Promise.all(
-      folders.map(async (folder) => {
-        const integPath = path.join(directory, folder);
-        if (!(await fs.lstat(integPath)).isDirectory()) {
-          // If it's not a directory (e.g. a README), skip it
-          return Promise.resolve(null);
-        }
-        // Otherwise, all directories must be integrations
-        const integ = new Integration(integPath);
-        await expect(integ.check()).resolves.toBe(true);
-      })
-    );
+  it('Should pass shallow validation for all local integrations.', async () => {
+    const repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
+    const integrations: Integration[] = await repository.getIntegrationList();
+    await Promise.all(integrations.map((i) => expect(i.check()).resolves.toBeTruthy()));
   });
 
   it('Should pass deep validation for all local integrations.', async () => {


### PR DESCRIPTION
### Description
The type for the VPC Flow log was corrupted in #740, leading to the VPC integration displaying lots of errors. This is a different failure mode from the usual result when the type is messed up, so it went undetected for a while.

This PR:
- Fixes the problem
- Adds a test to prevent recurrence

### Issues Resolved
Resolves #792 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
