### PR TITLE
Make OSD Bootstrap more sturdy in CI

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -14,6 +14,8 @@ jobs:
     strategy: 
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+      # Since Windows is inconsistent, we want to let other OSes run on a fail
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -51,11 +53,12 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/dashboards-observability
 
-
       - name: Plugin Bootstrap
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn osd bootstrap
+          yarn cache clean
+          yarn config set network-timeout 1000000 -g
+          yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -53,13 +53,13 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/dashboards-observability
 
-      - name: Cache OpenSearch Dashboards Bootstrap Results
+      - name: Load Plugin Bootstrap cache
         uses: actions/cache@v3
         with:
           path: |
             **/node_modules
             **/target
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('OpenSearch-Dashboards/yarn.lock', 'OpenSearch-Dashboards/plugins/dashboards-observability/yarn.lock') }}
 
       - name: Plugin Bootstrap
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -48,30 +48,24 @@ jobs:
       - run: node -v
       - run: yarn -v
 
+      - name: Checkout Dashboards Observability
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards/plugins/dashboards-observability
+
       - name: Cache OpenSearch Dashboards Bootstrap Results
         uses: actions/cache@v3
         with:
           path: |
-            OpenSearch-Dashboards/data
-            OpenSearch-Dashboards/node_modules
-            OpenSearch-Dashboards/target
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('OpenSearch-Dashboards/yarn.lock', 'OpenSearch-Dashboards/package.json') }}
+            **/node_modules
+            **/target
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('**/yarn.lock', '**/package.json') }}
 
       - name: OSD Bootstrap
         run: |
           cd OpenSearch-Dashboards
           yarn config set network-timeout 1000000 -g
           yarn osd bootstrap --skip-opensearch-dashboards-plugins || yarn osd bootstrap --skip-opensearch-dashboards-plugins
-
-      - name: Checkout Dashboards Observability
-        uses: actions/checkout@v2
-        with:
-          path: OpenSearch-Dashboards/plugins/dashboards-observability
-
-      - name: Plugin Bootstrap
-        run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -47,6 +47,7 @@ jobs:
 
       - run: node -v
       - run: yarn -v
+      - run: cd OpenSearch-Dashboards
 
       - name: Cache OpenSearch Dashboards Bootstrap Results
         uses: actions/cache@v3
@@ -55,11 +56,10 @@ jobs:
             data
             node_modules
             target
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('*/yarn.lock', '*/package.json') }}
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('yarn.lock', 'package.json') }}
 
       - name: OSD Bootstrap
         run: |
-          cd OpenSearch-Dashboards
           yarn config set network-timeout 1000000 -g
           yarn osd bootstrap --skip-opensearch-dashboards-plugins || yarn osd bootstrap --skip-opensearch-dashboards-plugins
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Plugin Bootstrap
         run: |
-          yarn config set network-timeout 1000000 -g
+          cd plugins/dashboards-observability
           yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -60,6 +60,7 @@ jobs:
             **/node_modules
             **/target
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('OpenSearch-Dashboards/yarn.lock', 'OpenSearch-Dashboards/plugins/dashboards-observability/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-bootstrap-
 
       - name: Plugin Bootstrap
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -47,7 +47,6 @@ jobs:
 
       - run: node -v
       - run: yarn -v
-      - run: cd OpenSearch-Dashboards
 
       - name: Cache OpenSearch Dashboards Bootstrap Results
         uses: actions/cache@v3
@@ -60,24 +59,23 @@ jobs:
 
       - name: OSD Bootstrap
         run: |
-          ls
+          cd OpenSearch-Dashboards
           yarn config set network-timeout 1000000 -g
           yarn osd bootstrap --skip-opensearch-dashboards-plugins || yarn osd bootstrap --skip-opensearch-dashboards-plugins
 
       - name: Checkout Dashboards Observability
         uses: actions/checkout@v2
         with:
-          path: plugins/dashboards-observability
-
-      - run: cd plugins/dashboards-observability
+          path: OpenSearch-Dashboards/plugins/dashboards-observability
 
       - name: Plugin Bootstrap
         run: |
+          cd OpenSearch-Dashboards/plugins/dashboards-observability
           yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules
         run: |
-          cd plugins/dashboards-observability
+          cd OpenSearch-Dashboards/plugins/dashboards-observability
           yarn test --coverage --maxWorkers=100%
 
       - name: Upload coverage

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: OSD Bootstrap
         run: |
+          ls
           yarn config set network-timeout 1000000 -g
           yarn osd bootstrap --skip-opensearch-dashboards-plugins || yarn osd bootstrap --skip-opensearch-dashboards-plugins
 
@@ -68,9 +69,10 @@ jobs:
         with:
           path: plugins/dashboards-observability
 
+      - run: cd plugins/dashboards-observability
+
       - name: Plugin Bootstrap
         run: |
-          cd plugins/dashboards-observability
           yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout Dashboards Observability
         uses: actions/checkout@v2
         with:
-          path: OpenSearch-Dashboards/plugins/dashboards-observability
+          path: plugins/dashboards-observability
 
       - name: Plugin Bootstrap
         run: |
@@ -75,7 +75,7 @@ jobs:
 
       - name: Test all dashboards-observability modules
         run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
+          cd plugins/dashboards-observability
           yarn test --coverage --maxWorkers=100%
 
       - name: Upload coverage

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -52,10 +52,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            data
-            node_modules
-            target
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('yarn.lock', 'package.json') }}
+            OpenSearch-Dashboards/data
+            OpenSearch-Dashboards/node_modules
+            OpenSearch-Dashboards/target
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('OpenSearch-Dashboards/yarn.lock', 'OpenSearch-Dashboards/package.json') }}
 
       - name: OSD Bootstrap
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -55,7 +55,7 @@ jobs:
             data
             node_modules
             target
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('yarn.lock', 'package.json') }}
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('*/yarn.lock', '*/package.json') }}
 
       - name: OSD Bootstrap
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -55,7 +55,7 @@ jobs:
             data
             node_modules
             target
