### PR TITLE
[BACKPORT 2.9] Apache URL fix (#811)

### DIFF
--- a/server/adaptors/integrations/__data__/repository/apache/apache-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/apache/apache-1.0.0.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "type": "logs",
     "author": "OpenSearch",
-    "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/aws_s3/info",
+    "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/apache/info",
     "statics": {
         "logo": {
             "annotation": "Apache Logo",


### PR DESCRIPTION
Signed-off-by: Daniel Dong <danieldong51@amazon.com>
Co-authored-by: Daniel Dong <danieldong51@amazon.com>
(cherry picked from commit a4b764ace27ba2c5141623b67fa3ac09cc2d3ff7)

### Description
Backports URL changes to Apache to 2.9

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/pull/811

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
