### PR TITLE
Set isolatedModules to true in jest config

### DIFF
--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -32,4 +32,9 @@ module.exports = {
     '^!!raw-loader!.*': 'jest-raw-loader',
   },
   testEnvironment: 'jsdom',
+  globals: {
+    'ts-jest': {
+      isolatedModules: true,
+    },
+  },
 };


### PR DESCRIPTION
### Description
A low-hanging fruit config setting that speeds up our test suite by a lot. More details in [the docs](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules/):

> By default ts-jest uses TypeScript compiler in the context of a project (yours), with full type-checking and features. But it can also be used to compile each file separately, what TypeScript calls an 'isolated module'. That's what the isolatedModules option (which defaults to false) does.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
