### PR TITLE
Changed log mappings to be apache-specific

### DIFF
--- a/server/adaptors/integrations/__data__/repository/apache/apache-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/apache/apache-1.0.0.json
@@ -29,7 +29,7 @@
             "version": "1.0.0"
         },
         {
-            "name": "logs",
+            "name": "logs-apache",
             "version": "1.0.0"
         }
     ],

--- a/server/adaptors/integrations/__data__/repository/apache/schemas/logs-apache-1.0.0.mapping.json
+++ b/server/adaptors/integrations/__data__/repository/apache/schemas/logs-apache-1.0.0.mapping.json
@@ -1,9 +1,12 @@
 {
     "index_patterns": [
-        "ss4o_logs-*-*"
+        "ss4o_logs-apache-*"
     ],
     "data_stream": {},
     "template": {
+        "aliases": {
+            "logs-apache": {}
+        },
         "mappings": {
             "_meta": {
                 "version": "1.0.0",


### PR DESCRIPTION
### Description
Changes log mapping names to be apache-specific, to avoid conflict with other log index patterns.

### Issues Resolved
#812 
[Backport comments](https://github.com/opensearch-project/dashboards-observability/pull/800#discussion_r1283513166)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
