### PR TITLE
Fix all yarn lints for server directory

### DIFF
--- a/common/constants/notebooks.ts
+++ b/common/constants/notebooks.ts
@@ -4,10 +4,11 @@
  */
 
 export const NOTEBOOKS_API_PREFIX = '/api/observability/notebooks';
-export const NOTEBOOKS_SELECTED_BACKEND = 'DEFAULT'; // ZEPPELIN || DEFAULT
+export const NOTEBOOKS_SELECTED_BACKEND: 'ZEPPELIN' | 'DEFAULT' = 'DEFAULT';
 export const NOTEBOOKS_FETCH_SIZE = 1000;
 export const CREATE_NOTE_MESSAGE = 'Enter a name to describe the purpose of this notebook.';
-export const NOTEBOOKS_DOCUMENTATION_URL = 'https://opensearch.org/docs/latest/observability-plugin/notebooks/';
+export const NOTEBOOKS_DOCUMENTATION_URL =
+  'https://opensearch.org/docs/latest/observability-plugin/notebooks/';
 
 export const zeppelinURL = 'http://localhost:8080';
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "husky": "6.0.0",
     "jest-dom": "^4.0.0",
     "lint-staged": "^13.1.0",
-    "mock-fs": "^4.12.0",
     "ts-jest": "^29.1.0"
   },
   "resolutions": {

--- a/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -8,7 +8,7 @@ import { PanelType, VisualizationType } from '../../../common/types/custom_panel
 import { ILegacyScopedClusterClient } from '../../../../../src/core/server';
 import { createDemoPanel } from '../../../common/constants/custom_panels';
 
-interface boxType {
+interface BoxType {
   x1: number;
   y1: number;
   x2: number;
@@ -274,14 +274,14 @@ export class CustomPanelsAdaptor {
     }
   };
 
-  calculatOverlapArea = (bb1: boxType, bb2: boxType) => {
-    const x_left = Math.max(bb1.x1, bb2.x1);
-    const y_top = Math.max(bb1.y1, bb2.y1);
-    const x_right = Math.min(bb1.x2, bb2.x2);
-    const y_bottom = Math.min(bb1.y2, bb2.y2);
+  calculatOverlapArea = (bb1: BoxType, bb2: BoxType) => {
+    const xLeft = Math.max(bb1.x1, bb2.x1);
+    const yTop = Math.max(bb1.y1, bb2.y1);
+    const xRight = Math.min(bb1.x2, bb2.x2);
+    const yBottom = Math.min(bb1.y2, bb2.y2);
 
-    if (x_right < x_left || y_bottom < y_top) return 0;
-    return (x_right - x_left) * (y_bottom - y_top);
+    if (xRight < xLeft || yBottom < yTop) return 0;
+    return (xRight - xLeft) * (yBottom - yTop);
   };
 
   getTotalOverlapArea = (panelVisualizations: VisualizationType[]) => {

--- a/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -142,7 +142,6 @@ export class CustomPanelsAdaptor {
     }
   };
 
-
   // Rename an existing panel
   renamePanel = async (client: ILegacyScopedClusterClient, panelId: string, panelName: string) => {
     const updatePanelBody = {
@@ -380,7 +379,7 @@ export class CustomPanelsAdaptor {
     savedVisualizationIds: string[]
   ) => {
     try {
-      let allPanelVisualizations = await this.getVisualizations(client, panelId);
+      const allPanelVisualizations = await this.getVisualizations(client, panelId);
 
       let newDimensions;
       let visualizationsList = [...allPanelVisualizations];

--- a/server/adaptors/notebooks/default_backend.ts
+++ b/server/adaptors/notebooks/default_backend.ts
@@ -77,7 +77,7 @@ export class DefaultBackend implements NotebookAdaptor {
         objectId: noteId,
       });
       if (response.observabilityObjectList.length === 0) {
-        throw 'notebook id not found';
+        throw new Error('notebook id not found');
       }
       return response.observabilityObjectList[0];
     } catch (error) {

--- a/server/adaptors/notebooks/default_backend.ts
+++ b/server/adaptors/notebooks/default_backend.ts
@@ -262,7 +262,7 @@ export class DefaultBackend implements NotebookAdaptor {
     _wreckOptions: optionsType
   ) {
     try {
-      let newNoteObject = { ...noteObj };
+      const newNoteObject = { ...noteObj };
       newNoteObject.id = 'note_' + uuid();
       newNoteObject.dateCreated = new Date().toISOString();
       newNoteObject.dateModified = new Date().toISOString();
@@ -283,7 +283,7 @@ export class DefaultBackend implements NotebookAdaptor {
    *         paragraphInput -> Input to be added
    */
   updateParagraph = function (
-    paragraphs: Array<DefaultParagraph>,
+    paragraphs: DefaultParagraph[],
     paragraphId: string,
     paragraphInput: string,
     paragraphType?: string
@@ -324,7 +324,7 @@ export class DefaultBackend implements NotebookAdaptor {
         inputType: paragraphType,
         inputText: paragraphInput,
       };
-      const outputObjects: Array<DefaultOutput> = [
+      const outputObjects: DefaultOutput[] = [
         {
           outputType: paragraphType,
           result: '',
@@ -350,7 +350,7 @@ export class DefaultBackend implements NotebookAdaptor {
    * UI renders Markdown
    */
   runParagraph = async function (
-    paragraphs: Array<DefaultParagraph>,
+    paragraphs: DefaultParagraph[],
     paragraphId: string,
     client: ILegacyScopedClusterClient
   ) {
@@ -526,7 +526,7 @@ export class DefaultBackend implements NotebookAdaptor {
       const newParagraph = this.createParagraph(params.paragraphInput, params.inputType);
       paragraphs.splice(params.paragraphIndex, 0, newParagraph);
       const updateNotebook = {
-        paragraphs: paragraphs,
+        paragraphs,
         dateModified: new Date().toISOString(),
       };
       const opensearchClientResponse = await this.updateNote(client, params.noteId, updateNotebook);
@@ -586,10 +586,10 @@ export class DefaultBackend implements NotebookAdaptor {
   ) {
     try {
       const opensearchClientGetResponse = await this.getNote(client, params.noteId);
-      let updatedparagraphs: DefaultParagraph[] = [];
+      const updatedparagraphs: DefaultParagraph[] = [];
       opensearchClientGetResponse.notebook.paragraphs.map(
         (paragraph: DefaultParagraph, index: number) => {
-          let updatedParagraph = { ...paragraph };
+          const updatedParagraph = { ...paragraph };
           updatedParagraph.output = [];
           updatedparagraphs.push(updatedParagraph);
         }

--- a/server/adaptors/notebooks/index.ts
+++ b/server/adaptors/notebooks/index.ts
@@ -8,10 +8,8 @@ import { DefaultBackend } from './default_backend';
 import { NOTEBOOKS_SELECTED_BACKEND } from '../../../common/constants/notebooks';
 
 // Selects backend based on config
-let BACKEND = new DefaultBackend();
+export let BACKEND: DefaultBackend | ZeppelinBackend = new DefaultBackend();
 
 if (NOTEBOOKS_SELECTED_BACKEND === 'ZEPPELIN') {
   BACKEND = new ZeppelinBackend();
 }
-
-export default BACKEND;

--- a/server/adaptors/notebooks/index.ts
+++ b/server/adaptors/notebooks/index.ts
@@ -10,7 +10,7 @@ import { NOTEBOOKS_SELECTED_BACKEND } from '../../../common/constants/notebooks'
 // Selects backend based on config
 let BACKEND = new DefaultBackend();
 
-if (NOTEBOOKS_SELECTED_BACKEND == 'ZEPPELIN') {
+if (NOTEBOOKS_SELECTED_BACKEND === 'ZEPPELIN') {
   BACKEND = new ZeppelinBackend();
 }
 

--- a/server/adaptors/ppl_datasource.ts
+++ b/server/adaptors/ppl_datasource.ts
@@ -4,19 +4,12 @@
  */
 
 import _ from 'lodash';
-import {
-  IPPLEventsDataSource,
-  IPPLVisualizationDataSource
-} from '../common/types';
+import { IPPLEventsDataSource, IPPLVisualizationDataSource } from '../common/types';
 
 type PPLResponse = IPPLEventsDataSource & IPPLVisualizationDataSource;
 
 export class PPLDataSource {
-
-  constructor(
-    private pplDataSource: PPLResponse,
-    private dataType: string
-  ) {
+  constructor(private pplDataSource: PPLResponse, private dataType: string) {
     if (this.dataType === 'jdbc') {
       this.addSchemaRowMapping();
     } else if (this.dataType === 'viz') {
@@ -42,9 +35,9 @@ export class PPLDataSource {
      *  agent: "chrome",
      *  avg(bytes): 5648
      *  ...
-     * }] 
+     * }]
      */
-    let res = [];
+    const res = [];
     if (visData?.metadata?.fields) {
       const queriedFields = visData.metadata.fields;
       for (let i = 0; i < visData.size; i++) {
@@ -55,29 +48,27 @@ export class PPLDataSource {
         });
         res.push(entry);
       }
-      visData['jsonData'] = res;
+      visData.jsonData = res;
     }
-  }
+  };
 
   /**
    * Add 'schemaName: data' entries for UI rendering
    */
   private addSchemaRowMapping = () => {
-    
     const pplRes = this.pplDataSource;
-    
+
     const data: any[] = [];
 
     _.forEach(pplRes.datarows, (row) => {
       const record: any = {};
-      
+
       for (let i = 0; i < pplRes.schema.length; i++) {
-        
         const cur = pplRes.schema[i];
-        
-        if (typeof(row[i]) === 'object') {
+
+        if (typeof row[i] === 'object') {
           record[cur.name] = JSON.stringify(row[i]);
-        } else if (typeof(row[i]) === 'boolean') {
+        } else if (typeof row[i] === 'boolean') {
           record[cur.name] = row[i].toString();
         } else {
           record[cur.name] = row[i];
@@ -86,8 +77,8 @@ export class PPLDataSource {
 
       data.push(record);
     });
-    pplRes['jsonData'] = data;
+    pplRes.jsonData = data;
   };
 
-  public getDataSource = () : PPLResponse => this.pplDataSource;
+  public getDataSource = (): PPLResponse => this.pplDataSource;
 }

--- a/server/common/helpers/notebooks/default_notebook_schema.ts
+++ b/server/common/helpers/notebooks/default_notebook_schema.ts
@@ -5,27 +5,27 @@
 
 // Default Backend Notebook Schema
 
-export type DefaultInput = {
+export interface DefaultInput {
   inputType: string;
   inputText: string;
-};
+}
 
-export type DefaultOutput = {
+export interface DefaultOutput {
   outputType: string;
   result: string;
   execution_time: string;
-};
-export type DefaultParagraph = {
+}
+export interface DefaultParagraph {
   id: string;
   dateCreated: string;
   dateModified: string;
   input: DefaultInput;
-  output: Array<DefaultOutput>;
-};
-export type DefaultNotebooks = {
+  output: DefaultOutput[];
+}
+export interface DefaultNotebooks {
   name: string;
   dateCreated: string;
   dateModified: string;
   backend: string;
-  paragraphs: Array<DefaultParagraph>;
-};
+  paragraphs: DefaultParagraph[];
+}

--- a/server/common/helpers/notebooks/query_helpers.ts
+++ b/server/common/helpers/notebooks/query_helpers.ts
@@ -3,33 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import QueryService from "../../../services/queryService";
+import QueryService from '../../../services/queryService';
 
 export const inputIsQuery = (inputText: string) => {
-  return (inputIsSQL(inputText) || inputIsPPL(inputText));
-}
+  return inputIsSQL(inputText) || inputIsPPL(inputText);
+};
 
 export const inputIsSQL = (inputText: string) => {
   return inputText.substring(0, 4) === '%sql';
-}
+};
 
 export const inputIsPPL = (inputText: string) => {
   return inputText.substring(0, 4) === '%ppl';
-}
+};
 
 export const getQueryOutput = async (inputText: string, queryService: QueryService) => {
   let output = {};
   if (inputIsSQL(inputText)) {
     output = await queryService.describeSQLQuery(inputText);
-  }
-  else if (inputIsPPL(inputText)) {
+  } else if (inputIsPPL(inputText)) {
     output = await queryService.describePPLQuery(inputText);
   }
   return output;
-}
+};
 
 export const formatNotRecognized = (inputText: string) => {
-  return (inputText.substring(0, 4) != '%sql' &&
-          inputText.substring(0, 4) != '%ppl' &&
-          inputText.substring(0, 3) != '%md')
-}
+  return (
+    inputText.substring(0, 4) != '%sql' &&
+    inputText.substring(0, 4) != '%ppl' &&
+    inputText.substring(0, 3) != '%md'
+  );
+};

--- a/server/common/helpers/notebooks/query_helpers.ts
+++ b/server/common/helpers/notebooks/query_helpers.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import QueryService from '../../../services/queryService';
+import { QueryService } from '../../../services/queryService';
 
 export const inputIsQuery = (inputText: string) => {
   return inputIsSQL(inputText) || inputIsPPL(inputText);

--- a/server/common/helpers/notebooks/query_helpers.ts
+++ b/server/common/helpers/notebooks/query_helpers.ts
@@ -29,8 +29,8 @@ export const getQueryOutput = async (inputText: string, queryService: QueryServi
 
 export const formatNotRecognized = (inputText: string) => {
   return (
-    inputText.substring(0, 4) != '%sql' &&
-    inputText.substring(0, 4) != '%ppl' &&
-    inputText.substring(0, 3) != '%md'
+    inputText.substring(0, 4) !== '%sql' &&
+    inputText.substring(0, 4) !== '%ppl' &&
+    inputText.substring(0, 3) !== '%md'
   );
 };

--- a/server/common/helpers/notebooks/sample_notebooks.ts
+++ b/server/common/helpers/notebooks/sample_notebooks.ts
@@ -18,8 +18,7 @@ const getDemoNotebook = (dateString: string, visId: string) => {
       {
         output: [
           {
-            result:
-              `An OpenSearch Dashboards notebook is an interface that lets you easily combine code snippets, live visualizations, and narrative text in a single notebook interface.
+            result: `An OpenSearch Dashboards notebook is an interface that lets you easily combine code snippets, live visualizations, and narrative text in a single notebook interface.
 
 Notebooks let you interactively explore data by running different visualizations that you can share with team members to collaborate on a project.
 
@@ -56,7 +55,8 @@ For more information, refer to the [documentation](https://opensearch.org/docs/d
       {
         output: [
           {
-            result: 'Notebooks combine code blocks and visualizations for describing data. Code blocks support markdown, SQL, and PPL languages. Specify the input language on the first line using %\[language type\] syntax. For example, type %md for markdown, %sql for SQL, and %ppl for PPL. A sample visualization is shown below:',
+            result:
+              'Notebooks combine code blocks and visualizations for describing data. Code blocks support markdown, SQL, and PPL languages. Specify the input language on the first line using %[language type] syntax. For example, type %md for markdown, %sql for SQL, and %ppl for PPL. A sample visualization is shown below:',
             outputType: 'MARKDOWN',
             execution_time: '0 ms',
           },
@@ -125,7 +125,7 @@ You can also reorder, duplicate, or delete paragraphs from these menus.`,
         output: [
           {
             result:
-              'To execute a paragraph, choose **Run**. To make changes to the input block, choose the downward arrow that\'s next to the paragraph title.',
+              "To execute a paragraph, choose **Run**. To make changes to the input block, choose the downward arrow that's next to the paragraph title.",
             outputType: 'MARKDOWN',
             execution_time: '0 ms',
           },
@@ -341,7 +341,7 @@ Check for any error log with response code 404 or 503 (filter).`,
       {
         output: [
           {
-            result: 'We see too many events. Let\'s quickly check which host has the issue (dedup).',
+            result: "We see too many events. Let's quickly check which host has the issue (dedup).",
             outputType: 'MARKDOWN',
             execution_time: '0.014 ms',
           },
@@ -380,7 +380,7 @@ We see too many events. Let's quickly check which host has the issue (dedup).`,
       {
         output: [
           {
-            result: 'We get too few events. Let\'s dedup in consecutive mode (dedup).',
+            result: "We get too few events. Let's dedup in consecutive mode (dedup).",
             outputType: 'MARKDOWN',
             execution_time: '0.006 ms',
           },
@@ -462,7 +462,7 @@ How many IP addresses for each response (stats).`,
       {
         output: [
           {
-            result: 'To dive deep, let\'s group by host and response, count, and sum (stats).',
+            result: "To dive deep, let's group by host and response, count, and sum (stats).",
             outputType: 'MARKDOWN',
             execution_time: '0.006 ms',
           },
@@ -552,7 +552,8 @@ We don't see a meaningful response. Let's change to resp_code (rename).`,
       {
         output: [
           {
-            result: 'The data looks better now. Let\'s sort by `DESC count` and `ASC sum_bytes` (sort).',
+            result:
+              "The data looks better now. Let's sort by `DESC count` and `ASC sum_bytes` (sort).",
             outputType: 'MARKDOWN',
             execution_time: '0.006 ms',
           },
@@ -599,7 +600,7 @@ The data looks better now. Let's sort by \`DESC count\` and \`ASC sum_bytes\` (s
       {
         output: [
           {
-            result: 'Let\'s check if we can perform aggregations after stats (eval).',
+            result: "Let's check if we can perform aggregations after stats (eval).",
             outputType: 'MARKDOWN',
             execution_time: '0.006 ms',
           },
@@ -710,8 +711,7 @@ const getSQLNotebook = (dateString: string) => {
       {
         output: [
           {
-            result:
-              `OpenSearch SQL lets you write queries in SQL rather than the [OpenSearch query domain-specific language (DSL)](https://opensearch.org/docs/opensearch/query-dsl/full-text/). If you’re already familiar with SQL and don’t want to learn the query DSL, this feature is a great option.
+            result: `OpenSearch SQL lets you write queries in SQL rather than the [OpenSearch query domain-specific language (DSL)](https://opensearch.org/docs/opensearch/query-dsl/full-text/). If you’re already familiar with SQL and don’t want to learn the query DSL, this feature is a great option.
 
 For more information, please refer to the [documentation](https://opensearch.org/docs/search-plugins/sql/index/).`,
             outputType: 'MARKDOWN',
@@ -786,7 +786,7 @@ Select * from opensearch_dashboards_sample_data_flights limit 20;`,
         output: [
           {
             result:
-              'You can specify fields in the `SELECT` clause and use the `WHERE` clause to filter results. The following query finds flights heading to countries that start with \'A\' that are more than 5000 miles away.',
+              "You can specify fields in the `SELECT` clause and use the `WHERE` clause to filter results. The following query finds flights heading to countries that start with 'A' that are more than 5000 miles away.",
             outputType: 'MARKDOWN',
             execution_time: '0.006 ms',
           },
@@ -820,8 +820,7 @@ SELECT FlightNum,OriginCountry,OriginCityName,DestCountry,DestCityName,DistanceM
       {
         output: [
           {
-            result:
-              'OpenSearch SQL also supports subqueries:',
+            result: 'OpenSearch SQL also supports subqueries:',
             outputType: 'MARKDOWN',
             execution_time: '0.007 ms',
           },

--- a/server/common/helpers/notebooks/wreck_requests.ts
+++ b/server/common/helpers/notebooks/wreck_requests.ts
@@ -4,7 +4,7 @@
  */
 
 import Wreck from '@hapi/wreck';
-import { optionsType } from "../../../../common/types/notebooks";
+import { optionsType } from '../../../../common/types/notebooks';
 
 export const requestor = async function (
   requestType: string,

--- a/server/common/metrics/metrics_helper.ts
+++ b/server/common/metrics/metrics_helper.ts
@@ -66,7 +66,7 @@ export function addRequestToMetric(
 
   rollingCounter[component][request][counter]!++;
   if (counter === 'count') {
-    GLOBAL_BASIC_COUNTER[component][request]['total']!++;
+    GLOBAL_BASIC_COUNTER[component][request].total!++;
   }
 
   time2CountWin.set(timeKey, rollingCounter);

--- a/server/common/metrics/metrics_helper.ts
+++ b/server/common/metrics/metrics_helper.ts
@@ -46,7 +46,9 @@ export function addRequestToMetric(
 export function addRequestToMetric(
   component: ComponentType,
   request: RequestType,
-  counter: CounterNameType
+  // ESLint would prefer less definitions with union types instead of multiple definitions.
+  // Disabled one-time: if this is recurring look at configuring `ignoreDifferentlyNamedParameters=true`
+  counter: CounterNameType // eslint-disable-line @typescript-eslint/unified-signatures
 ): void;
 export function addRequestToMetric(
   component: ComponentType,

--- a/server/common/metrics/types.ts
+++ b/server/common/metrics/types.ts
@@ -10,11 +10,11 @@ export type RequestType = typeof REQUESTS[number];
 export type CounterNameType = 'count' | 'system_error' | 'user_error' | 'total';
 
 // counter to track user click actions
-type ClickCounterType = {
+interface ClickCounterType {
   [element: string]: {
     [counter in CounterNameType]?: number;
   };
-};
+}
 
 // counter to track requests to OpenSearch
 type RequestCounterType = {

--- a/server/common/types/index.ts
+++ b/server/common/types/index.ts
@@ -4,20 +4,20 @@
  */
 
 export interface ISchema {
-  name: string,
-  type: string
+  name: string;
+  type: string;
 }
 
 export interface IPPLVisualizationDataSource {
   data: any;
   metadata: any;
-  jsonData?: Array<any>;
-  size: Number;
-  status: Number;
+  jsonData?: any[];
+  size: number;
+  status: number;
 }
 
 export interface IPPLEventsDataSource {
-  schema: Array<ISchema>;
-  datarows: Array<any>;
-  jsonData?: Array<any>;
+  schema: ISchema[];
+  datarows: any[];
+  jsonData?: any[];
 }

--- a/server/routes/application_analytics/app_analytics_router.ts
+++ b/server/routes/application_analytics/app_analytics_router.ts
@@ -2,7 +2,6 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-/* eslint-disable no-console */
 
 import { schema } from '@osd/config-schema';
 import {

--- a/server/routes/custom_panels/panels_router.ts
+++ b/server/routes/custom_panels/panels_router.ts
@@ -125,7 +125,6 @@ export function PanelsRouter(router: IRouter) {
     }
   );
 
-
   // update an existing panel
   router.post(
     {
@@ -166,7 +165,6 @@ export function PanelsRouter(router: IRouter) {
       }
     }
   );
-
 
   // rename an existing panel
   router.post(

--- a/server/routes/dsl.ts
+++ b/server/routes/dsl.ts
@@ -3,98 +3,92 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  IRouter,
-} from '../../../../src/core/server';
 import { schema } from '@osd/config-schema';
-import DSLFacet from '../services/facets/dsl_facet';
-import {
-  DSL_BASE,
-  DSL_SEARCH,
-  DSL_CAT,
-  DSL_MAPPING
-} from '../../common/constants/shared';
 import { RequestParams } from '@elastic/elasticsearch';
+import { IRouter } from '../../../../src/core/server';
+import DSLFacet from '../services/facets/dsl_facet';
+import { DSL_BASE, DSL_SEARCH, DSL_CAT, DSL_MAPPING } from '../../common/constants/shared';
 
-export function registerDslRoute({
-  router,
-  facet,
-}: {
-  router: IRouter
-  facet: DSLFacet
-}) {
-  router.post({
-    path: `${DSL_BASE}${DSL_SEARCH}`,
-    validate: { body:schema.any() }
-  },
-  async (context, request, response) => {
-    const { index, size, ...rest } = request.body;
-    const params: RequestParams.Search = {
-      index: index,
-      size,
-      body: rest,
-    };
-    try {
-      const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
-        'search',
-        params
-      );
-      return response.ok({
-        body: resp,
-      });
-    } catch (error) {
-      if (error.statusCode !== 404) console.error(error);
-      return response.custom({
-        statusCode: error.statusCode || 500,
-        body: error.message,
-      });
+export function registerDslRoute({ router, facet }: { router: IRouter; facet: DSLFacet }) {
+  router.post(
+    {
+      path: `${DSL_BASE}${DSL_SEARCH}`,
+      validate: { body: schema.any() },
+    },
+    async (context, request, response) => {
+      const { index, size, ...rest } = request.body;
+      const params: RequestParams.Search = {
+        index,
+        size,
+        body: rest,
+      };
+      try {
+        const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
+          'search',
+          params
+        );
+        return response.ok({
+          body: resp,
+        });
+      } catch (error) {
+        if (error.statusCode !== 404) console.error(error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
     }
-  })
+  );
 
-  router.get({
-    path: `${DSL_BASE}${DSL_CAT}`,
-    validate: { query: schema.object({
-      format: schema.string()
-    }) }
-  },
-  async (context, request, response) => {
-    try {
-      const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
-        'cat.indices',
-        request.query
-      );
-      return response.ok({
-        body: resp
-      });
-    } catch (error) {
-      if (error.statusCode !== 404) console.error(error);
-      return response.custom({
-        statusCode: error.statusCode || 500,
-        body: error.message
-      })
+  router.get(
+    {
+      path: `${DSL_BASE}${DSL_CAT}`,
+      validate: {
+        query: schema.object({
+          format: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
+          'cat.indices',
+          request.query
+        );
+        return response.ok({
+          body: resp,
+        });
+      } catch (error) {
+        if (error.statusCode !== 404) console.error(error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
     }
-  })
-  
-  router.get({
-    path: `${DSL_BASE}${DSL_MAPPING}`,
-    validate: { query: schema.any() }
-  },
-  async (context, request, response) => {
-    try {
-      const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
-        'indices.getMapping',
-        { index: request.query.index }
-      );
-      return response.ok({
-        body: resp
-      });
-    } catch (error) {
-      if (error.statusCode !== 404) console.error(error);
-      return response.custom({
-        statusCode: error.statusCode || 500,
-        body: error.message,
-      })
+  );
+
+  router.get(
+    {
+      path: `${DSL_BASE}${DSL_MAPPING}`,
+      validate: { query: schema.any() },
+    },
+    async (context, request, response) => {
+      try {
+        const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
+          'indices.getMapping',
+          { index: request.query.index }
+        );
+        return response.ok({
+          body: resp,
+        });
+      } catch (error) {
+        if (error.statusCode !== 404) console.error(error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
     }
-  }
-  )
+  );
 }

--- a/server/routes/dsl.ts
+++ b/server/routes/dsl.ts
@@ -6,7 +6,7 @@
 import { schema } from '@osd/config-schema';
 import { RequestParams } from '@elastic/elasticsearch';
 import { IRouter } from '../../../../src/core/server';
-import DSLFacet from '../services/facets/dsl_facet';
+import { DSLFacet } from '../services/facets/dsl_facet';
 import { DSL_BASE, DSL_SEARCH, DSL_CAT, DSL_MAPPING } from '../../common/constants/shared';
 
 export function registerDslRoute({ router, facet }: { router: IRouter; facet: DSLFacet }) {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -5,9 +5,9 @@
 
 import { IRouter, ILegacyClusterClient } from '../../../../src/core/server';
 import { registerPplRoute } from './ppl';
-import PPLFacet from '../services/facets/ppl_facet';
+import { PPLFacet } from '../services/facets/ppl_facet';
 import { registerDslRoute } from './dsl';
-import DSLFacet from '../services/facets/dsl_facet';
+import { DSLFacet } from '../services/facets/dsl_facet';
 import SavedObjectFacet from '../services/facets/saved_objects';
 import { PanelsRouter } from './custom_panels/panels_router';
 import { VisualizationsRouter } from './custom_panels/visualizations_router';
@@ -15,7 +15,7 @@ import { registerTraceAnalyticsDslRouter } from './trace_analytics_dsl_router';
 import { registerParaRoute } from './notebooks/paraRouter';
 import { registerNoteRoute } from './notebooks/noteRouter';
 import { registerVizRoute } from './notebooks/vizRouter';
-import QueryService from '../services/queryService';
+import { QueryService } from '../services/queryService';
 import { registerSqlRoute } from './notebooks/sqlRouter';
 import { registerEventAnalyticsRouter } from './event_analytics/event_analytics_router';
 import { registerAppAnalyticsRouter } from './application_analytics/app_analytics_router';

--- a/server/routes/metrics/metrics_rounter.ts
+++ b/server/routes/metrics/metrics_rounter.ts
@@ -40,7 +40,7 @@ export function registerMetricsRoute(router: IRouter) {
       path: `${OBSERVABILITY_BASE}/stats`,
       validate: {
         body: schema.object({
-          element: schema.string()
+          element: schema.string(),
         }),
       },
     },

--- a/server/routes/notebooks/noteRouter.ts
+++ b/server/routes/notebooks/noteRouter.ts
@@ -11,7 +11,7 @@ import {
   ResponseError,
 } from '../../../../../src/core/server';
 import { NOTEBOOKS_API_PREFIX, wreckOptions } from '../../../common/constants/notebooks';
-import BACKEND from '../../adaptors/notebooks';
+import { BACKEND } from '../../adaptors/notebooks';
 
 export function registerNoteRoute(router: IRouter) {
   // Fetch all the notebooks available

--- a/server/routes/notebooks/paraRouter.ts
+++ b/server/routes/notebooks/paraRouter.ts
@@ -175,7 +175,7 @@ export function registerParaRoute(router: IRouter) {
       );
       try {
         const updateNotebook: Partial<DefaultNotebooks> = {
-          paragraphs: request.body.paragraphs as Array<DefaultParagraph>,
+          paragraphs: request.body.paragraphs as DefaultParagraph[],
           dateModified: new Date().toISOString(),
         };
         const updateResponse = await BACKEND.updateNote(

--- a/server/routes/notebooks/paraRouter.ts
+++ b/server/routes/notebooks/paraRouter.ts
@@ -11,7 +11,7 @@ import {
   ResponseError,
 } from '../../../../../src/core/server';
 import { NOTEBOOKS_API_PREFIX, wreckOptions } from '../../../common/constants/notebooks';
-import BACKEND from '../../adaptors/notebooks';
+import { BACKEND } from '../../adaptors/notebooks';
 import {
   DefaultNotebooks,
   DefaultParagraph,

--- a/server/routes/notebooks/sqlRouter.ts
+++ b/server/routes/notebooks/sqlRouter.ts
@@ -9,7 +9,7 @@ import {
   IRouter,
   ResponseError,
 } from '../../../../../src/core/server';
-import QueryService from '../../services/queryService';
+import { QueryService } from '../../services/queryService';
 
 export function registerSqlRoute(server: IRouter, service: QueryService) {
   server.post(

--- a/server/routes/ppl.ts
+++ b/server/routes/ppl.ts
@@ -5,7 +5,7 @@
 
 import { schema } from '@osd/config-schema';
 import { IRouter, IOpenSearchDashboardsResponse, ResponseError } from '../../../../src/core/server';
-import PPLFacet from '../services/facets/ppl_facet';
+import { PPLFacet } from '../services/facets/ppl_facet';
 import { PPL_BASE, PPL_SEARCH } from '../../common/constants/shared';
 
 export function registerPplRoute({ router, facet }: { router: IRouter; facet: PPLFacet }) {

--- a/server/routes/ppl.ts
+++ b/server/routes/ppl.ts
@@ -3,50 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { 
-  IRouter,
-  IOpenSearchDashboardsResponse,
-  ResponseError,
- } from '../../../../src/core/server';
 import { schema } from '@osd/config-schema';
+import { IRouter, IOpenSearchDashboardsResponse, ResponseError } from '../../../../src/core/server';
 import PPLFacet from '../services/facets/ppl_facet';
-import {
-  PPL_BASE,
-  PPL_SEARCH
-} from '../../common/constants/shared';
+import { PPL_BASE, PPL_SEARCH } from '../../common/constants/shared';
 
-export function registerPplRoute({
-  router,
-  facet,
-}: {
-  router: IRouter
-  facet: PPLFacet
-}) {
-  router.post({
-    path: `${PPL_BASE}${PPL_SEARCH}`,
-    validate: { 
-      body: schema.object({
-        query: schema.string(),
-        format: schema.string()
-    })}
-  }, 
-  async (
-    context,
-    req,
-    res
-  ) : Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-    const queryRes: any = await facet.describeQuery(req);
-    if (queryRes['success']) {
-      const result: any = {
-        body: {
-          ...queryRes['data']
-        }
-      };
-      return res.ok(result);
+export function registerPplRoute({ router, facet }: { router: IRouter; facet: PPLFacet }) {
+  router.post(
+    {
+      path: `${PPL_BASE}${PPL_SEARCH}`,
+      validate: {
+        body: schema.object({
+          query: schema.string(),
+          format: schema.string(),
+        }),
+      },
+    },
+    async (context, req, res): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      const queryRes: any = await facet.describeQuery(req);
+      if (queryRes.success) {
+        const result: any = {
+          body: {
+            ...queryRes.data,
+          },
+        };
+        return res.ok(result);
+      }
+      return res.custom({
+        statusCode: queryRes.data.statusCode || queryRes.data.status || 500,
+        body: queryRes.data.body || queryRes.data.message || '',
+      });
     }
-    return res.custom({
-      statusCode: queryRes.data.statusCode || queryRes.data.status || 500,
-      body: queryRes.data.body || queryRes.data.message || '',
-    });
-  });
+  );
 }

--- a/server/services/facets/dsl_facet.ts
+++ b/server/services/facets/dsl_facet.ts
@@ -10,32 +10,27 @@ export default class DSLFacet {
     this.client = client;
   }
 
-  private fetch = async( 
-    request: any,
-    format: string,
-    responseFormat: string
-  ) => {
+  private fetch = async (request: any, format: string, responseFormat: string) => {
     const res = {
       success: false,
-      data: {}
+      data: {},
     };
     try {
       const params = {
-        query: JSON.stringify(request.body)
+        query: JSON.stringify(request.body),
       };
       const queryRes = await this.client.asScoped(request).callAsCurrentUser(format, params);
       const dslDataSource = queryRes;
-      res['success'] = true;
-      res['data'] = dslDataSource;
-    }
-    catch (err: any) {
+      res.success = true;
+      res.data = dslDataSource;
+    } catch (err: any) {
       console.error(err);
-      res['data'] = err.body;
+      res.data = err.body;
     }
     return res;
   };
 
   describeQuery = async (request: any) => {
-    return this.fetch(request, 'dsl.dslQuery', 'json')
-  }
-} 
+    return this.fetch(request, 'dsl.dslQuery', 'json');
+  };
+}

--- a/server/services/facets/dsl_facet.ts
+++ b/server/services/facets/dsl_facet.ts
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 
-export default class DSLFacet {
+export class DSLFacet {
   constructor(private client: any) {
     this.client = client;
   }

--- a/server/services/facets/ppl_facet.ts
+++ b/server/services/facets/ppl_facet.ts
@@ -6,7 +6,7 @@
 import _ from 'lodash';
 import { PPLDataSource } from '../../adaptors/ppl_datasource';
 
-export default class PPLFacet {
+export class PPLFacet {
   constructor(private client: any) {
     this.client = client;
   }

--- a/server/services/facets/ppl_facet.ts
+++ b/server/services/facets/ppl_facet.ts
@@ -7,41 +7,36 @@ import _ from 'lodash';
 import { PPLDataSource } from '../../adaptors/ppl_datasource';
 
 export default class PPLFacet {
-
   constructor(private client: any) {
     this.client = client;
   }
-  
-  private fetch = async (
-    request: any,
-    format: string,
-    responseFormat: string
-  ) => {
+
+  private fetch = async (request: any, format: string, responseFormat: string) => {
     const res = {
       success: false,
-      data: {}
+      data: {},
     };
     try {
       const params = {
         body: {
-          query: request.body.query
-        }
+          query: request.body.query,
+        },
       };
       if (request.body.format !== 'jdbc') {
-        params['format'] = request.body.format;
+        params.format = request.body.format;
       }
       const queryRes = await this.client.asScoped(request).callAsCurrentUser(format, params);
       const pplDataSource = new PPLDataSource(queryRes, request.body.format);
-      res['success'] = true;
-      res['data'] = pplDataSource.getDataSource();
+      res.success = true;
+      res.data = pplDataSource.getDataSource();
     } catch (err: any) {
       console.error('PPL query fetch err: ', err);
-      res['data'] = err;
+      res.data = err;
     }
-    return res
+    return res;
   };
 
   describeQuery = async (request: any) => {
     return this.fetch(request, 'ppl.pplQuery', 'json');
-  }
+  };
 }

--- a/server/services/queryService.ts
+++ b/server/services/queryService.ts
@@ -11,12 +11,12 @@ export default class QueryService {
   private client: any;
   constructor(client: any) {
     this.client = client;
-  }    
+  }
 
   describeQueryInternal = async (request: any, format: string, responseFormat: string) => {
     try {
       const queryRequest = {
-        query: request.body
+        query: request.body,
       };
       const params = {
         body: JSON.stringify(queryRequest),
@@ -34,7 +34,7 @@ export default class QueryService {
         data: {
           ok: false,
           resp: err.response,
-          body: err.body
+          body: err.body,
         },
       };
     }
@@ -42,9 +42,9 @@ export default class QueryService {
 
   describeSQLQuery = async (request: any) => {
     return this.describeQueryInternal(request, 'ppl.sqlQuery', 'json');
-  }
+  };
 
   describePPLQuery = async (request: any) => {
     return this.describeQueryInternal(request, 'ppl.pplQuery', 'json');
-  }
+  };
 }

--- a/server/services/queryService.ts
+++ b/server/services/queryService.ts
@@ -7,7 +7,7 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import _ from 'lodash';
 
-export default class QueryService {
+export class QueryService {
   private client: any;
   constructor(client: any) {
     this.client = client;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,57 +3,58 @@
 
 
 "@algolia/autocomplete-core@^1.4.1":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.9.4.tgz#4dfea22c8558c90f4ff107633efb298df382aef3"
-  integrity sha512-sakE1Lks15UXKHkjDyxZ7yT/fGrHrmvlfQ1Fz3m/cqXxBUhBtD5AKuuSpPUW0M/SaTnGSOf/8jJnOcyjznZ1UA==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.11.0.tgz#9db68f2aa38fe3149507d214082a1926b6b91fac"
+  integrity sha512-kFtn8XPMdE1QGDxyMTObGgaUpq5lcG2fLVsda6E88MoZZsfYkC8Oua6dwa0b06/GpgEWaliby/7AksUqz05uzw==
   dependencies:
-    "@algolia/autocomplete-plugin-algolia-insights" "1.9.4"
-    "@algolia/autocomplete-shared" "1.9.4"
+    "@algolia/autocomplete-plugin-algolia-insights" "1.11.0"
+    "@algolia/autocomplete-shared" "1.11.0"
 
-"@algolia/autocomplete-plugin-algolia-insights@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.4.tgz#57181d5b88ea750826b74e1f58d17a826c9d12a2"
-  integrity sha512-1ZzFX3wDYWUPPwEWmjEjBlYa4oWaI57ntPIEMVNB+vdPYLy9QCroRsKruCHgmD1+GekAdEj7ayYkDlbB//kdiw==
+"@algolia/autocomplete-plugin-algolia-insights@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.11.0.tgz#edae2ebe5d88afe62ce3efa1723289e5ae376ce3"
+  integrity sha512-TsJ5vs1jR9IbYDRWnd0tHLF/y54quoSAV7fDbyDdfUdkuI9bVP0bzulxT+POezPT5+6Ya5IJNCrg4DViA3Dm0Q==
   dependencies:
-    "@algolia/autocomplete-shared" "1.9.4"
+    "@algolia/autocomplete-shared" "1.11.0"
 
-"@algolia/autocomplete-shared@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.4.tgz#7b008675d6fd26e31e35629a78b531faa8cba672"
-  integrity sha512-4iEdI9K2BXEATYeptL2ZVJPNQ5Zd42WTqjnLPsuJCUwPTnrnpHZEJcmUQYktnMnbgvvVzIByRrRJ1NSLQOno3w==
+"@algolia/autocomplete-shared@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.11.0.tgz#2ba14b056e695ad2bbd0eb04f5d6dcbd3584c751"
+  integrity sha512-ug1HYGQfe8+bvGuVJ3Fbdxn+YvR6MHPD36vQ5kv+5WWnBiW+QTyGk5yiluS9+i81l9wxH34Zl3XN/6MQ68MAgw==
 
 "@algolia/autocomplete-theme-classic@^1.2.1":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.9.4.tgz#6400359de17fe0c698eb65303f67cea53175bb08"
-  integrity sha512-ydeYji3VKIPRFHTnIBVbwocFs9FOKLJnQtYIqmT3z3SVhsceeju2XUD9v3jZRrKb9FVrs1oKQaw0MsessZXMkw==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.11.0.tgz#3523744fc244f1979850560a898f5c562664ee08"
+  integrity sha512-R6k8D/6rwI5EQliVweK+JvX6JAF2cnzJvWhfgwOkdkVHYX3RT9yXR8aE7m6Rxv8wtQpivGsCKeTEJl2jD5goEw==
 
 "@babel/code-frame@^7.0.0":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
-  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.10.tgz#1c20e612b768fefa75f6e90d6ecb86329247f0a3"
+  integrity sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==
   dependencies:
-    "@babel/highlight" "^7.22.5"
+    "@babel/highlight" "^7.22.10"
+    chalk "^2.4.2"
 
 "@babel/helper-validator-identifier@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
   integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
-"@babel/highlight@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
-  integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
+"@babel/highlight@^7.22.10":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.10.tgz#02a3f6d8c1cb4521b2fd0ab0da8f4739936137d7"
+  integrity sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.22.5"
-    chalk "^2.0.0"
+    chalk "^2.4.2"
     js-tokens "^4.0.0"
 
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.9.2":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
-  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
   dependencies:
-    regenerator-runtime "^0.13.11"
+    regenerator-runtime "^0.14.0"
 
 "@blueprintjs/colors@^4.0.0-alpha.3":
   version "4.2.1"
@@ -97,15 +98,20 @@
     classnames "^2.2"
     tslib "~2.3.1"
 
-"@colors/colors@1.5.0", "@colors/colors@^1.5.0":
+"@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cypress/request@^2.88.10":
-  version "2.88.11"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.11.tgz#5a4c7399bc2d7e7ed56e92ce5acb620c8b187047"
-  integrity sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==
+"@colors/colors@^1.5.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
+"@cypress/request@2.88.12":
+  version "2.88.12"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
+  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -122,7 +128,7 @@
     performance-now "^2.1.0"
     qs "~6.10.3"
     safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
+    tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
@@ -152,19 +158,19 @@
     gud "^1.0.0"
     warning "^4.0.3"
 
-"@jest/schemas@^29.4.3":
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.4.3.tgz#39cf1b8469afc40b6f5a2baaa146e332c4151788"
-  integrity sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
-    "@sinclair/typebox" "^0.25.16"
+    "@sinclair/typebox" "^0.27.8"
 
-"@jest/types@^29.5.0":
-  version "29.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.5.0.tgz#f59ef9b031ced83047c67032700d8c807d6e1593"
-  integrity sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
   dependencies:
-    "@jest/schemas" "^29.4.3"
+    "@jest/schemas" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -224,10 +230,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@sinclair/typebox@^0.25.16":
-  version "0.25.24"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
-  integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
 "@types/cheerio@*":
   version "0.22.31"
@@ -257,11 +263,11 @@
     "@types/react" "^16"
 
 "@types/hast@^2.0.0":
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
-  integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.5.tgz#08caac88b44d0fdd04dc17a19142355f43bd8a7a"
+  integrity sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==
   dependencies:
-    "@types/unist" "*"
+    "@types/unist" "^2"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.4"
@@ -288,19 +294,19 @@
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
 "@types/node@*":
-  version "20.3.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.2.tgz#fa6a90f2600e052a03c18b8cb3fd83dd4e599898"
-  integrity sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==
+  version "20.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.4.tgz#4666fb40f9974d60c53c4ff554315860ba4feab8"
+  integrity sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==
 
-"@types/node@^14.14.31":
-  version "14.18.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.52.tgz#214674cbff9f86fad4bf0c25f31ab9b9fa31110f"
-  integrity sha512-DGhiXKOHSFVVm+PJD+9Y0ObxXLeG6qwc0HoOn+ooQKeNNu+T2mEJCM5UBDUREKAggl9MHYjb5E71PAmx6MbzIg==
+"@types/node@^16.18.39":
+  version "16.18.44"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.44.tgz#3c3ea2a832014b869f0f370630d98bb026171e76"
+  integrity sha512-PZXtT+wqSMHnLPVExTh+tMt1VK+GvjRLsGZMbcQ4Mb/cG63xJig/TUmgrDa9aborl2i22UnpIzHYNu7s97NbBQ==
 
 "@types/plotly.js@*":
-  version "2.12.18"
-  resolved "https://registry.yarnpkg.com/@types/plotly.js/-/plotly.js-2.12.18.tgz#7a231ce72a73fafe4842096b8c99d10a41b60962"
-  integrity sha512-ff+CIEWnqZNjZqHtQZvkEAVuLs9fkm1f54QnPVmgoET7wMHdSqUka2hasVN4e5yfHD05YwGjsAtCseewJh/BMw==
+  version "2.12.26"
+  resolved "https://registry.yarnpkg.com/@types/plotly.js/-/plotly.js-2.12.26.tgz#42c7b98a462645af56bdcb00349cf0beaae96fe1"
+  integrity sha512-vP1iaVL4HHYSbugv49pwtLL6D9CSqOnQLjiRRdRYjVMEDbjIWhMgxc49BJAxSUShupiJHDp35e0WJS9SwIB2WA==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -323,18 +329,18 @@
     "@types/react" "^16"
 
 "@types/react@*":
-  version "18.2.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
-  integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
+  version "18.2.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
+  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/react@^16":
-  version "16.14.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.43.tgz#bc6e7a0e99826809591d38ddf1193955de32c446"
-  integrity sha512-7zdjv7jvoLLQg1tTvpQsm+hyNUMT2mPlNV1+d0I8fbGhkJl82spopMyBlu4wb1dviZAxpGdk5eHu/muacknnfw==
+  version "16.14.46"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.46.tgz#42ac91aece416176e6b6127cd9ec9e381ea67e16"
+  integrity sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -362,10 +368,10 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
   integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
-"@types/unist@*":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
-  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+"@types/unist@^2":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.7.tgz#5b06ad6894b236a1d2bd6b2f07850ca5c59cf4d6"
+  integrity sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -463,6 +469,13 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-5.0.0.tgz#b6a0caf0eef0c41af190e9a749e0c00ec04bb2a6"
+  integrity sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==
+  dependencies:
+    type-fest "^1.0.2"
+
 ansi-regex@^4.1.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -482,7 +495,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.0.0:
+ansi-styles@^6.0.0, ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -670,9 +683,9 @@ buffer@^5.6.0:
     ieee754 "^1.1.13"
 
 cachedir@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
-  integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
+  integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
 
 call-bind@^1.0.2:
   version "1.0.2"
@@ -702,12 +715,12 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
-chalk@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
+chalk@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -786,6 +799,13 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-cursor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
+  integrity sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==
+  dependencies:
+    restore-cursor "^4.0.0"
+
 cli-table3@^0.6.0, cli-table3@~0.6.1:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
@@ -863,7 +883,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^2.0.16, colorette@^2.0.19:
+colorette@^2.0.16, colorette@^2.0.20:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
@@ -880,10 +900,10 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
-  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+commander@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
+  integrity sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==
 
 commander@^6.2.1:
   version "6.2.1"
@@ -963,13 +983,13 @@ cypress-watch-and-reload@^1.10.6:
     ws "8.13.0"
 
 cypress@^12.8.1:
-  version "12.16.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.16.0.tgz#d0dcd0725a96497f4c60cf54742242259847924c"
-  integrity sha512-mwv1YNe48hm0LVaPgofEhGCtLwNIQEjmj2dJXnAkY1b4n/NE9OtgPph4TyS+tOtYp5CKtRmDvBzWseUXQTjbTg==
+  version "12.17.4"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.4.tgz#b4dadf41673058493fa0d2362faa3da1f6ae2e6c"
+  integrity sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "2.88.12"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
+    "@types/node" "^16.18.39"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
@@ -1002,9 +1022,10 @@ cypress@^12.8.1:
     minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -1018,11 +1039,11 @@ dashdash@^1.12.0:
     assert-plus "^1.0.0"
 
 dayjs@^1.10.4:
-  version "1.11.8"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.8.tgz#4282f139c8c19dd6d0c7bd571e30c2d0ba7698ea"
-  integrity sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==
+  version "1.11.9"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
+  integrity sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==
 
-debug@4.3.3, debug@^3.1.0, debug@^4.0.1, debug@^4.1.1, debug@^4.3.4:
+debug@4.3.3, debug@4.3.4, debug@^3.1.0, debug@^4.0.1, debug@^4.1.1, debug@^4.3.4:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -1159,11 +1180,12 @@ end-of-stream@^1.1.0:
     once "^1.4.0"
 
 enquirer@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
+  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
   dependencies:
     ansi-colors "^4.1.1"
+    strip-ansi "^6.0.1"
 
 entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
@@ -1301,6 +1323,11 @@ eventemitter2@6.4.7:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.7.tgz#a7f6c4d7abf28a14c1ef3442f21cb306a054271d"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 execa@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
@@ -1316,10 +1343,10 @@ execa@4.1.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-7.1.1.tgz#3eb3c83d239488e7b409d48e8813b76bb55c9c43"
-  integrity sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==
+execa@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-7.2.0.tgz#657e75ba984f42a70f38928cedc87d6f2d4fe4e9"
+  integrity sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==
   dependencies:
     cross-spawn "^7.0.3"
     get-stream "^6.0.1"
@@ -1502,9 +1529,9 @@ fs.realpath@^1.0.0:
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1985,11 +2012,11 @@ jest-dom@^4.0.0:
   integrity sha512-gBxYZlZB1Jgvf2gP2pRfjjUWF8woGBHj/g5rAQgFPB/0K2atGuhVcPO+BItyjWeKg9zM+dokgcMOH01vrWVMFA==
 
 jest-util@^29.0.0:
-  version "29.5.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.5.0.tgz#24a4d3d92fc39ce90425311b23c27a6e0ef16b8f"
-  integrity sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.6.3.tgz#e15c3eac8716440d1ed076f09bc63ace1aebca63"
+  integrity sha512-QUjna/xSy4B32fzcKTSz1w7YYzgiHrjjJjevdRf61HYk998R5vVMMNmrHESYZVDS5DSWs+1srPLPKxXPkeSDOA==
   dependencies:
-    "@jest/types" "^29.5.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -2089,23 +2116,32 @@ lilconfig@2.1.0:
   integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
 
 lint-staged@^13.1.0:
-  version "13.2.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.3.tgz#f899aad6c093473467e9c9e316e3c2d8a28f87a7"
-  integrity sha512-zVVEXLuQIhr1Y7R7YAWx4TZLdvuzk7DnmrsTNL0fax6Z3jrpFcas+vKbzxhhvp6TA55m1SQuWkpzI1qbfDZbAg==
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.3.0.tgz#7965d72a8d6a6c932f85e9c13ccf3596782d28a5"
+  integrity sha512-mPRtrYnipYYv1FEE134ufbWpeggNTo+O/UPzngoaKzbzHAthvR55am+8GfHTnqNRQVRRrYQLGW9ZyUoD7DsBHQ==
   dependencies:
-    chalk "5.2.0"
-    cli-truncate "^3.1.0"
-    commander "^10.0.0"
-    debug "^4.3.4"
-    execa "^7.0.0"
+    chalk "5.3.0"
+    commander "11.0.0"
+    debug "4.3.4"
+    execa "7.2.0"
     lilconfig "2.1.0"
-    listr2 "^5.0.7"
-    micromatch "^4.0.5"
-    normalize-path "^3.0.0"
-    object-inspect "^1.12.3"
-    pidtree "^0.6.0"
-    string-argv "^0.3.1"
-    yaml "^2.2.2"
+    listr2 "6.6.1"
+    micromatch "4.0.5"
+    pidtree "0.6.0"
+    string-argv "0.3.2"
+    yaml "2.3.1"
+
+listr2@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-6.6.1.tgz#08b2329e7e8ba6298481464937099f4a2cd7f95d"
+  integrity sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==
+  dependencies:
+    cli-truncate "^3.1.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^5.0.1"
+    rfdc "^1.3.0"
+    wrap-ansi "^8.1.0"
 
 listr2@^3.8.3:
   version "3.14.0"
@@ -2118,20 +2154,6 @@ listr2@^3.8.3:
     p-map "^4.0.0"
     rfdc "^1.3.0"
     rxjs "^7.5.1"
-    through "^2.3.8"
-    wrap-ansi "^7.0.0"
-
-listr2@^5.0.7:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-5.0.8.tgz#a9379ffeb4bd83a68931a65fb223a11510d6ba23"
-  integrity sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==
-  dependencies:
-    cli-truncate "^2.1.0"
-    colorette "^2.0.19"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rfdc "^1.3.0"
-    rxjs "^7.8.0"
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
@@ -2202,6 +2224,17 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+log-update@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-5.0.1.tgz#9e928bf70cb183c1f0c9e91d9e6b7115d597ce09"
+  integrity sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==
+  dependencies:
+    ansi-escapes "^5.0.0"
+    cli-cursor "^4.0.0"
+    slice-ansi "^5.0.0"
+    strip-ansi "^7.0.1"
+    wrap-ansi "^8.0.1"
+
 loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -2246,7 +2279,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-micromatch@^4.0.5:
+micromatch@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -2330,11 +2363,6 @@ mocha@~9.2.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-mock-fs@^4.12.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
-  integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
-
 ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -2388,11 +2416,6 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
-object-inspect@^1.12.3:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
-  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -2561,7 +2584,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pidtree@^0.6.0:
+pidtree@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
@@ -2572,9 +2595,9 @@ pify@^2.2.0:
   integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 plotly.js-dist@^2.2.0:
-  version "2.24.2"
-  resolved "https://registry.yarnpkg.com/plotly.js-dist/-/plotly.js-dist-2.24.2.tgz#31d067343cdd944f20ce78e7d16fef7f0ec90efd"
-  integrity sha512-J5Jg6mAkMwzjHsfLlZaZiS11ntKvdkyP5C1Re2SFL5dXL7Nb66BGGpu3UopbIUaopLVJBiYu9kvOfUTjy0rHFQ==
+  version "2.25.2"
+  resolved "https://registry.yarnpkg.com/plotly.js-dist/-/plotly.js-dist-2.25.2.tgz#0d8625fe05c21fea77d2a5473ff5d5f904788b64"
+  integrity sha512-C2hsTfqAZGRJYJBTZx2+eN6BKZPZC4nvy0ejFU1VW88IBO85xuZYDRUnILMgX0CQ3i26PVfYaR2BWO8Af7KqPQ==
 
 popper.js@^1.14.4, popper.js@^1.16.1:
   version "1.16.1"
@@ -2606,6 +2629,11 @@ prismjs@^1.22.0, prismjs@^1.27.0, prismjs@~1.27.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
 progress@^2.0.0:
   version "2.0.3"
@@ -2674,9 +2702,9 @@ randombytes@^2.1.0:
     safe-buffer "^5.1.0"
 
 re-resizable@^6.5.0:
-  version "6.9.9"
-  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.9.tgz#99e8b31c67a62115dc9c5394b7e55892265be216"
-  integrity sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==
+  version "6.9.11"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.11.tgz#f356e27877f12d926d076ab9ad9ff0b95912b475"
+  integrity sha512-a3hiLWck/NkmyLvGWUuvkAmN1VhwAz4yOhS6FdMTaxCUVN9joIWkT11wsO68coG/iEYuwn+p/7qAmfQzRhiPLQ==
 
 react-base16-styling@^0.7.0:
   version "0.7.0"
@@ -2819,10 +2847,10 @@ refractor@^3.6.0:
     parse-entities "^2.0.0"
     prismjs "~1.27.0"
 
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regexp.prototype.flags@^1.2.0:
   version "1.5.0"
@@ -2926,6 +2954,14 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-4.0.0.tgz#519560a4318975096def6e609d44100edaa4ccb9"
+  integrity sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
@@ -2957,7 +2993,7 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.5.1, rxjs@^7.8.0:
+rxjs@^7.5.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
@@ -2981,7 +3017,7 @@ sanitize-filename@*, sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-semver@7.x, semver@^5.5.0, semver@^6.1.2, semver@^7.3.2, semver@^7.5.2:
+semver@^5.5.0, semver@^6.1.2, semver@^7.5.2, semver@^7.5.3:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -3094,7 +3130,7 @@ state-toggle@^1.0.0:
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
   integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
 
-string-argv@^0.3.1:
+string-argv@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
@@ -3117,7 +3153,7 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.0:
+string-width@^5.0.0, string-width@^5.0.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -3229,7 +3265,7 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^4.1.3, tough-cookie@~2.5.0:
+tough-cookie@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
   integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
@@ -3262,9 +3298,9 @@ truncate-utf8-bytes@^1.0.0:
     utf8-byte-length "^1.0.1"
 
 ts-jest@^29.1.0:
-  version "29.1.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.0.tgz#4a9db4104a49b76d2b368ea775b6c9535c603891"
-  integrity sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
+  integrity sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
@@ -3272,7 +3308,7 @@ ts-jest@^29.1.0:
     json5 "^2.2.3"
     lodash.memoize "4.x"
     make-error "1.x"
-    semver "7.x"
+    semver "^7.5.3"
     yargs-parser "^21.0.1"
 
 tslib@^1.9.0:
@@ -3281,9 +3317,9 @@ tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.1.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
-  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@~2.3.1:
   version "2.3.1"
@@ -3323,6 +3359,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 typed-styles@^0.0.7:
   version "0.0.7"
@@ -3431,9 +3472,9 @@ uuid@^8.3.2:
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
+  integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
 verror@1.10.0:
   version "1.10.0"
@@ -3503,9 +3544,9 @@ which@^1.2.9:
     isexe "^2.0.0"
 
 word-wrap@~1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
-  integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 workerpool@6.2.0:
   version "6.2.0"
@@ -3529,6 +3570,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -3572,7 +3622,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.2.2:
+yaml@2.3.1, yaml@^2.2.2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
   integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==


### PR DESCRIPTION
### Description
As part of the long-term goal of #676, this is a small maintenance PR that fixes all linting errors for the `server` directory. In addition to autofixable lints that form the majority of the errors (the first commit), this PR addresses 16 manual-fix problems (the rest of them). I also found one unused dev dependency that I removed.

After this PR, there are 999 `yarn lint` errors remaining in other directories, which reduces to 166 when running `yarn lint --fix`. Saving from running a full `--fix` to reduce the surface for merge conflicts.

<details>
  <summary>16 manually fixed problems</summary>
  <pre><code>yarn run v1.22.19
$ yarn lint:es server
$ node ../../scripts/eslint server

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
   11:11  error  Interface name `boxType` must match one of the following formats: PascalCase, UPPER_CASE             @typescript-eslint/naming-convention
  278:11  error  Variable name `x_left` must match one of the following formats: camelCase, UPPER_CASE, PascalCase    @typescript-eslint/naming-convention
  279:11  error  Variable name `y_top` must match one of the following formats: camelCase, UPPER_CASE, PascalCase     @typescript-eslint/naming-convention
  280:11  error  Variable name `x_right` must match one of the following formats: camelCase, UPPER_CASE, PascalCase   @typescript-eslint/naming-convention
  281:11  error  Variable name `y_bottom` must match one of the following formats: camelCase, UPPER_CASE, PascalCase  @typescript-eslint/naming-convention

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/adaptors/notebooks/default_backend.ts
  80:9  error  Expected an error object to be thrown  no-throw-literal

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/adaptors/notebooks/index.ts
  13:32  error  Expected '===' and instead saw '=='  eqeqeq
  17:8   error  Prefer named exports                 import/no-default-export

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/common/helpers/notebooks/query_helpers.ts
  32:31  error  Expected '!==' and instead saw '!='  eqeqeq
  33:31  error  Expected '!==' and instead saw '!='  eqeqeq
  34:31  error  Expected '!==' and instead saw '!='  eqeqeq

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/common/metrics/metrics_helper.ts
  49:3  error  These overloads can be combined into one signature taking `{ statusCode: number } | CounterNameType`  @typescript-eslint/unified-signatures

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/routes/application_analytics/app_analytics_router.ts
  5:19  error  'no-console' rule is disabled but never reported  eslint-comments/no-unused-disable

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/services/facets/dsl_facet.ts
  8:8  error  Prefer named exports  import/no-default-export

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/services/facets/ppl_facet.ts
  9:8  error  Prefer named exports  import/no-default-export

/Users/sawiddis/Documents/code/dashboards/plugins/dashboards-observability/server/services/queryService.ts
  10:8  error  Prefer named exports  import/no-default-export

✖ 16 problems (16 errors, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.</code></pre>
</details>

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
