### PR TITLE
Refactor integration validation logic with a cleaner interface

### DIFF
--- a/server/adaptors/integrations/__test__/local_repository.test.ts
+++ b/server/adaptors/integrations/__test__/local_repository.test.ts
@@ -31,14 +31,4 @@ describe('The local repository', () => {
     const integrations: Integration[] = await repository.getIntegrationList();
     await Promise.all(integrations.map((i) => expect(i.deepCheck()).resolves.toBeTruthy()));
   });
-
-  it('Should not have a type that is not imported in the config', async () => {
-    const repository: Repository = new Repository(path.join(__dirname, '../__data__/repository'));
-    const integrations: Integration[] = await repository.getIntegrationList();
-    for (const integration of integrations) {
-      const config = await integration.getConfig();
-      const components = config!.components.map((x) => x.name);
-      expect(components).toContain(config!.type);
-    }
-  });
 });

--- a/server/adaptors/integrations/__test__/validators.test.ts
+++ b/server/adaptors/integrations/__test__/validators.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { validateTemplate, validateInstance } from '../validators';
+import { validateTemplate, validateInstance, ValidationResult } from '../validators';
 
 const validTemplate: IntegrationTemplate = {
   name: 'test',
@@ -28,62 +28,57 @@ const validInstance: IntegrationInstance = {
 };
 
 describe('validateTemplate', () => {
-  it('Returns true for a valid Integration Template', () => {
-    expect(validateTemplate(validTemplate)).toBe(true);
+  it('Returns a success value for a valid Integration Template', () => {
+    const result: ValidationResult<IntegrationTemplate> = validateTemplate(validTemplate);
+    expect(result.ok).toBe(true);
+    expect((result as any).value).toBe(validTemplate);
   });
 
-  it('Returns false if a template is missing a license', () => {
+  it('Returns a failure value if a template is missing a license', () => {
     const sample: any = structuredClone(validTemplate);
     sample.license = undefined;
-    expect(validateTemplate(sample)).toBe(false);
+
+    const result: ValidationResult<IntegrationTemplate> = validateTemplate(sample);
+
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toBeInstanceOf(Error);
   });
 
-  it('Returns false if a template has an invalid type', () => {
+  it('Returns a failure if a template has an invalid type', () => {
     const sample: any = structuredClone(validTemplate);
     sample.components[0].name = 'not-logs';
-    expect(validateTemplate(sample)).toBe(false);
-  });
 
-  it('Respects logErrors', () => {
-    const logValidationErrorsMock = jest.spyOn(console, 'error');
-    const sample1: any = structuredClone(validTemplate);
-    sample1.license = undefined;
-    const sample2: any = structuredClone(validTemplate);
-    sample2.components[0].name = 'not-logs';
+    const result: ValidationResult<IntegrationTemplate> = validateTemplate(sample);
 
-    expect(validateTemplate(sample1, true)).toBe(false);
-    expect(validateTemplate(sample2, true)).toBe(false);
-    expect(logValidationErrorsMock).toBeCalledTimes(2);
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toBeInstanceOf(Error);
   });
 
   it("Doesn't crash if given a non-object", () => {
     // May happen in some user-provided JSON parsing scenarios.
-    expect(validateTemplate([] as any, true)).toBe(false);
+    expect(validateTemplate([] as any).ok).toBe(false);
   });
 });
 
 describe('validateInstance', () => {
   it('Returns true for a valid Integration Instance', () => {
-    expect(validateInstance(validInstance)).toBe(true);
+    const result: ValidationResult<IntegrationInstance> = validateInstance(validInstance);
+    expect(result.ok).toBe(true);
+    expect((result as any).value).toBe(validInstance);
   });
 
   it('Returns false if an instance is missing a template', () => {
     const sample: any = structuredClone(validInstance);
     sample.templateName = undefined;
-    expect(validateInstance(sample)).toBe(false);
-  });
 
-  it('Respects logErrors', () => {
-    const logValidationErrorsMock = jest.spyOn(console, 'error');
-    const sample1: any = structuredClone(validInstance);
-    sample1.templateName = undefined;
+    const result: ValidationResult<IntegrationInstance> = validateInstance(sample);
 
-    expect(validateInstance(sample1, true)).toBe(false);
-    expect(logValidationErrorsMock).toBeCalled();
+    expect(result.ok).toBe(false);
+    expect((result as any).error).toBeInstanceOf(Error);
   });
 
   it("Doesn't crash if given a non-object", () => {
     // May happen in some user-provided JSON parsing scenarios.
-    expect(validateInstance([] as any, true)).toBe(false);
+    expect(validateInstance([] as any).ok).toBe(false);
   });
 });

--- a/server/adaptors/integrations/__test__/validators.test.ts
+++ b/server/adaptors/integrations/__test__/validators.test.ts
@@ -55,6 +55,11 @@ describe('validateTemplate', () => {
     expect(validateTemplate(sample2, true)).toBe(false);
     expect(logValidationErrorsMock).toBeCalledTimes(2);
   });
+
+  it("Doesn't crash if given a non-object", () => {
+    // May happen in some user-provided JSON parsing scenarios.
+    expect(validateTemplate([] as any, true)).toBe(false);
+  });
 });
 
 describe('validateInstance', () => {
@@ -75,5 +80,10 @@ describe('validateInstance', () => {
 
     expect(validateInstance(sample1, true)).toBe(false);
     expect(logValidationErrorsMock).toBeCalled();
+  });
+
+  it("Doesn't crash if given a non-object", () => {
+    // May happen in some user-provided JSON parsing scenarios.
+    expect(validateInstance([] as any, true)).toBe(false);
   });
 });

--- a/server/adaptors/integrations/__test__/validators.test.ts
+++ b/server/adaptors/integrations/__test__/validators.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { validateTemplate, validateInstance } from '../validators';
+
+const validTemplate: IntegrationTemplate = {
+  name: 'test',
+  version: '1.0.0',
+  license: 'Apache-2.0',
+  type: 'logs',
+  components: [
+    {
+      name: 'logs',
+      version: '1.0.0',
+    },
+  ],
+  assets: {},
+};
+
+const validInstance: IntegrationInstance = {
+  name: 'test',
+  templateName: 'test',
+  dataSource: 'test',
+  creationDate: new Date(0).toISOString(),
+  assets: [],
+};
+
+describe('validateTemplate', () => {
+  it('Returns true for a valid Integration Template', () => {
+    expect(validateTemplate(validTemplate)).toBe(true);
+  });
+
+  it('Returns false if a template is missing a license', () => {
+    const sample: any = structuredClone(validTemplate);
+    sample.license = undefined;
+    expect(validateTemplate(sample)).toBe(false);
+  });
+
+  it('Returns false if a template has an invalid type', () => {
+    const sample: any = structuredClone(validTemplate);
+    sample.components[0].name = 'not-logs';
+    expect(validateTemplate(sample)).toBe(false);
+  });
+
+  it('Respects logErrors', () => {
+    const logValidationErrorsMock = jest.spyOn(console, 'error');
+    const sample1: any = structuredClone(validTemplate);
+    sample1.license = undefined;
+    const sample2: any = structuredClone(validTemplate);
+    sample2.components[0].name = 'not-logs';
+
+    expect(validateTemplate(sample1, true)).toBe(false);
+    expect(validateTemplate(sample2, true)).toBe(false);
+    expect(logValidationErrorsMock).toBeCalledTimes(2);
+  });
+});
+
+describe('validateInstance', () => {
+  it('Returns true for a valid Integration Instance', () => {
+    expect(validateInstance(validInstance)).toBe(true);
+  });
+
+  it('Returns false if an instance is missing a template', () => {
+    const sample: any = structuredClone(validInstance);
+    sample.templateName = undefined;
+    expect(validateInstance(sample)).toBe(false);
+  });
+
+  it('Respects logErrors', () => {
+    const logValidationErrorsMock = jest.spyOn(console, 'error');
+    const sample1: any = structuredClone(validInstance);
+    sample1.templateName = undefined;
+
+    expect(validateInstance(sample1, true)).toBe(false);
+    expect(logValidationErrorsMock).toBeCalled();
+  });
+});

--- a/server/adaptors/integrations/repository/__test__/integration.test.ts
+++ b/server/adaptors/integrations/repository/__test__/integration.test.ts
@@ -16,8 +16,13 @@ describe('Integration', () => {
     name: 'sample',
     version: '2.0.0',
     license: 'Apache-2.0',
-    type: '',
-    components: [],
+    type: 'logs',
+    components: [
+      {
+        name: 'logs',
+        version: '1.0.0',
+      },
+    ],
     assets: {
       savedObjects: {
         name: 'sample',
@@ -105,7 +110,7 @@ describe('Integration', () => {
       const result = await integration.getConfig(sampleIntegration.version);
 
       expect(result).toBeNull();
-      expect(logValidationErrorsMock).toHaveBeenCalledWith(expect.any(String), expect.any(Array));
+      expect(logValidationErrorsMock).toHaveBeenCalled();
     });
 
     it('should return null and log syntax errors if the config file has syntax errors', async () => {

--- a/server/adaptors/integrations/repository/integration.ts
+++ b/server/adaptors/integrations/repository/integration.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs/promises';
 import path from 'path';
 import { ValidateFunction } from 'ajv';
-import { templateValidator } from '../validators';
+import { validateTemplate } from '../validators';
 
 /**
  * Helper function to compare version numbers.
@@ -47,18 +47,6 @@ async function isDirectory(dirPath: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-/**
- * Helper function to log validation errors.
- * Relies on the `ajv` package for validation error logs..
- *
- * @param integration The name of the component that failed validation.
- * @param validator A failing ajv validator.
- */
-function logValidationErrors(integration: string, validator: ValidateFunction<any>) {
-  const errors = validator.errors?.map((e) => e.message);
-  console.error(`Validation errors in ${integration}`, errors);
 }
 
 /**
@@ -165,12 +153,7 @@ export class Integration {
       const config = await fs.readFile(configPath, { encoding: 'utf-8' });
       const possibleTemplate = JSON.parse(config);
 
-      if (!templateValidator(possibleTemplate)) {
-        logValidationErrors(configFile, templateValidator);
-        return null;
-      }
-
-      return possibleTemplate;
+      return validateTemplate(possibleTemplate, true) ? possibleTemplate : null;
     } catch (err: any) {
       if (err instanceof SyntaxError) {
         console.error(`Syntax errors in ${configFile}`, err);

--- a/server/adaptors/integrations/repository/integration.ts
+++ b/server/adaptors/integrations/repository/integration.ts
@@ -5,7 +5,6 @@
 
 import * as fs from 'fs/promises';
 import path from 'path';
-import { ValidateFunction } from 'ajv';
 import { validateTemplate } from '../validators';
 
 /**

--- a/server/adaptors/integrations/repository/integration.ts
+++ b/server/adaptors/integrations/repository/integration.ts
@@ -151,8 +151,12 @@ export class Integration {
     try {
       const config = await fs.readFile(configPath, { encoding: 'utf-8' });
       const possibleTemplate = JSON.parse(config);
-
-      return validateTemplate(possibleTemplate, true) ? possibleTemplate : null;
+      const template = validateTemplate(possibleTemplate);
+      if (template.ok) {
+        return template.value;
+      }
+      console.error(template.error);
+      return null;
     } catch (err: any) {
       if (err instanceof SyntaxError) {
         console.error(`Syntax errors in ${configFile}`, err);

--- a/server/adaptors/integrations/validators.ts
+++ b/server/adaptors/integrations/validators.ts
@@ -116,7 +116,7 @@ export const validateTemplate = (data: { name?: unknown }, logErrors?: true): bo
   if (!templateValidator(data)) {
     if (logErrors) {
       console.error(
-        `The integration '${data.name ?? 'config'}' is invalid:`,
+        `The integration config '${data.name ?? data}' is invalid:`,
         ajv.errorsText(templateValidator.errors)
       );
     }
@@ -136,7 +136,7 @@ export const validateInstance = (data: { name?: unknown }, logErrors?: true): bo
   if (!instanceValidator(data)) {
     if (logErrors) {
       console.error(
-        `The integration '${data.name ?? 'instance'} is invalid:`,
+        `The integration instance '${data.name ?? data}' is invalid:`,
         ajv.errorsText(instanceValidator.errors)
       );
     }


### PR DESCRIPTION
### Description
While working on the unrelated [remote catalog](https://github.com/opensearch-project/opensearch-catalog/issues/69) feature, I separately refactored our Ajv usage to provide better error messages and help break tight coupling. This change on its own is small and generally applicable, so I've moved it to its own PR.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
