### PR TITLE
Inline Editor for Metrics Visualizations.

### DIFF
--- a/common/constants/metrics.ts
+++ b/common/constants/metrics.ts
@@ -24,13 +24,13 @@ export const resolutionOptions = [
   { value: 'y', text: 'years' },
 ];
 
-export const DEFAULT_METRIC_HEIGHT = 2;
+export const DEFAULT_METRIC_HEIGHT = 3;
 export const DEFAULT_METRIC_WIDTH = 12;
 
 export const AGGREGATION_OPTIONS = [
-  { label: 'avg' },
-  { label: 'sum' },
-  { label: 'count' },
-  { label: 'min' },
-  { label: 'max' },
+  { value: 'avg', text: 'avg()' },
+  { value: 'sum', text: 'sum()' },
+  { value: 'count', text: 'count()' },
+  { value: 'min', text: 'min()' },
+  { value: 'max', text: 'max()' },
 ];

--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -203,7 +203,7 @@ export const DEFAULT_CHART_STYLES: DefaultChartStylesProps = {
   FillOpacity: 100,
   MarkerSize: 5,
   ShowLegend: 'show',
-  LegendPosition: 'v',
+  LegendPosition: 'h',
   LabelAngle: 0,
   DefaultSortSectors: 'largest_to_smallest',
   DefaultModeScatter: 'markers',

--- a/common/types/metrics.ts
+++ b/common/types/metrics.ts
@@ -5,12 +5,6 @@
 
 import { VisualizationType } from './custom_panels';
 
-export interface MetricData {
-  metricId: string;
-  metricType: 'savedCustomMetric' | 'prometheusMetric';
-  metricName: string;
-}
-
 export interface MetricType extends VisualizationType {
   id: string;
   savedVisualizationId: string;
@@ -18,5 +12,11 @@ export interface MetricType extends VisualizationType {
   y: number;
   w: number;
   h: number;
-  metricType: 'savedCustomMetric' | 'prometheusMetric';
+  query: {
+    type: 'savedCustomMetric' | 'prometheusMetric';
+    aggregation: string;
+    attributesGroupBy: string[];
+    catalog: string;
+    availableAttributes?: string[];
+  };
 }

--- a/public/components/application_analytics/helpers/utils.tsx
+++ b/public/components/application_analytics/helpers/utils.tsx
@@ -218,7 +218,7 @@ export const calculateAvailability = async (
     const visData = await fetchVisualizationById(http, visualizationId, (value: string) =>
       console.error(value)
     );
-    const userConfigs = visData.user_configs ? JSON.parse(visData.user_configs) : {};
+    const userConfigs = visData.user_configs || {};
     // If there are levels, we get the current value
     if (userConfigs.availabilityConfig?.hasOwnProperty('level')) {
       // For every saved visualization with availability levels we push it to visWithAvailability

--- a/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
@@ -257,7 +257,7 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
                         "props": Object {
                           "defaultSelections": Array [
                             Object {
-                              "id": "v",
+                              "id": "h",
                               "name": "Right",
                             },
                           ],
@@ -420,7 +420,7 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
           "id": "bar",
           "label": "Vertical bar",
           "labelangle": 0,
-          "legendposition": "v",
+          "legendposition": "h",
           "linewidth": 0,
           "mode": "group",
           "name": "bar",
@@ -712,7 +712,7 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
                           "props": Object {
                             "defaultSelections": Array [
                               Object {
-                                "id": "v",
+                                "id": "h",
                                 "name": "Right",
                               },
                             ],
@@ -875,7 +875,7 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
             "id": "bar",
             "label": "Vertical bar",
             "labelangle": 0,
-            "legendposition": "v",
+            "legendposition": "h",
             "linewidth": 0,
             "mode": "group",
             "name": "bar",
@@ -919,7 +919,23 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
             "responsive": true,
           }
         }
-        layout={[Function]}
+        layout={
+          Object {
+            "height": 1180,
+            "legend": Object {
+              "orientation": "v",
+              "traceorder": "normal",
+            },
+            "margin": Object {
+              "b": 30,
+              "l": 60,
+              "pad": 0,
+              "r": 30,
+              "t": 50,
+            },
+            "showlegend": true,
+          }
+        }
         visualizations={
           Object {
             "data": Object {
@@ -1174,7 +1190,7 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -1337,7 +1353,7 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
               "id": "bar",
               "label": "Vertical bar",
               "labelangle": 0,
-              "legendposition": "v",
+              "legendposition": "h",
               "linewidth": 0,
               "mode": "group",
               "name": "bar",
@@ -1433,9 +1449,11 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
                 "#BD6F26",
                 "#4C636F",
               ],
+              "height": 1180,
               "hovermode": "closest",
               "legend": Object {
-                "orientation": "v",
+                "orientation": "h",
+                "traceorder": "normal",
               },
               "margin": Object {
                 "b": 30,
@@ -1526,9 +1544,11 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
                   "#BD6F26",
                   "#4C636F",
                 ],
+                "height": 1180,
                 "hovermode": "closest",
                 "legend": Object {
-                  "orientation": "v",
+                  "orientation": "h",
+                  "traceorder": "normal",
                 },
                 "margin": Object {
                   "b": 30,
@@ -1792,7 +1812,7 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                         "props": Object {
                           "defaultSelections": Array [
                             Object {
-                              "id": "v",
+                              "id": "h",
                               "name": "Right",
                             },
                           ],
@@ -2308,7 +2328,7 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                           "props": Object {
                             "defaultSelections": Array [
                               Object {
-                                "id": "v",
+                                "id": "h",
                                 "name": "Right",
                               },
                             ],
@@ -2628,7 +2648,47 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
             },
           }
         }
-        layout={[Function]}
+        layout={
+          Object {
+            "colorway": Array [
+              "#3CA1C7",
+              "#8C55A3",
+              "#DB748A",
+              "#F2BE4B",
+              "#68CCC2",
+              "#2A7866",
+              "#843769",
+              "#374FB8",
+              "#BD6F26",
+              "#4C636F",
+            ],
+            "height": 1180,
+            "legend": Object {
+              "orientation": "v",
+              "traceorder": "normal",
+            },
+            "margin": Object {
+              "b": 30,
+              "l": 60,
+              "pad": 0,
+              "r": 30,
+              "t": 50,
+            },
+            "paper_bgcolor": "rgba(0, 0, 0, 0)",
+            "plot_bgcolor": "rgba(0, 0, 0, 0)",
+            "showlegend": true,
+            "xaxis": Object {
+              "fixedrange": true,
+              "showgrid": false,
+              "visible": true,
+            },
+            "yaxis": Object {
+              "fixedrange": true,
+              "showgrid": false,
+              "visible": true,
+            },
+          }
+        }
         visualizations={
           Object {
             "data": Object {
@@ -2838,7 +2898,7 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -3205,8 +3265,22 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
           layout={
             Object {
               "autosize": true,
+              "colorway": Array [
+                "#3CA1C7",
+                "#8C55A3",
+                "#DB748A",
+                "#F2BE4B",
+                "#68CCC2",
+                "#2A7866",
+                "#843769",
+                "#374FB8",
+                "#BD6F26",
+                "#4C636F",
+              ],
+              "height": 1180,
               "legend": Object {
-                "orientation": "v",
+                "orientation": "h",
+                "traceorder": "normal",
               },
               "margin": Object {
                 "b": 30,
@@ -3215,6 +3289,8 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                 "r": 5,
                 "t": 50,
               },
+              "paper_bgcolor": "rgba(0, 0, 0, 0)",
+              "plot_bgcolor": "rgba(0, 0, 0, 0)",
               "shapes": Array [],
               "showlegend": true,
               "title": "",
@@ -3295,9 +3371,23 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
               Object {
                 "autosize": true,
                 "barmode": "stack",
+                "colorway": Array [
+                  "#3CA1C7",
+                  "#8C55A3",
+                  "#DB748A",
+                  "#F2BE4B",
+                  "#68CCC2",
+                  "#2A7866",
+                  "#843769",
+                  "#374FB8",
+                  "#BD6F26",
+                  "#4C636F",
+                ],
+                "height": 1180,
                 "hovermode": "closest",
                 "legend": Object {
-                  "orientation": "v",
+                  "orientation": "h",
+                  "traceorder": "normal",
                 },
                 "margin": Object {
                   "b": 30,
@@ -3306,6 +3396,8 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                   "r": 5,
                   "t": 50,
                 },
+                "paper_bgcolor": "rgba(0, 0, 0, 0)",
+                "plot_bgcolor": "rgba(0, 0, 0, 0)",
                 "shapes": Array [],
                 "showlegend": true,
                 "title": "",
@@ -3602,7 +3694,7 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                         "props": Object {
                           "defaultSelections": Array [
                             Object {
-                              "id": "v",
+                              "id": "h",
                               "name": "Right",
                             },
                           ],
@@ -3765,7 +3857,7 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
           "id": "horizontal_bar",
           "label": "Horizontal bar",
           "labelangle": 0,
-          "legendposition": "v",
+          "legendposition": "h",
           "linewidth": 0,
           "mode": "group",
           "name": "horizontal_bar",
@@ -4057,7 +4149,7 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                           "props": Object {
                             "defaultSelections": Array [
                               Object {
-                                "id": "v",
+                                "id": "h",
                                 "name": "Right",
                               },
                             ],
@@ -4220,7 +4312,7 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
             "id": "horizontal_bar",
             "label": "Horizontal bar",
             "labelangle": 0,
-            "legendposition": "v",
+            "legendposition": "h",
             "linewidth": 0,
             "mode": "group",
             "name": "horizontal_bar",
@@ -4264,7 +4356,23 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
             "responsive": true,
           }
         }
-        layout={[Function]}
+        layout={
+          Object {
+            "height": 1180,
+            "legend": Object {
+              "orientation": "v",
+              "traceorder": "normal",
+            },
+            "margin": Object {
+              "b": 30,
+              "l": 60,
+              "pad": 0,
+              "r": 30,
+              "t": 50,
+            },
+            "showlegend": true,
+          }
+        }
         visualizations={
           Object {
             "data": Object {
@@ -4519,7 +4627,7 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -4682,7 +4790,7 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
               "id": "horizontal_bar",
               "label": "Horizontal bar",
               "labelangle": 0,
-              "legendposition": "v",
+              "legendposition": "h",
               "linewidth": 0,
               "mode": "group",
               "name": "horizontal_bar",
@@ -4778,9 +4886,11 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                 "#BD6F26",
                 "#4C636F",
               ],
+              "height": 1180,
               "hovermode": "closest",
               "legend": Object {
-                "orientation": "v",
+                "orientation": "h",
+                "traceorder": "normal",
               },
               "margin": Object {
                 "b": 30,
@@ -4871,9 +4981,11 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                   "#BD6F26",
                   "#4C636F",
                 ],
+                "height": 1180,
                 "hovermode": "closest",
                 "legend": Object {
-                  "orientation": "v",
+                  "orientation": "h",
+                  "traceorder": "normal",
                 },
                 "margin": Object {
                   "b": 30,

--- a/public/components/custom_panels/helpers/utils.tsx
+++ b/public/components/custom_panels/helpers/utils.tsx
@@ -397,14 +397,13 @@ export const renderCatalogVisualization = async ({
   const catalogSourceName = catalogSource.split('.')[0];
   const catalogTableName = catalogSource.split('.')[1];
 
-  const defaultAggregation = 'avg'; // pass in attributes to this function
-  const attributes: string[] = [];
+  const defaultAggregation = 'avg';
 
   const visualizationQuery = updateCatalogVisualizationQuery({
     catalogSourceName,
     catalogTableName,
-    aggregation: defaultAggregation,
-    attributesGroupBy: attributes,
+    aggregation: queryMetaData.aggregation,
+    attributesGroupBy: queryMetaData.attributesGroupBy,
     startTime,
     endTime,
     spanParam,

--- a/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
+++ b/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /* eslint-disable react-hooks/exhaustive-deps */
-/* eslint-disable no-console */
 
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
@@ -109,6 +108,7 @@ export const PanelGrid = (props: PanelGridProps) => {
           pplFilterValue={pplFilterValue}
           showFlyout={showFlyout}
           removeVisualization={removeVisualization}
+          contextMenuId="visualization"
         />
       )
     );

--- a/public/components/custom_panels/panel_modules/panel_grid/panel_grid_so.tsx
+++ b/public/components/custom_panels/panel_modules/panel_grid/panel_grid_so.tsx
@@ -105,6 +105,7 @@ export const PanelGridSO = (props: PanelGridProps) => {
           pplFilterValue={pplFilterValue}
           showFlyout={showFlyout}
           removeVisualization={removeVisualization}
+          contextMenuId="visualization"
         />
       )
     );

--- a/public/components/custom_panels/panel_modules/visualization_container/__tests__/__snapshots__/visualization_container.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_container/__tests__/__snapshots__/visualization_container.test.tsx.snap
@@ -1,156 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Visualization Container Component renders add visualization container 1`] = `
-<Component
-  cloneVisualization={[MockFunction]}
-  editMode={true}
-  fromTime="now-15m"
-  http={[MockFunction]}
-  onEditClick={[Function]}
-  onRefresh={true}
-  pplFilterValue="where Carrier = \\"OpenSearch-Air\\""
-  pplService={
-    PPLService {
-      "fetch": [Function],
-      "http": [MockFunction],
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(Symbol.observable): [Function],
     }
   }
-  removeVisualization={[MockFunction]}
-  savedVisualizationId="oiuccXwBYVazWqOO1e06"
-  showFlyout={[MockFunction]}
-  toTime="now"
-  visualizationId="panel_viz_9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
 >
-  <EuiPanel
-    className="panel-full-width"
-    data-test-subj="VisualizationPanel"
-    grow={false}
+  <Component
+    cloneVisualization={[MockFunction]}
+    contextMenuId="visualization"
+    editMode={true}
+    fromTime="now-15m"
+    http={[MockFunction]}
+    onEditClick={[Function]}
+    onRefresh={true}
+    pplFilterValue="where Carrier = \\"OpenSearch-Air\\""
+    pplService={
+      PPLService {
+        "fetch": [Function],
+        "http": [MockFunction],
+      }
+    }
+    removeVisualization={[MockFunction]}
+    savedVisualizationId="oiuccXwBYVazWqOO1e06"
+    showFlyout={[MockFunction]}
+    toTime="now"
+    visualizationId="panel_viz_9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
   >
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero panel-full-width"
+    <EuiPanel
+      className="panel-full-width "
       data-test-subj="VisualizationPanel"
+      grow={false}
     >
       <div
-        className="mouseGrabber"
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero panel-full-width "
+        data-test-subj="VisualizationPanel"
       >
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
+        <div
+          className="mouseGrabber"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
-            <EuiFlexItem
-              style={
-                Object {
-                  "width": "35%",
-                }
-              }
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem"
+              <EuiFlexItem
                 style={
                   Object {
                     "width": "35%",
                   }
                 }
               >
-                <EuiText
-                  className="panels-title-text"
-                  grow={false}
+                <div
+                  className="euiFlexItem"
+                  style={
+                    Object {
+                      "width": "35%",
+                    }
+                  }
                 >
-                  <div
-                    className="euiText euiText--medium panels-title-text euiText--constrainedWidth"
+                  <EuiText
+                    className="panels-title-text"
+                    grow={false}
                   >
-                    <EuiToolTip
-                      content=""
-                      delay="long"
-                      position="top"
+                    <div
+                      className="euiText euiText--medium panels-title-text euiText--constrainedWidth"
                     >
-                      <span
-                        className="euiToolTipAnchor"
-                        onKeyUp={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
+                      <EuiToolTip
+                        content=""
+                        delay="long"
+                        position="top"
                       >
-                        <h5
-                          data-test-subj="visualizationHeader"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                        />
-                      </span>
-                    </EuiToolTip>
-                  </div>
-                </EuiText>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              className="visualization-action-button"
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero visualization-action-button"
+                        <span
+                          className="euiToolTipAnchor"
+                          onKeyUp={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          <h5
+                            data-test-subj="visualizationHeader"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                          />
+                        </span>
+                      </EuiToolTip>
+                    </div>
+                  </EuiText>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                className="visualization-action-button"
+                grow={false}
               >
-                <EuiIcon
-                  data-test-subj="removeVisualizationButton"
-                  onClick={[Function]}
-                  type="crossInACircleFilled"
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero visualization-action-button"
                 >
-                  <EuiIconEmpty
-                    aria-hidden={true}
-                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                  <EuiIcon
                     data-test-subj="removeVisualizationButton"
-                    focusable="false"
                     onClick={[Function]}
-                    role="img"
-                    style={null}
+                    type="crossInACircleFilled"
                   >
-                    <svg
+                    <EuiIconEmpty
                       aria-hidden={true}
                       className="euiIcon euiIcon--medium euiIcon-isLoading"
                       data-test-subj="removeVisualizationButton"
                       focusable="false"
-                      height={16}
                       onClick={[Function]}
                       role="img"
                       style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </EuiIconEmpty>
-                </EuiIcon>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </div>
-      <div
-        className="visualization-div"
-      >
-        <EuiLoadingChart
-          className="visualization-loading-chart"
-          mono={true}
-          size="xl"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="euiIcon euiIcon--medium euiIcon-isLoading"
+                        data-test-subj="removeVisualizationButton"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        role="img"
+                        style={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      />
+                    </EuiIconEmpty>
+                  </EuiIcon>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+        </div>
+        <div
+          className="visualization-div"
         >
-          <span
-            className="euiLoadingChart euiLoadingChart--mono visualization-loading-chart euiLoadingChart--xLarge"
+          <EuiLoadingChart
+            className="visualization-loading-chart"
+            mono={true}
+            size="xl"
           >
             <span
-              className="euiLoadingChart__bar"
-            />
-            <span
-              className="euiLoadingChart__bar"
-            />
-            <span
-              className="euiLoadingChart__bar"
-            />
-            <span
-              className="euiLoadingChart__bar"
-            />
-          </span>
-        </EuiLoadingChart>
+              className="euiLoadingChart euiLoadingChart--mono visualization-loading-chart euiLoadingChart--xLarge"
+            >
+              <span
+                className="euiLoadingChart__bar"
+              />
+              <span
+                className="euiLoadingChart__bar"
+              />
+              <span
+                className="euiLoadingChart__bar"
+              />
+              <span
+                className="euiLoadingChart__bar"
+              />
+            </span>
+          </EuiLoadingChart>
+        </div>
       </div>
-    </div>
-  </EuiPanel>
-</Component>
+    </EuiPanel>
+  </Component>
+</Provider>
 `;

--- a/public/components/custom_panels/panel_modules/visualization_container/__tests__/visualization_container.test.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/__tests__/visualization_container.test.tsx
@@ -58,6 +58,7 @@ describe('Visualization Container Component', () => {
         showFlyout={showFlyout}
         removeVisualization={removeVisualization}
         onEditClick={onEditClick}
+        contextMenuId="visualization"
       />
     );
     wrapper.update();

--- a/public/components/custom_panels/panel_modules/visualization_container/__tests__/visualization_container.test.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/__tests__/visualization_container.test.tsx
@@ -15,6 +15,9 @@ import {
   sampleSavedVisualization,
   samplePPLResponse,
 } from '../../../../../../test/panels_constants';
+import { createStore } from '@reduxjs/toolkit';
+import { rootReducer } from '../../../../../framework/redux/reducers';
+import { Provider } from 'react-redux';
 
 describe('Visualization Container Component', () => {
   configure({ adapter: new Adapter() });
@@ -27,6 +30,9 @@ describe('Visualization Container Component', () => {
     httpClientMock.post = jest.fn(() =>
       Promise.resolve((samplePPLResponse as unknown) as HttpResponse)
     );
+
+    // configure({ adapter: new Adapter() });
+    const store = createStore(rootReducer);
 
     const editMode = true;
     const visualizationId = 'panel_viz_9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d';
@@ -44,22 +50,24 @@ describe('Visualization Container Component', () => {
     };
 
     const wrapper = mount(
-      <VisualizationContainer
-        http={httpClientMock}
-        editMode={editMode}
-        visualizationId={visualizationId}
-        savedVisualizationId={savedVisualizationId}
-        pplService={pplService}
-        fromTime={fromTime}
-        toTime={toTime}
-        onRefresh={onRefresh}
-        cloneVisualization={cloneVisualization}
-        pplFilterValue={pplFilterValue}
-        showFlyout={showFlyout}
-        removeVisualization={removeVisualization}
-        onEditClick={onEditClick}
-        contextMenuId="visualization"
-      />
+      <Provider store={store}>
+        <VisualizationContainer
+          http={httpClientMock}
+          editMode={editMode}
+          visualizationId={visualizationId}
+          savedVisualizationId={savedVisualizationId}
+          pplService={pplService}
+          fromTime={fromTime}
+          toTime={toTime}
+          onRefresh={onRefresh}
+          cloneVisualization={cloneVisualization}
+          pplFilterValue={pplFilterValue}
+          showFlyout={showFlyout}
+          removeVisualization={removeVisualization}
+          onEditClick={onEditClick}
+          contextMenuId="visualization"
+        />
+      </Provider>
     );
     wrapper.update();
 

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.scss
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.scss
@@ -34,6 +34,43 @@
   text-align: center;
 }
 
+.metricVis {
+  #metricsEditInline {
+    /* for ... reasons (?), margin here causes
+       other rules to activate... providing
+       a more-correct display.
+     */
+    margin: 0 0px;
+  }
+
+
+    #aggregation__field {
+      .euiFormLabel {
+        width: 130px
+      }
+    }
+
+  //  #explorerPlotComponent {
+  //    //overflow: hidden;
+  //  }
+  //
+    .svg-container {
+      //height: 425px !important;
+      margin-top: -25px !important;
+    }
+
+  //  .main-svg {
+  //    //margin-top: -10px;
+  //    //height: calc(100% - 10px);
+  //  }
+  //
+
+  .main-svg {
+    margin-top: -10px;
+    //height: calc(100% - 60px);
+  }
+}
+
 %center-div {
   top: 50%;
   left: 50%;

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -26,6 +26,7 @@ import {
 } from '@elastic/eui';
 import React, { useEffect, useMemo, useState } from 'react';
 import _ from 'lodash';
+import { useSelector } from 'react-redux';
 import {
   displayVisualization,
   renderCatalogVisualization,
@@ -33,6 +34,8 @@ import {
 } from '../../helpers/utils';
 import './visualization_container.scss';
 import { VizContainerError } from '../../../../../common/types/custom_panels';
+import { MetricsEditInline } from '../../../metrics/sidebar/metrics_edit_inline';
+import { metricQuerySelector } from '../../../metrics/redux/slices/metrics_slice';
 import { coreRefs } from '../../../../framework/core_refs';
 
 /*
@@ -71,6 +74,7 @@ interface Props {
   removeVisualization?: (visualizationId: string) => void;
   catalogVisualization?: boolean;
   spanParam?: string;
+  contextMenuId: 'visualization' | 'notebook' | 'metrics';
 }
 
 export const VisualizationContainer = ({
@@ -88,6 +92,7 @@ export const VisualizationContainer = ({
   removeVisualization,
   catalogVisualization,
   spanParam,
+  contextMenuId,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [visualizationTitle, setVisualizationTitle] = useState('');
@@ -103,6 +108,7 @@ export const VisualizationContainer = ({
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [modalContent, setModalContent] = useState(<></>);
 
+  const queryMetaData = useSelector(metricQuerySelector(visualizationId));
   const closeModal = () => setIsModalVisible(false);
   const showModal = (modalType: string) => {
     if (modalType === 'catalogModal')
@@ -227,6 +233,7 @@ export const VisualizationContainer = ({
         setVisualizationMetaData,
         setIsLoading,
         setIsError,
+        queryMetaData,
       });
     else
       await renderSavedVisualization(
@@ -283,11 +290,17 @@ export const VisualizationContainer = ({
     loadVisaulization();
   }, [onRefresh]);
 
+  useEffect(() => {
+    if (catalogVisualization) loadVisaulization();
+  }, [queryMetaData]);
+
+  const metricVisCssClassName = catalogVisualization ? 'metricVis' : '';
+
   return (
     <>
       <EuiPanel
         data-test-subj={`${visualizationTitle}VisualizationPanel`}
-        className="panel-full-width"
+        className={`panel-full-width ${metricVisCssClassName}`}
         grow={false}
       >
         <div className={editMode ? 'mouseGrabber' : ''}>
@@ -333,6 +346,7 @@ export const VisualizationContainer = ({
               )}
             </EuiFlexItem>
           </EuiFlexGroup>
+          {catalogVisualization && <MetricsEditInline visualizationId={visualizationId} />}
         </div>
         {memoisedVisualizationBox}
       </EuiPanel>

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -118,6 +118,7 @@ import { Sidebar } from './sidebar';
 import { TimechartHeader } from './timechart_header';
 import { ExplorerVisualizations } from './visualizations';
 import { CountDistribution } from './visualizations/count_distribution';
+import { processMetricsData } from '../../custom_panels/helpers/utils';
 
 export const Explorer = ({
   pplService,
@@ -627,17 +628,22 @@ export const Explorer = ({
     isOverridingPattern,
   ]);
 
+  const visualizationSettings = !isEmpty(userVizConfigs[curVisId])
+    ? { ...userVizConfigs[curVisId] }
+    : {
+        dataConfig: getDefaultVisConfig(queryManager.queryParser().parse(tempQuery).getStats()),
+      };
+
   const visualizations: IVisualizationContainerProps = useMemo(() => {
     return getVizContainerProps({
       vizId: curVisId,
       rawVizData: explorerVisualizations,
       query,
       indexFields: explorerFields,
-      userConfigs: !isEmpty(userVizConfigs[curVisId])
-        ? { ...userVizConfigs[curVisId] }
-        : {
-            dataConfig: getDefaultVisConfig(queryManager.queryParser().parse(tempQuery).getStats()),
-          },
+      userConfigs: {
+        ...visualizationSettings,
+        ...processMetricsData(explorerData.schema, visualizationSettings),
+      },
       appData: { fromApp: appLogEvents },
       explorer: { explorerData, explorerFields, query, http, pplService },
     });

--- a/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
@@ -465,7 +465,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -628,7 +628,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",
@@ -787,7 +787,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -951,7 +951,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
               "id": "bar",
               "label": "Vertical bar",
               "labelangle": 0,
-              "legendposition": "v",
+              "legendposition": "h",
               "linewidth": 0,
               "mode": "group",
               "name": "bar",
@@ -1092,7 +1092,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -1255,7 +1255,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
               "id": "horizontal_bar",
               "label": "Horizontal bar",
               "labelangle": 0,
-              "legendposition": "v",
+              "legendposition": "h",
               "linewidth": 0,
               "mode": "group",
               "name": "horizontal_bar",
@@ -1337,7 +1337,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -1688,13 +1688,13 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
                               "options": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                                 Object {
@@ -1821,7 +1821,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
               "icontype": "visPie",
               "id": "pie",
               "label": "Pie",
-              "legendposition": "v",
+              "legendposition": "h",
               "mode": "pie",
               "name": "pie",
               "seriesaxis": "yaxis",
@@ -2484,7 +2484,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -2648,7 +2648,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
               "id": "bar",
               "label": "Vertical bar",
               "labelangle": 0,
-              "legendposition": "v",
+              "legendposition": "h",
               "linewidth": 0,
               "mode": "group",
               "name": "bar",
@@ -2821,7 +2821,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                 "props": Object {
                                   "defaultSelections": Array [
                                     Object {
-                                      "id": "v",
+                                      "id": "h",
                                       "name": "Right",
                                     },
                                   ],
@@ -2985,7 +2985,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                   "id": "bar",
                   "label": "Vertical bar",
                   "labelangle": 0,
-                  "legendposition": "v",
+                  "legendposition": "h",
                   "linewidth": 0,
                   "mode": "group",
                   "name": "bar",
@@ -3163,7 +3163,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                       "props": Object {
                                         "defaultSelections": Array [
                                           Object {
-                                            "id": "v",
+                                            "id": "h",
                                             "name": "Right",
                                           },
                                         ],
@@ -3328,7 +3328,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       id="bar"
                       key="vertical bar"
                       labelangle={0}
-                      legendposition="v"
+                      legendposition="h"
                       linewidth={0}
                       mode="group"
                       name="bar"
@@ -3440,7 +3440,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                         "props": Object {
                                           "defaultSelections": Array [
                                             Object {
-                                              "id": "v",
+                                              "id": "h",
                                               "name": "Right",
                                             },
                                           ],
@@ -3604,7 +3604,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                           "id": "bar",
                           "label": "Vertical bar",
                           "labelangle": 0,
-                          "legendposition": "v",
+                          "legendposition": "h",
                           "linewidth": 0,
                           "mode": "group",
                           "name": "bar",
@@ -3783,7 +3783,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                         "props": Object {
                                           "defaultSelections": Array [
                                             Object {
-                                              "id": "v",
+                                              "id": "h",
                                               "name": "Right",
                                             },
                                           ],
@@ -3947,7 +3947,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                         icontype="visBarVerticalStacked"
                         id="bar"
                         labelangle={0}
-                        legendposition="v"
+                        legendposition="h"
                         linewidth={0}
                         mode="group"
                         name="bar"
@@ -4096,7 +4096,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                             "props": Object {
                                               "defaultSelections": Array [
                                                 Object {
-                                                  "id": "v",
+                                                  "id": "h",
                                                   "name": "Right",
                                                 },
                                               ],
@@ -4259,7 +4259,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             icontype="visBarVerticalStacked"
                             id="bar"
                             labelangle={0}
-                            legendposition="v"
+                            legendposition="h"
                             linewidth={0}
                             mode="group"
                             name="bar"
@@ -4577,7 +4577,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                           "props": Object {
                             "defaultSelections": Array [
                               Object {
-                                "id": "v",
+                                "id": "h",
                                 "name": "Right",
                               },
                             ],
@@ -5187,7 +5187,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "props": Object {
                                     "defaultSelections": Array [
                                       Object {
-                                        "id": "v",
+                                        "id": "h",
                                         "name": "Right",
                                       },
                                     ],
@@ -5350,7 +5350,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                     "id": "bar",
                     "label": "Vertical bar",
                     "labelangle": 0,
-                    "legendposition": "v",
+                    "legendposition": "h",
                     "linewidth": 0,
                     "mode": "group",
                     "name": "bar",
@@ -5519,7 +5519,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             "props": Object {
                               "defaultSelections": Array [
                                 Object {
-                                  "id": "v",
+                                  "id": "h",
                                   "name": "Right",
                                 },
                               ],
@@ -6129,7 +6129,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                     "props": Object {
                                       "defaultSelections": Array [
                                         Object {
-                                          "id": "v",
+                                          "id": "h",
                                           "name": "Right",
                                         },
                                       ],
@@ -6292,7 +6292,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       "id": "bar",
                       "label": "Vertical bar",
                       "labelangle": 0,
-                      "legendposition": "v",
+                      "legendposition": "h",
                       "linewidth": 0,
                       "mode": "group",
                       "name": "bar",
@@ -6502,7 +6502,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                           "props": Object {
                             "defaultSelections": Array [
                               Object {
-                                "id": "v",
+                                "id": "h",
                                 "name": "Right",
                               },
                             ],
@@ -7112,7 +7112,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "props": Object {
                                     "defaultSelections": Array [
                                       Object {
-                                        "id": "v",
+                                        "id": "h",
                                         "name": "Right",
                                       },
                                     ],
@@ -7275,7 +7275,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                     "id": "bar",
                     "label": "Vertical bar",
                     "labelangle": 0,
-                    "legendposition": "v",
+                    "legendposition": "h",
                     "linewidth": 0,
                     "mode": "group",
                     "name": "bar",
@@ -7823,7 +7823,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                 "props": Object {
                                                   "defaultSelections": Array [
                                                     Object {
-                                                      "id": "v",
+                                                      "id": "h",
                                                       "name": "Right",
                                                     },
                                                   ],
@@ -7986,7 +7986,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "id": "bar",
                                   "label": "Vertical bar",
                                   "labelangle": 0,
-                                  "legendposition": "v",
+                                  "legendposition": "h",
                                   "linewidth": 0,
                                   "mode": "group",
                                   "name": "bar",
@@ -8269,6 +8269,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
+                      key="tooltip_options"
                       labelType="label"
                     >
                       <div
@@ -8801,7 +8802,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                 "props": Object {
                                                   "defaultSelections": Array [
                                                     Object {
-                                                      "id": "v",
+                                                      "id": "h",
                                                       "name": "Right",
                                                     },
                                                   ],
@@ -8964,7 +8965,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "id": "bar",
                                   "label": "Vertical bar",
                                   "labelangle": 0,
-                                  "legendposition": "v",
+                                  "legendposition": "h",
                                   "linewidth": 0,
                                   "mode": "group",
                                   "name": "bar",
@@ -9743,6 +9744,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
+                      key="legend"
                       labelType="label"
                     >
                       <div
@@ -9790,7 +9792,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "props": Object {
                                     "defaultSelections": Array [
                                       Object {
-                                        "id": "v",
+                                        "id": "h",
                                         "name": "Right",
                                       },
                                     ],
@@ -10278,7 +10280,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                 "props": Object {
                                                   "defaultSelections": Array [
                                                     Object {
-                                                      "id": "v",
+                                                      "id": "h",
                                                       "name": "Right",
                                                     },
                                                   ],
@@ -10441,7 +10443,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "id": "bar",
                                   "label": "Vertical bar",
                                   "labelangle": 0,
-                                  "legendposition": "v",
+                                  "legendposition": "h",
                                   "linewidth": 0,
                                   "mode": "group",
                                   "name": "bar",
@@ -10830,7 +10832,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                           defaultSelections={
                                             Array [
                                               Object {
-                                                "id": "v",
+                                                "id": "h",
                                                 "name": "Right",
                                               },
                                             ]
@@ -10850,7 +10852,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                             ]
                                           }
                                           handleButtonChange={[Function]}
-                                          idSelected="v"
+                                          idSelected="h"
                                           legend="Position"
                                           options={
                                             Array [
@@ -10893,7 +10895,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                             <EuiButtonGroup
                                               buttonSize="compressed"
                                               id="random_html_id"
-                                              idSelected="v"
+                                              idSelected="h"
                                               isFullWidth={false}
                                               legend="Position"
                                               name="Position"
@@ -10934,7 +10936,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                     id="v"
                                                     isDisabled={false}
                                                     isIconOnly={false}
-                                                    isSelected={true}
+                                                    isSelected={false}
                                                     key="0"
                                                     label="Right"
                                                     name="Right"
@@ -10943,7 +10945,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                   >
                                                     <EuiButtonDisplay
                                                       baseClassName="euiButtonGroupButton"
-                                                      className="euiButtonGroupButton-isSelected"
+                                                      className=""
                                                       color="text"
                                                       element="label"
                                                       fill={false}
@@ -10961,7 +10963,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       }
                                                     >
                                                       <label
-                                                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isSelected"
+                                                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
                                                         disabled={false}
                                                         htmlFor="random_html_id"
                                                         onClick={[Function]}
@@ -10992,7 +10994,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                               title="Right"
                                                             >
                                                               <input
-                                                                checked={true}
+                                                                checked={false}
                                                                 className="euiScreenReaderOnly"
                                                                 data-test-subj="v"
                                                                 disabled={false}
@@ -11014,7 +11016,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                     id="h"
                                                     isDisabled={false}
                                                     isIconOnly={false}
-                                                    isSelected={false}
+                                                    isSelected={true}
                                                     key="1"
                                                     label="Bottom"
                                                     name="Bottom"
@@ -11023,7 +11025,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                   >
                                                     <EuiButtonDisplay
                                                       baseClassName="euiButtonGroupButton"
-                                                      className=""
+                                                      className="euiButtonGroupButton-isSelected"
                                                       color="text"
                                                       element="label"
                                                       fill={false}
@@ -11041,7 +11043,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       }
                                                     >
                                                       <label
-                                                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton-isSelected"
                                                         disabled={false}
                                                         htmlFor="random_html_id"
                                                         onClick={[Function]}
@@ -11072,7 +11074,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                               title="Bottom"
                                                             >
                                                               <input
-                                                                checked={false}
+                                                                checked={true}
                                                                 className="euiScreenReaderOnly"
                                                                 data-test-subj="h"
                                                                 disabled={false}
@@ -11188,6 +11190,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
+                      key="chart_styles"
                       labelType="label"
                     >
                       <div
@@ -11776,7 +11779,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                 "props": Object {
                                                   "defaultSelections": Array [
                                                     Object {
-                                                      "id": "v",
+                                                      "id": "h",
                                                       "name": "Right",
                                                     },
                                                   ],
@@ -11939,7 +11942,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "id": "bar",
                                   "label": "Vertical bar",
                                   "labelangle": 0,
-                                  "legendposition": "v",
+                                  "legendposition": "h",
                                   "linewidth": 0,
                                   "mode": "group",
                                   "name": "bar",
@@ -14360,6 +14363,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                       fullWidth={true}
                       hasChildLabel={true}
                       hasEmptyLabelSpace={false}
+                      key="color-theme"
                       labelType="label"
                     >
                       <div
@@ -14839,7 +14843,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                 "props": Object {
                                                   "defaultSelections": Array [
                                                     Object {
-                                                      "id": "v",
+                                                      "id": "h",
                                                       "name": "Right",
                                                     },
                                                   ],
@@ -15002,7 +15006,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   "id": "bar",
                                   "label": "Vertical bar",
                                   "labelangle": 0,
-                                  "legendposition": "v",
+                                  "legendposition": "h",
                                   "linewidth": 0,
                                   "mode": "group",
                                   "name": "bar",

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/default_vis_editor.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/default_vis_editor.tsx
@@ -20,7 +20,7 @@ export const VizDataPanel = ({ visualizations, onConfigChange, vizState = {}, ta
   const dynamicContent = tabProps.sections.map((section) => {
     const Editor = section.editor;
     return (
-      <EuiFormRow fullWidth>
+      <EuiFormRow key={section.id} fullWidth>
         <Editor
           visualizations={visualizations}
           schemas={section.schemas}

--- a/public/components/metrics/helpers/__tests__/utils.test.tsx
+++ b/public/components/metrics/helpers/__tests__/utils.test.tsx
@@ -59,7 +59,7 @@ describe('Utils helper functions', () => {
       x: 0,
       y: 0,
       w: 12,
-      h: 2,
+      h: 3,
     });
 
     expect(getNewVizDimensions(samplePanelVisualizations1)).toStrictEqual(samplenewDimensions1);

--- a/public/components/metrics/helpers/utils.tsx
+++ b/public/components/metrics/helpers/utils.tsx
@@ -30,14 +30,14 @@ export const onTimeChange = (
   setStart: React.Dispatch<React.SetStateAction<string>>,
   setEnd: React.Dispatch<React.SetStateAction<string>>
 ) => {
-  const recentlyUsedRange = recentlyUsedRanges.filter((recentlyUsedRange) => {
+  const dedupedRanges = recentlyUsedRanges.filter((recentlyUsedRange) => {
     const isDuplicate = recentlyUsedRange.start === start && recentlyUsedRange.end === end;
     return !isDuplicate;
   });
-  recentlyUsedRange.unshift({ start, end });
+  dedupedRanges.unshift({ start, end });
   setStart(start);
   setEnd(end);
-  setRecentlyUsedRanges(recentlyUsedRange.slice(0, 9));
+  setRecentlyUsedRanges(dedupedRanges.slice(0, 9));
 };
 
 // PPL Service requestor
@@ -58,21 +58,21 @@ export const getVisualizations = (http: CoreStart['http']) => {
     });
 };
 
-interface boxType {
+interface BoxType {
   x1: number;
   y1: number;
   x2: number;
   y2: number;
 }
 
-const calculatOverlapArea = (bb1: boxType, bb2: boxType) => {
-  const x_left = Math.max(bb1.x1, bb2.x1);
-  const y_top = Math.max(bb1.y1, bb2.y1);
-  const x_right = Math.min(bb1.x2, bb2.x2);
-  const y_bottom = Math.min(bb1.y2, bb2.y2);
+const calculatOverlapArea = (bb1: BoxType, bb2: BoxType) => {
+  const xLeft = Math.max(bb1.x1, bb2.x1);
+  const yTop = Math.max(bb1.y1, bb2.y1);
+  const xRight = Math.min(bb1.x2, bb2.x2);
+  const yBottom = Math.min(bb1.y2, bb2.y2);
 
-  if (x_right < x_left || y_bottom < y_top) return 0;
-  return (x_right - x_left) * (y_bottom - y_top);
+  if (xRight < xLeft || yBottom < yTop) return 0;
+  return (xRight - xLeft) * (yBottom - yTop);
 };
 
 const getTotalOverlapArea = (panelVisualizations: MetricType[]) => {
@@ -149,7 +149,7 @@ export const mergeLayoutAndMetrics = (
 
   for (let i = 0; i < newVisualizationList.length; i++) {
     for (let j = 0; j < layout.length; j++) {
-      if (newVisualizationList[i].id == layout[j].i) {
+      if (newVisualizationList[i].id === layout[j].i) {
         newPanelVisualizations.push({
           ...newVisualizationList[i],
           x: layout[j].x,
@@ -206,6 +206,6 @@ export const updateMetricsWithSelections = (
     description: savedVisualization.description,
     type: 'line',
     subType: 'metric',
-    userConfigs: JSON.stringify(savedVisualization.user_configs),
+    userConfigs: savedVisualization.user_configs,
   };
 };

--- a/public/components/metrics/sidebar/metrics_edit_inline.tsx
+++ b/public/components/metrics/sidebar/metrics_edit_inline.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiComboBox,
+  EuiFormControlLayout,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormLabel,
+  EuiSelect,
+} from '@elastic/eui';
+import { useDispatch, useSelector } from 'react-redux';
+import { AGGREGATION_OPTIONS } from '../../../../common/constants/metrics';
+import {
+  metricQuerySelector,
+  setMetricSelectedAttributes,
+  updateMetricQuery,
+} from '../redux/slices/metrics_slice';
+
+const useObservable = (observable, observer, deps) => {
+  // useEffect with empty deps will call this only once
+  useEffect(() => {
+    const sub = observable.subscribe(observer); // connect
+    return () => sub.unsubscribe(); // < unsub on unmount
+  }, deps);
+};
+
+export const MetricsEditInline = ({ visualizationId }: { visualizationId: string }) => {
+  const [aggregationIsOpen, setAggregationIsOpen] = useState(false);
+  const [attributesGroupByIsOpen, setAttributesGroupByIsOpen] = useState(false);
+
+  const dispatch = useDispatch();
+
+  const query = useSelector(metricQuerySelector(visualizationId));
+  useEffect(() => {
+    console.log({ visualizationId, query });
+  }, [query, visualizationId]);
+
+  const availableAttributesLabels = query.availableAttributes.map((attribute) => ({
+    label: attribute,
+    name: attribute,
+  }));
+
+  const onChangeAggregation = (e) => {
+    dispatch(updateMetricQuery(visualizationId, { aggregation: e.target.value }));
+    setAggregationIsOpen(false);
+  };
+
+  const onChangeAttributesGroupBy = async (selectedAttributes) => {
+    console.log('onChangeAttributes', selectedAttributes);
+    const attributesGroupBy = selectedAttributes.map(({ label }) => label);
+    dispatch(setMetricSelectedAttributes({ visualizationId, attributesGroupBy }));
+
+    setAttributesGroupByIsOpen(false);
+  };
+
+  const renderAggregationEditor = () => (
+    <EuiFlexGroup>
+      <EuiFlexItem id="aggregation__field">
+        <EuiSelect
+          compressed
+          value={query.aggregation}
+          onChange={onChangeAggregation}
+          options={AGGREGATION_OPTIONS}
+          prepend="AGGREGATION"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const renderAttributesGroupByEditor = () => (
+    <EuiFormControlLayout
+      readOnly
+      compressed
+      fullWidth
+      prepend={<EuiFormLabel htmlFor="attributeGroupBy">ATTRIBUTES GROUP BY</EuiFormLabel>}
+    >
+      <EuiComboBox
+        className={'attributesGroupBy'}
+        compressed
+        fullWidth
+        selectedOptions={query.attributesGroupBy.map((label) => ({ label, value: label }))}
+        onChange={onChangeAttributesGroupBy}
+        options={availableAttributesLabels}
+        prepend={'ATTRIBUTES GROUP BY'}
+      />
+    </EuiFormControlLayout>
+  );
+
+  return (
+    <EuiFlexGroup id="metricsEditInline">
+      <EuiFlexItem grow={false}>{renderAggregationEditor()}</EuiFlexItem>
+      <EuiFlexItem>{renderAttributesGroupByEditor()}</EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/public/components/metrics/sidebar/sidebar.tsx
+++ b/public/components/metrics/sidebar/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   selectMetric,
   loadMetrics,
   selectedMetricsSelector,
+  addSelectedMetric,
 } from '../redux/slices/metrics_slice';
 import { CoreStart } from '../../../../../../src/core/public';
 import PPLService from '../../../services/requests/ppl';
@@ -33,7 +34,7 @@ export const Sidebar = () => {
     });
   }, [dispatch]);
 
-  const handleAddMetric = (metric: any) => dispatch(selectMetric(metric));
+  const handleAddMetric = (metric: any) => dispatch(addSelectedMetric(metric));
 
   const handleRemoveMetric = (metric: any) => {
     dispatch(deSelectMetric(metric));

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export_panel.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export_panel.test.tsx.snap
@@ -22,7 +22,11 @@ exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1
         Object {
           "h": 2,
           "id": "Y4muP4QBiaYaSxpXk7r8",
-          "metricType": "savedCustomMetric",
+          "query": Object {
+            "aggregation": "avg",
+            "attributesGroupBy": Array [],
+            "type": "savedCustomMetric",
+          },
           "savedVisualizationId": "Y4muP4QBiaYaSxpXk7r8",
           "w": 12,
           "x": 0,
@@ -31,7 +35,11 @@ exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1
         Object {
           "h": 2,
           "id": "prometheus.process_resident_memory_bytes",
-          "metricType": "prometheusMetric",
+          "query": Object {
+            "aggregation": "avg",
+            "attributesGroupBy": Array [],
+            "type": "prometheusMetric",
+          },
           "savedVisualizationId": "prometheus.process_resident_memory_bytes",
           "w": 12,
           "x": 0,

--- a/public/components/metrics/view/metrics_grid.tsx
+++ b/public/components/metrics/view/metrics_grid.tsx
@@ -57,7 +57,7 @@ export const MetricsGrid = ({
   };
 
   const [currentLayout, setCurrentLayout] = useState<Layout[]>([]);
-  const [postEditLayout, setPostEditLayout] = useState<Layout[]>([]);
+  const [previousEditLayout, setPreviousEditLayout] = useState<Layout[]>([]);
   const [gridData, setGridData] = useState(panelVisualizations.map(() => <></>));
   const [removeMetricsList, setRemoveMetricsList] = useState<Array<{ id: string }>>([]);
   const isLocked = useObservable(chrome.getIsNavDrawerLocked$());

--- a/public/components/metrics/view/metrics_grid.tsx
+++ b/public/components/metrics/view/metrics_grid.tsx
@@ -16,6 +16,7 @@ import { updateMetricsLayout, deSelectMetric } from '../redux/slices/metrics_sli
 import { mergeLayoutAndMetrics } from '../helpers/utils';
 
 import './metrics_grid.scss';
+import { coreRefs } from '../../../framework/core_refs';
 
 // HOC container to provide dynamic width for Grid layout
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -47,6 +48,7 @@ export const MetricsGrid = ({
   setEditActionType,
   spanParam,
 }: MetricsGridProps) => {
+  const { http, pplService } = coreRefs;
   // Redux tools
   const dispatch = useDispatch();
   const updateLayout = (metric: any) => dispatch(updateMetricsLayout(metric));
@@ -84,6 +86,7 @@ export const MetricsGrid = ({
           panelVisualization.metricType === 'savedCustomMetric' ? undefined : true
         }
         spanParam={spanParam}
+        contextMenuId="metrics"
       />
     ));
     setGridData(gridDataComps);
@@ -121,7 +124,7 @@ export const MetricsGrid = ({
       reloadLayout();
       loadVizComponents();
     }
-  }, [editMode]);
+  }, [editMode, reloadLayout, loadVizComponents]);
 
   useEffect(() => {
     if (editActionType === 'cancel') {
@@ -132,13 +135,20 @@ export const MetricsGrid = ({
       updateLayout(mergeLayoutAndMetrics(postEditLayout, panelVisualizations));
       setEditActionType('');
     }
-  }, [editActionType]);
+  }, [
+    editActionType,
+    handleRemoveMetric,
+    postEditLayout,
+    removeMetricsList,
+    panelVisualizations,
+    setEditActionType,
+  ]);
 
   // Update layout whenever visualizations are updated
   useEffect(() => {
     reloadLayout();
     loadVizComponents();
-  }, [panelVisualizations]);
+  }, [panelVisualizations, reloadLayout, loadVizComponents]);
 
   // Reset Size of Panel Grid when Nav Dock is Locked
   useEffect(() => {

--- a/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -70,44 +70,45 @@ export const ParaOutput = (props: {
     return data;
   };
 
-  const QueryOutput = ({ typeOut, val }: { typeOut: string; val: string }) => {
-    const inputQuery = para.inp.substring(4, para.inp.length);
-    const queryObject = JSON.parse(val);
-    const columns = createQueryColumns(queryObject.schema);
-    const data = getQueryOutputData(queryObject);
-    const [visibleColumns, setVisibleColumns] = useState(() => columns.map(({ id }) => id));
-    if (queryObject.hasOwnProperty('error')) {
-      return <EuiCodeBlock>{val}</EuiCodeBlock>;
-    } else {
-      return (
-        <div>
-          <EuiText className="wrapAll">
-            <b>{inputQuery}</b>
-          </EuiText>
-          <EuiSpacer />
-          <QueryDataGridMemo
-            rowCount={queryObject.datarows.length}
-            queryColumns={columns}
-            visibleColumns={visibleColumns}
-            setVisibleColumns={setVisibleColumns}
-            dataValues={data}
-          />
-        </div>
-      );
-    }
-  };
-
-  const OutputBody = ({ typeOut, val }: { typeOut: string; val: string }) => {
+  const OutputBody = ({ key, typeOut, val }: { key: string; typeOut: string; val: string }) => {
     /* Returns a component to render paragraph outputs using the para.typeOut property
      * Currently supports HTML, TABLE, IMG
      * TODO: add table rendering
      */
     const dateFormat = uiSettingsService.get('dateFormat');
 
+    const [visibleColumns, setVisibleColumns] = useState<Array<{ id: any; displayAsText: any }>>(
+      []
+    );
+
     if (typeOut !== undefined) {
       switch (typeOut) {
         case 'QUERY':
-          return <QueryOutput typeOut={typeOut} val={val} />;
+          const inputQuery = para.inp.substring(4, para.inp.length);
+          const queryObject = JSON.parse(val);
+          if (queryObject.hasOwnProperty('error')) {
+            return <EuiCodeBlock key={key}>{val}</EuiCodeBlock>;
+          } else {
+            const columns = createQueryColumns(queryObject.schema);
+            setVisibleColumns(columns);
+            const data = getQueryOutputData(queryObject);
+            return (
+              <div>
+                <EuiText key={'query-input-key'}>
+                  <b>{inputQuery}</b>
+                </EuiText>
+                <EuiSpacer />
+                <QueryDataGridMemo
+                  key={key}
+                  rowCount={queryObject.datarows.length}
+                  queryColumns={columns}
+                  visibleColumns={visibleColumns}
+                  setVisibleColumns={setVisibleColumns}
+                  dataValues={data}
+                />
+              </div>
+            );
+          }
         case 'MARKDOWN':
           return (
             <EuiText className="wrapAll markdown-output-text">
@@ -153,6 +154,7 @@ export const ParaOutput = (props: {
                   onRefresh={false}
                   pplFilterValue={''}
                   usedInNotebooks={true}
+                  contextMenuId="notebook"
                 />
               </div>
             </>

--- a/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -70,45 +70,44 @@ export const ParaOutput = (props: {
     return data;
   };
 
-  const OutputBody = ({ key, typeOut, val }: { key: string; typeOut: string; val: string }) => {
+  const QueryOutput = ({ typeOut, val }: { typeOut: string; val: string }) => {
+    const inputQuery = para.inp.substring(4, para.inp.length);
+    const queryObject = JSON.parse(val);
+    const columns = createQueryColumns(queryObject.schema);
+    const data = getQueryOutputData(queryObject);
+    const [visibleColumns, setVisibleColumns] = useState(() => columns.map(({ id }) => id));
+    if (queryObject.hasOwnProperty('error')) {
+      return <EuiCodeBlock>{val}</EuiCodeBlock>;
+    } else {
+      return (
+        <div>
+          <EuiText className="wrapAll">
+            <b>{inputQuery}</b>
+          </EuiText>
+          <EuiSpacer />
+          <QueryDataGridMemo
+            rowCount={queryObject.datarows.length}
+            queryColumns={columns}
+            visibleColumns={visibleColumns}
+            setVisibleColumns={setVisibleColumns}
+            dataValues={data}
+          />
+        </div>
+      );
+    }
+  };
+
+  const OutputBody = ({ typeOut, val }: { typeOut: string; val: string }) => {
     /* Returns a component to render paragraph outputs using the para.typeOut property
      * Currently supports HTML, TABLE, IMG
      * TODO: add table rendering
      */
     const dateFormat = uiSettingsService.get('dateFormat');
 
-    const [visibleColumns, setVisibleColumns] = useState<Array<{ id: any; displayAsText: any }>>(
-      []
-    );
-
     if (typeOut !== undefined) {
       switch (typeOut) {
         case 'QUERY':
-          const inputQuery = para.inp.substring(4, para.inp.length);
-          const queryObject = JSON.parse(val);
-          if (queryObject.hasOwnProperty('error')) {
-            return <EuiCodeBlock key={key}>{val}</EuiCodeBlock>;
-          } else {
-            const columns = createQueryColumns(queryObject.schema);
-            setVisibleColumns(columns);
-            const data = getQueryOutputData(queryObject);
-            return (
-              <div>
-                <EuiText key={'query-input-key'}>
-                  <b>{inputQuery}</b>
-                </EuiText>
-                <EuiSpacer />
-                <QueryDataGridMemo
-                  key={key}
-                  rowCount={queryObject.datarows.length}
-                  queryColumns={columns}
-                  visibleColumns={visibleColumns}
-                  setVisibleColumns={setVisibleColumns}
-                  dataValues={data}
-                />
-              </div>
-            );
-          }
+          return <QueryOutput typeOut={typeOut} val={val} />;
         case 'MARKDOWN':
           return (
             <EuiText className="wrapAll markdown-output-text">

--- a/public/components/notebooks/components/paragraph_components/para_query_grid.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_query_grid.tsx
@@ -5,49 +5,41 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import $ from 'jquery';
-import { 
-  EuiDataGrid,
-  EuiLoadingSpinner,
-  EuiSpacer
-} from '@elastic/eui';
+import { EuiDataGrid, EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
+import { Dispatch } from 'react';
+import { SetStateAction } from 'react';
 
-type QueryDataGridProps = {
-  rowCount: number,
-  queryColumns: Array<any>,
-  visibleColumns: Array<any>,
-  setVisibleColumns: (visibleColumns: string[]) => void,
-  dataValues: Array<any>,
+interface QueryDataGridProps {
+  rowCount: number;
+  queryColumns: any[];
+  visibleColumns: any[];
+  setVisibleColumns: Dispatch<SetStateAction<Array<{ id: any; displayAsText: any }>>>;
+  dataValues: any[];
 }
 
-type RenderCellValueProps = {
-  rowIndex: number,
-  columnId: string
+interface RenderCellValueProps {
+  rowIndex: number;
+  columnId: string;
 }
 
 function QueryDataGrid(props: QueryDataGridProps) {
-  const {
-    rowCount,
-    queryColumns,
-    visibleColumns,
-    setVisibleColumns,
-    dataValues,
-  } = props;
+  const { rowCount, queryColumns, visibleColumns, setVisibleColumns, dataValues } = props;
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
   // ** Sorting config
   const [sortingColumns, setSortingColumns] = useState([]);
   const [isVisible, setIsVisible] = useState(false);
 
   const onSort = useCallback(
-    (sortingColumns) => {
-      setSortingColumns(sortingColumns);
+    (newColumns) => {
+      setSortingColumns(newColumns);
     },
     [setSortingColumns]
   );
 
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
-      setPagination((pagination) => ({
-        ...pagination,
+      setPagination((currentPagination) => ({
+        ...currentPagination,
         pageSize,
         pageIndex: 0,
       })),
@@ -55,28 +47,24 @@ function QueryDataGrid(props: QueryDataGridProps) {
   );
 
   const onChangePage = useCallback(
-    (pageIndex) =>
-      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    (pageIndex) => setPagination((currentPagination) => ({ ...currentPagination, pageIndex })),
     [setPagination]
   );
 
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId }: RenderCellValueProps) => {
-      return dataValues.hasOwnProperty(rowIndex)
-        ? dataValues[rowIndex][columnId]
-        : null;
+      return dataValues.hasOwnProperty(rowIndex) ? dataValues[rowIndex][columnId] : null;
     };
-  }, []);
+  }, [dataValues]);
 
-  const getUpdatedVisibleColumns = (queryColumns: Array<Object>) => {
-    let updatedVisibleColumns = [];
-    for (let index = 0; index < queryColumns.length; ++index) {
-      updatedVisibleColumns.push(queryColumns[index].displayAsText);
+  const getUpdatedVisibleColumns = (newQueryColumns: unknown[]) => {
+    const updatedVisibleColumns = [];
+    for (let index = 0; index < newQueryColumns.length; ++index) {
+      updatedVisibleColumns.push(newQueryColumns[index].displayAsText);
     }
     return updatedVisibleColumns;
-  }
+  };
 
-  
   useEffect(() => {
     if ($('.euiDataGrid__overflow').is(':visible')) {
       setIsVisible(true);
@@ -89,9 +77,9 @@ function QueryDataGrid(props: QueryDataGridProps) {
     setVisibleColumns(getUpdatedVisibleColumns(queryColumns));
   }, []);
 
-  const displayLoadingSpinner = (!isVisible) ? (
+  const displayLoadingSpinner = !isVisible ? (
     <>
-      <EuiLoadingSpinner size="xl"/>
+      <EuiLoadingSpinner size="xl" />
       <EuiSpacer />
     </>
   ) : null;
@@ -100,7 +88,7 @@ function QueryDataGrid(props: QueryDataGridProps) {
     <div id="queryDataGrid">
       {displayLoadingSpinner}
       <EuiDataGrid
-        aria-label='Query datagrid'
+        aria-label="Query datagrid"
         columns={queryColumns}
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         rowCount={rowCount}
@@ -110,19 +98,21 @@ function QueryDataGrid(props: QueryDataGridProps) {
         pagination={{
           ...pagination,
           pageSizeOptions: [10, 20, 50],
-          onChangeItemsPerPage: onChangeItemsPerPage,
-          onChangePage: onChangePage,
+          onChangeItemsPerPage,
+          onChangePage,
         }}
       />
     </div>
-  )
+  );
 }
 
 function queryDataGridPropsAreEqual(prevProps: QueryDataGridProps, nextProps: QueryDataGridProps) {
-  return prevProps.rowCount === nextProps.rowCount
-    && JSON.stringify(prevProps.queryColumns) === JSON.stringify(nextProps.queryColumns)
-    && JSON.stringify(prevProps.visibleColumns) === JSON.stringify(nextProps.visibleColumns)
-    && JSON.stringify(prevProps.dataValues) === JSON.stringify(nextProps.dataValues)
+  return (
+    prevProps.rowCount === nextProps.rowCount &&
+    JSON.stringify(prevProps.queryColumns) === JSON.stringify(nextProps.queryColumns) &&
+    JSON.stringify(prevProps.visibleColumns) === JSON.stringify(nextProps.visibleColumns) &&
+    JSON.stringify(prevProps.dataValues) === JSON.stringify(nextProps.dataValues)
+  );
 }
 
 export const QueryDataGridMemo = React.memo(QueryDataGrid, queryDataGridPropsAreEqual);

--- a/public/components/visualizations/charts/__tests__/__snapshots__/bar.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/bar.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`Veritcal Bar component Renders veritcal bar component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -643,7 +643,7 @@ exports[`Veritcal Bar component Renders veritcal bar component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",
@@ -703,7 +703,7 @@ exports[`Veritcal Bar component Renders veritcal bar component 1`] = `
         "height": 220,
         "hovermode": "closest",
         "legend": Object {
-          "orientation": "v",
+          "orientation": "h",
         },
         "margin": Object {
           "b": 30,
@@ -761,7 +761,7 @@ exports[`Veritcal Bar component Renders veritcal bar component 1`] = `
           "height": 220,
           "hovermode": "closest",
           "legend": Object {
-            "orientation": "v",
+            "orientation": "h",
           },
           "margin": Object {
             "b": 30,

--- a/public/components/visualizations/charts/__tests__/__snapshots__/heatmap.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/heatmap.test.tsx.snap
@@ -484,7 +484,7 @@ exports[`Heatmap component Renders heatmap component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -647,7 +647,7 @@ exports[`Heatmap component Renders heatmap component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",

--- a/public/components/visualizations/charts/__tests__/__snapshots__/histogram.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/histogram.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`Histogram component Renders histogram component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -643,7 +643,7 @@ exports[`Histogram component Renders histogram component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",
@@ -715,7 +715,7 @@ exports[`Histogram component Renders histogram component 1`] = `
         ],
         "height": 220,
         "legend": Object {
-          "orientation": "v",
+          "orientation": "h",
         },
         "margin": Object {
           "b": 30,
@@ -772,7 +772,7 @@ exports[`Histogram component Renders histogram component 1`] = `
           "height": 220,
           "hovermode": "closest",
           "legend": Object {
-            "orientation": "v",
+            "orientation": "h",
           },
           "margin": Object {
             "b": 30,

--- a/public/components/visualizations/charts/__tests__/__snapshots__/horizontal_bar.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/horizontal_bar.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`Horizontal bar component Renders horizontal bar component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -643,7 +643,7 @@ exports[`Horizontal bar component Renders horizontal bar component 1`] = `
         "id": "horizontal_bar",
         "label": "Horizontal bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "horizontal_bar",
@@ -703,7 +703,7 @@ exports[`Horizontal bar component Renders horizontal bar component 1`] = `
         "height": 220,
         "hovermode": "closest",
         "legend": Object {
-          "orientation": "v",
+          "orientation": "h",
         },
         "margin": Object {
           "b": 30,
@@ -761,7 +761,7 @@ exports[`Horizontal bar component Renders horizontal bar component 1`] = `
           "height": 220,
           "hovermode": "closest",
           "legend": Object {
-            "orientation": "v",
+            "orientation": "h",
           },
           "margin": Object {
             "b": 30,

--- a/public/components/visualizations/charts/__tests__/__snapshots__/line.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/line.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`Line component Renders line component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -643,7 +643,7 @@ exports[`Line component Renders line component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",
@@ -701,7 +701,7 @@ exports[`Line component Renders line component 1`] = `
         ],
         "height": 220,
         "legend": Object {
-          "orientation": "v",
+          "orientation": "h",
         },
         "margin": Object {
           "b": 30,
@@ -754,7 +754,7 @@ exports[`Line component Renders line component 1`] = `
           "height": 220,
           "hovermode": "closest",
           "legend": Object {
-            "orientation": "v",
+            "orientation": "h",
           },
           "margin": Object {
             "b": 30,

--- a/public/components/visualizations/charts/__tests__/__snapshots__/pie.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/pie.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`Pie component Renders pie component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -643,7 +643,7 @@ exports[`Pie component Renders pie component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",
@@ -697,7 +697,7 @@ exports[`Pie component Renders pie component 1`] = `
         },
         "height": 220,
         "legend": Object {
-          "orientation": "v",
+          "orientation": "h",
         },
         "margin": Object {
           "b": 30,
@@ -745,7 +745,7 @@ exports[`Pie component Renders pie component 1`] = `
           "height": 220,
           "hovermode": "closest",
           "legend": Object {
-            "orientation": "v",
+            "orientation": "h",
           },
           "margin": Object {
             "b": 30,

--- a/public/components/visualizations/charts/__tests__/__snapshots__/text.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/text.test.tsx.snap
@@ -463,7 +463,7 @@ exports[`Text component Renders text component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -626,7 +626,7 @@ exports[`Text component Renders text component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",

--- a/public/components/visualizations/charts/__tests__/__snapshots__/treemap.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/treemap.test.tsx.snap
@@ -480,7 +480,7 @@ exports[`Treemap component Renders treemap component 1`] = `
                       "props": Object {
                         "defaultSelections": Array [
                           Object {
-                            "id": "v",
+                            "id": "h",
                             "name": "Right",
                           },
                         ],
@@ -643,7 +643,7 @@ exports[`Treemap component Renders treemap component 1`] = `
         "id": "bar",
         "label": "Vertical bar",
         "labelangle": 0,
-        "legendposition": "v",
+        "legendposition": "h",
         "linewidth": 0,
         "mode": "group",
         "name": "bar",

--- a/public/components/visualizations/visualization_chart.tsx
+++ b/public/components/visualizations/visualization_chart.tsx
@@ -5,9 +5,7 @@
 
 import React, { useMemo } from 'react';
 
-interface IVisualizationChart {}
-
-export const VisualizationChart = ({ visualizations }: IVisualizationChart) => {
+export const VisualizationChart = ({ visualizations }) => {
   const { vis } = visualizations;
   const { layout = {}, config = {} } = visualizations?.data?.userConfigs;
   const Visualization = visualizations?.vis?.component;
@@ -29,7 +27,7 @@ export const VisualizationChart = ({ visualizations }: IVisualizationChart) => {
   return (
     <Visualization
       visualizations={visualizations}
-      layout={finalFigureLayout}
+      layout={finalFigureLayout()}
       config={finalFigureConfig}
     />
   );

--- a/public/services/saved_objects/saved_object_loaders/ppl/ppl_loader.ts
+++ b/public/services/saved_objects/saved_object_loaders/ppl/ppl_loader.ts
@@ -190,7 +190,7 @@ export class PPLSavedObjectLoader extends SavedObjectLoaderBase implements ISave
     const { tabId, queryManager, getDefaultVisConfig } = this.loadContext;
     // fill saved user configs
     let visConfig = {};
-    const customConfig = objectData.user_configs ? JSON.parse(objectData.user_configs) : {};
+    const customConfig = objectData.user_configs || {};
     if (!isEmpty(customConfig.dataConfig) && !isEmpty(customConfig.dataConfig?.series)) {
       visConfig = { ...customConfig };
     } else {

--- a/test/metrics_contants.ts
+++ b/test/metrics_contants.ts
@@ -157,7 +157,7 @@ export const samplenewDimensions1 = {
   x: 0,
   y: 2,
   w: 12,
-  h: 2,
+  h: 3,
 };
 
 export const samplePanelVisualizations2 = [
@@ -185,7 +185,7 @@ export const samplenewDimensions2 = {
   x: 0,
   y: 4,
   w: 12,
-  h: 2,
+  h: 3,
 };
 
 export const samplePrometheusVisualizationId = 'prometheus.process_resident_memory_bytes';
@@ -258,7 +258,7 @@ export const samplePrometheusSampleUpdateWithSelections = {
   subType: 'metric',
   timestamp: '@timestamp',
   type: 'line',
-  userConfigs: '{}',
+  userConfigs: {},
 };
 
 export const sampleSavedMetric = {
@@ -320,6 +320,22 @@ export const sampleSavedMetricUpdate = {
   subType: 'metric',
   timestamp: 'timestamp',
   type: 'line',
-  userConfigs:
-    '{"dataConfig":{"series":[{"label":"machine.ram","name":"machine.ram","aggregation":"avg","customLabel":""}],"dimensions":[],"span":{"time_field":[{"name":"timestamp","type":"timestamp","label":"timestamp"}],"unit":[{"text":"Day","value":"d","label":"Day"}],"interval":"1"}}}',
+  userConfigs: {
+    dataConfig: {
+      series: [
+        {
+          label: 'machine.ram',
+          name: 'machine.ram',
+          aggregation: 'avg',
+          customLabel: '',
+        },
+      ],
+      dimensions: [],
+      span: {
+        time_field: [{ name: 'timestamp', type: 'timestamp', label: 'timestamp' }],
+        unit: [{ text: 'Day', value: 'd', label: 'Day' }],
+        interval: '1',
+      },
+    },
+  },
 };

--- a/test/metrics_contants.ts
+++ b/test/metrics_contants.ts
@@ -7,7 +7,7 @@ export const sampleMetricsVisualizations = [
   {
     h: 2,
     id: 'Y4muP4QBiaYaSxpXk7r8',
-    metricType: 'savedCustomMetric',
+    query: { type: 'savedCustomMetric', aggregation: 'avg', attributesGroupBy: [] },
     savedVisualizationId: 'Y4muP4QBiaYaSxpXk7r8',
     w: 12,
     x: 0,
@@ -25,7 +25,7 @@ export const sampleMetricsVisualizations = [
   {
     h: 2,
     id: 'prometheus.process_resident_memory_bytes',
-    metricType: 'prometheusMetric',
+    query: { type: 'prometheusMetric', aggregation: 'avg', attributesGroupBy: [] },
     savedVisualizationId: 'prometheus.process_resident_memory_bytes',
     w: 12,
     x: 0,
@@ -59,7 +59,7 @@ export const sampleSortedMetricsLayout = [
   {
     h: 2,
     id: 'Y4muP4QBiaYaSxpXk7r8',
-    metricType: 'savedCustomMetric',
+    query: { type: 'savedCustomMetric', aggregation: 'avg', attributesGroupBy: [] },
     savedVisualizationId: 'Y4muP4QBiaYaSxpXk7r8',
     w: 12,
     x: 0,
@@ -68,7 +68,7 @@ export const sampleSortedMetricsLayout = [
   {
     h: 2,
     id: 'prometheus.process_resident_memory_bytes',
-    metricType: 'prometheusMetric',
+    query: { type: 'prometheusMetric', aggregation: 'avg', attributesGroupBy: [] },
     savedVisualizationId: 'prometheus.process_resident_memory_bytes',
     w: 12,
     x: 0,
@@ -168,7 +168,7 @@ export const samplePanelVisualizations2 = [
     y: 0,
     h: 2,
     w: 12,
-    metricType: 'savedCustomMetric',
+    query: { type: 'savedCustomMetric', aggregation: 'avg', attributesGroupBy: [] },
   },
   {
     id: 'tomAP4QBiaYaSxpXALls',
@@ -177,7 +177,7 @@ export const samplePanelVisualizations2 = [
     y: 2,
     h: 2,
     w: 12,
-    metricType: 'savedCustomMetric',
+    query: { type: 'savedCustomMetric', aggregation: 'avg', attributesGroupBy: [] },
   },
 ];
 


### PR DESCRIPTION
### Description
* Add Inline Editor to all Prometheus-connected Metrics in Metrics Explorer
![image](https://github.com/opensearch-project/dashboards-observability/assets/11318/c5a9bc91-45b2-4290-a3c4-01a1538f8620)

* Ensure Prometheus-connected Metric is displayed correctly on Observability Dashboards
![image](https://github.com/opensearch-project/dashboards-observability/assets/11318/daafb4b2-b87c-4f4a-97a1-214c65d3615c)

* Ensure Prometheus-connected Metric - Saved As Visualization - Is editable in Log Explorer / Visualization
![image](https://github.com/opensearch-project/dashboards-observability/assets/11318/e91ba8bc-ad0e-4b18-addd-1489ea279ab1)


### Issues Resolved


### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
