### PR TITLE
Fix index name collisions on integration sample creation.

### DIFF
--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -67,7 +67,7 @@ export function Integration(props: AvailableIntegrationProps) {
     } else {
       payload.index_patterns = [dataSourceName];
       return fetch(
-        `/api/console/proxy?path=_index_template/${integration.name}_${componentName}_${version}&method=POST`,
+        `/api/console/proxy?path=_index_template/ss4o_${componentName}_${version}_${integration.name}&method=POST`,
         {
           method: 'POST',
           headers: [

--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -50,7 +50,7 @@ export function Integration(props: AvailableIntegrationProps) {
       .post('/api/console/proxy', {
         body: JSON.stringify(payload),
         query: {
-          path: `_component_template/ss4o_${componentName}_${version}_template`,
+          path: `_component_template/ss4o_${componentName}-${version}-template`,
           method: 'POST',
         },
       })
@@ -75,7 +75,7 @@ export function Integration(props: AvailableIntegrationProps) {
       .post('/api/console/proxy', {
         body: JSON.stringify(payload),
         query: {
-          path: `_index_template/ss4o_${componentName}_${version}_${integration.name}`,
+          path: `_index_template/ss4o_${componentName}-${integration.name}-${version}-sample`,
           method: 'POST',
         },
       })
@@ -90,9 +90,9 @@ export function Integration(props: AvailableIntegrationProps) {
     let error = null;
     const mappings = data.data.mappings;
     mappings[integration.type].composed_of = mappings[integration.type].composed_of.map(
-      (templateName: string) => {
-        const version = mappings[templateName].template.mappings._meta.version;
-        return `ss4o_${templateName}_${version}_template`;
+      (componentName: string) => {
+        const version = mappings[componentName].template.mappings._meta.version;
+        return `ss4o_${componentName}-${version}-template`;
       }
     );
     // Create component mappings before the index mapping

--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -31,7 +31,7 @@ export function Integration(props: AvailableIntegrationProps) {
 
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const { setToast } = useToast();
-  const [integration, setIntegration] = useState({});
+  const [integration, setIntegration] = useState({} as { name: string; type: string });
 
   const [integrationMapping, setMapping] = useState(null);
   const [integrationAssets, setAssets] = useState([]);
@@ -67,7 +67,7 @@ export function Integration(props: AvailableIntegrationProps) {
     } else {
       payload.index_patterns = [dataSourceName];
       return fetch(
-        `/api/console/proxy?path=_index_template/${componentName}_${version}&method=POST`,
+        `/api/console/proxy?path=_index_template/${integration.name}_${componentName}_${version}&method=POST`,
         {
           method: 'POST',
           headers: [
@@ -256,7 +256,7 @@ export function Integration(props: AvailableIntegrationProps) {
 
   const [selectedTabId, setSelectedTabId] = useState('assets');
 
-  const onSelectedTabChanged = (id) => {
+  const onSelectedTabChanged = (id: string) => {
     setSelectedTabId(id);
   };
 


### PR DESCRIPTION
### Description
When updating an index template with the same name, OpenSearch rejects the request if it invalidates any old indices. This affects the integration plugin's sample data creation, since it was previously only using type information for creating indices, and this led to collisions with index patterns. This PR also adds name information to the created indices, in order to avoid these collisions.

### Issues Resolved
Resolves #812 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
