### PR TITLE
Switch Integrations "try it" button to be secondary

### DIFF
--- a/public/components/integrations/components/integration_overview_panel.tsx
+++ b/public/components/integrations/components/integration_overview_panel.tsx
@@ -44,6 +44,19 @@ export function IntegrationOverview(props: any) {
               <EuiButton
                 size="m"
                 onClick={() => {
+                  props.setUpSample();
+                }}
+                disabled={props.loading}
+                data-test-subj="try-it-button"
+                data-click-metric-element="integrations.create_from_try_it"
+              >
+                Try It
+              </EuiButton>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                size="m"
+                onClick={() => {
                   props.showFlyout(config.name);
                 }}
                 fill
@@ -52,20 +65,6 @@ export function IntegrationOverview(props: any) {
                 data-click-metric-element="integrations.set_up"
               >
                 Set Up
-              </EuiButton>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                size="m"
-                onClick={() => {
-                  props.setUpSample();
-                }}
-                fill
-                disabled={props.loading}
-                data-test-subj="try-it-button"
-                data-click-metric-element="integrations.create_from_try_it"
-              >
-                Try It
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>


### PR DESCRIPTION
### Description
Per UX team feedback, this PR switches the order of the "Try it" button and switches its shade to make the two buttons stand out as separate options.

![image](https://github.com/opensearch-project/dashboards-observability/assets/31739405/db6f9ab5-ad35-4458-8dcd-bab0b392dd47)

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
