### PR TITLE
Remove dependence on integrations variable

### DIFF
--- a/public/components/integrations/components/added_integration_table.tsx
+++ b/public/components/integrations/components/added_integration_table.tsx
@@ -117,7 +117,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
     setIsModalVisible(true);
   };
 
-  const integTemplateNames = [...new Set(integrations.map((i) => i.templateName))].sort();
+  const integTemplateNames = [...new Set(props.data.hits.map((i) => i.templateName))].sort();
 
   const search = {
     box: {


### PR DESCRIPTION
### Description
Fixes an invisible merge conflict: one PR deleted a variable while another PR added an instance of using it. Result is that whole integrations plugin doesn't render.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
