### PR TITLE
Copy latest Apache version to 2.9

### DIFF
--- a/server/adaptors/integrations/__data__/repository/apache/apache-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/apache/apache-1.0.0.json
@@ -4,7 +4,7 @@
     "displayName": "Apache Dashboard",
     "description": "Apache web logs collector",
     "license": "Apache-2.0",
-    "type": "logs",
+    "type": "logs_apache",
     "author": "OpenSearch",
     "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/apache/info",
     "statics": {
@@ -29,7 +29,7 @@
             "version": "1.0.0"
         },
         {
-            "name": "logs",
+            "name": "logs_apache",
             "version": "1.0.0"
         }
     ],

--- a/server/adaptors/integrations/__data__/repository/apache/schemas/logs_apache-1.0.0.mapping.json
+++ b/server/adaptors/integrations/__data__/repository/apache/schemas/logs_apache-1.0.0.mapping.json
@@ -1,0 +1,242 @@
+{
+    "index_patterns": [
+        "ss4o_logs-apache-*"
+    ],
+    "data_stream": {},
+    "template": {
+        "aliases": {
+            "logs-apache": {}
+        },
+        "mappings": {
+            "_meta": {
+                "version": "1.0.0",
+                "catalog": "observability",
+                "type": "logs",
+                "component": "log",
+                "correlations": [
+                    {
+                        "field": "spanId",
+                        "foreign-schema": "traces",
+                        "foreign-field": "spanId"
+                    },
+                    {
+                        "field": "traceId",
+                        "foreign-schema": "traces",
+                        "foreign-field": "traceId"
+                    }
+                ]
+            },
+            "_source": {
+                "enabled": true
+            },
+            "dynamic_templates": [
+                {
+                    "resources_map": {
+                        "mapping": {
+                            "type": "keyword"
+                        },
+                        "path_match": "resource.*"
+                    }
+                },
+                {
+                    "attributes_map": {
+                        "mapping": {
+                            "type": "keyword"
+                        },
+                        "path_match": "attributes.*"
+                    }
+                },
+                {
+                    "instrumentation_scope_attributes_map": {
+                        "mapping": {
+                            "type": "keyword"
+                        },
+                        "path_match": "instrumentationScope.attributes.*"
+                    }
+                }
+            ],
+            "properties": {
+                "severity": {
+                    "properties": {
+                        "number": {
+                            "type": "long"
+                        },
+                        "text": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        }
+                    }
+                },
+                "attributes": {
+                    "type": "object",
+                    "properties": {
+                        "data_stream": {
+                            "properties": {
+                                "dataset": {
+                                    "ignore_above": 128,
+                                    "type": "keyword"
+                                },
+                                "namespace": {
+                                    "ignore_above": 128,
+                                    "type": "keyword"
+                                },
+                                "type": {
+                                    "ignore_above": 56,
+                                    "type": "keyword"
+                                }
+                            }
+                        }
+                    }
+                },
+                "body": {
+                    "type": "text"
+                },
+                "@timestamp": {
+                    "type": "date"
+                },
+                "observedTimestamp": {
+                    "type": "date"
+                },
+                "observerTime": {
+                    "type": "alias",
+                    "path": "observedTimestamp"
+                },
+                "traceId": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                },
+                "spanId": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                },
+                "schemaUrl": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "instrumentationScope": {
+                    "properties": {
+                        "name": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 128
+                                }
+                            }
+                        },
+                        "version": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        },
+                        "dropped_attributes_count": {
+                            "type": "integer"
+                        },
+                        "schemaUrl": {
+                            "type": "text",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword",
+                                    "ignore_above": 256
+                                }
+                            }
+                        }
+                    }
+                },
+                "event": {
+                    "properties": {
+                        "domain": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "source": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "category": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "type": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "kind": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "result": {
+                            "ignore_above": 256,
+                            "type": "keyword"
+                        },
+                        "exception": {
+                            "properties": {
+                                "message": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "type": {
+                                    "ignore_above": 256,
+                                    "type": "keyword"
+                                },
+                                "stacktrace": {
+                                    "type": "text"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "settings": {
+            "index": {
+                "mapping": {
+                    "total_fields": {
+                        "limit": 10000
+                    }
+                },
+                "refresh_interval": "5s"
+            }
+        }
+    },
+    "composed_of": [
+        "communication",
+        "http"
+    ],
+    "version": 1,
+    "_meta": {
+        "description": "Simple Schema For Observability",
+        "catalog": "observability",
+        "type": "logs",
+        "correlations": [
+            {
+                "field": "spanId",
+                "foreign-schema": "traces",
+                "foreign-field": "spanId"
+            },
+            {
+                "field": "traceId",
+                "foreign-schema": "traces",
+                "foreign-field": "traceId"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
### Description
Due to mixed revision and backport events, Apache has two broken PRs open and 2.x + 2.9 are both out of date. This is one of two syncing PRs to close #800 and #833.

### Issues Resolved

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
