### PR TITLE
Fix failing CI

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/public/components/metrics/sidebar/__tests__/__snapshots__/searchbar.test.tsx.snap
+++ b/public/components/metrics/sidebar/__tests__/__snapshots__/searchbar.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Search Bar Component Search Side Bar Component with available metrics 1
         }
         defaultQuery=""
         onChange={[Function]}
+        query=""
       >
         <EuiFlexGroup
           alignItems="center"
@@ -180,6 +181,7 @@ exports[`Search Bar Component Search Side Bar Component with no available metric
         }
         defaultQuery=""
         onChange={[Function]}
+        query=""
       >
         <EuiFlexGroup
           alignItems="center"

--- a/public/components/metrics/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/public/components/metrics/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`Side Bar Component renders Side Bar Component 1`] = `
                   }
                   defaultQuery=""
                   onChange={[Function]}
+                  query=""
                 >
                   <EuiFlexGroup
                     alignItems="center"


### PR DESCRIPTION
### Description
The current CI is failing on main for 3 reasons:
- Snapshots for sidebar tests are outdated
- E2E workflow is broken overall
- Backport workflow triggering early if a PR is labeled before merged

This PR updates the snapshots and adds a check so backport only runs when a PR is merged. E2E was disabled separately, it can be re-enabled when someone has the time to fix it.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