-          key: ${{ runner.os }}-bootstrap-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('yarn.lock', 'package.json') }}
 
       - name: OSD Bootstrap
         run: |
@@ -70,9 +70,8 @@ jobs:
 
       - name: Plugin Bootstrap
         run: |
-          cd plugins/dashboards-observability
           yarn config set network-timeout 1000000 -g
-          yarn osd bootstrap --no- || yarn osd bootstrap
+          yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -48,6 +48,21 @@ jobs:
       - run: node -v
       - run: yarn -v
 
+      - name: Cache OpenSearch Dashboards Bootstrap Results
+        uses: actions/cache@v3
+        with:
+          path: |
+            data
+            node_modules
+            target
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+
+      - name: OSD Bootstrap
+        run: |
+          cd OpenSearch-Dashboards
+          yarn config set network-timeout 1000000 -g
+          yarn osd bootstrap --skip-opensearch-dashboards-plugins || yarn osd bootstrap --skip-opensearch-dashboards-plugins
+
       - name: Checkout Dashboards Observability
         uses: actions/checkout@v2
         with:
@@ -55,10 +70,9 @@ jobs:
 
       - name: Plugin Bootstrap
         run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn cache clean
+          cd plugins/dashboards-observability
           yarn config set network-timeout 1000000 -g
-          yarn osd bootstrap || yarn osd bootstrap
+          yarn osd bootstrap --no- || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -61,11 +61,11 @@ jobs:
             **/target
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('**/yarn.lock', '**/package.json') }}
 
-      - name: OSD Bootstrap
+      - name: Plugin Bootstrap
         run: |
           cd OpenSearch-Dashboards
           yarn config set network-timeout 1000000 -g
-          yarn osd bootstrap --skip-opensearch-dashboards-plugins || yarn osd bootstrap --skip-opensearch-dashboards-plugins
+          yarn osd bootstrap || yarn osd bootstrap
 
       - name: Test all dashboards-observability modules
         run: |

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -234,7 +234,6 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
                   setDataSourceValid(validationResult);
                 }}
                 disabled={dataSource.length === 0}
-                fill
               >
                 Validate
               </EuiButton>

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -234,6 +234,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
                   setDataSourceValid(validationResult);
                 }}
                 disabled={dataSource.length === 0}
+                fill
               >
                 Validate
               </EuiButton>


### PR DESCRIPTION
### Description
As the Bootstrap command in CI is inconsistent, this has been causing a lot of delays in getting CI feedback in PRs. This PR seeks to address this with a few safeguards:

1. Advice from the [OSD Developer Guide](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/DEVELOPER_GUIDE.md) was applied to update the network timeout. In their own CI they use this network setting and also have a backup call in case it fails. They also use a `clean` which may address some inconsistency, though it should be a no-op in a CI setting.
2. `fail-fast` is disabled in the CI, so even if the measures from (1) are unsuccessful, we will at least receive some feedback from the other two runs without needing a full re-run.
3. The results are cached to both reduce the effects of the issue and speed up CI overall.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
