### PR TITLE
Speed up unit testing CI by updating maxWorkers setting

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Test all dashboards-observability modules
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn test --coverage --maxWorkers=2
+          yarn test --coverage --maxWorkers=100%
 
       - name: Upload coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Test all dashboards-observability modules
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn test --coverage
+          yarn test --coverage --maxWorkers=2
 
       - name: Upload coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
### Description
I did some poking around on why our tests might be so slow in CI, and discovered that by default Jest limits itself to 50% of CPU resources. GH Actions has 2 cores, so setting it manually may make our tests run considerably faster.

This is mostly just experimental to see what the difference is.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
