### PR TITLE
WIP - Enable PRomQL Query Language on Log Explorer

### DIFF
--- a/common/constants/explorer.ts
+++ b/common/constants/explorer.ts
@@ -13,6 +13,9 @@ export const OPEN_TELEMETRY_LOG_CORRELATION_LINK =
   'https://opentelemetry.io/docs/reference/specification/logs/overview/#log-correlation';
 export const RAW_QUERY = 'rawQuery';
 export const FINAL_QUERY = 'finalQuery';
+export const QUERY_LANGUAGE = 'queryLanguage';
+export const QUERY_LANGUAGE_PPL = 'PPL';
+export const QUERY_LANGUAGE_PROMQL = 'PromQL';
 export const SELECTED_DATE_RANGE = 'selectedDateRange';
 export const INDEX = 'index';
 export const SELECTED_PATTERN_FIELD = 'selectedPatternField';

--- a/common/utils/ppl_query_util.ts
+++ b/common/utils/ppl_query_util.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isEmpty } from 'lodash';
+import datemath from '@elastic/datemath';
+
+import { QueryUtil, QueryUtilPreProcessInput } from './query_utils';
+import {
+  DATE_PICKER_FORMAT,
+  PPL_DEFAULT_PATTERN_REGEX_FILETER,
+} from '../../common/constants/explorer';
+import {
+  PPL_INDEX_INSERT_POINT_REGEX,
+  PPL_INDEX_REGEX,
+  PPL_NEWLINE_REGEX,
+} from '../../common/constants/shared';
+
+export class PPLQueryUtil extends QueryUtil {
+  // insert time filter command and additional commands based on raw query
+  public preProcessQuery({
+    rawQuery,
+    startTime,
+    endTime,
+    timeField,
+    isLiveQuery,
+    selectedPatternField,
+    patternRegex,
+    filteredPattern,
+    whereClause,
+  }: QueryUtilPreProcessInput) {
+    let finalQuery = '';
+
+    if (isEmpty(rawQuery)) return finalQuery;
+
+    // convert to moment
+    const start = datemath.parse(startTime)?.utc().format(DATE_PICKER_FORMAT);
+    const end = datemath.parse(endTime, { roundUp: true })?.utc().format(DATE_PICKER_FORMAT);
+    const tokens = rawQuery.replaceAll(PPL_NEWLINE_REGEX, '').match(PPL_INDEX_INSERT_POINT_REGEX);
+
+    if (isEmpty(tokens)) return finalQuery;
+
+    finalQuery = `${tokens![1]}=${
+      tokens![2]
+    } | where ${timeField} >= '${start}' and ${timeField} <= '${end}'`;
+
+    if (whereClause) {
+      finalQuery += ` AND ${whereClause}`;
+    }
+
+    finalQuery += tokens![3];
+
+    if (isLiveQuery) {
+      finalQuery = finalQuery + ` | sort - ${timeField}`;
+    }
+
+    // if a pattern is selected as filter, build it into finalQuery
+    if (selectedPatternField && filteredPattern)
+      finalQuery = this.buildPatternsQuery(
+        finalQuery,
+        selectedPatternField,
+        patternRegex,
+        filteredPattern
+      );
+
+    return finalQuery;
+  }
+
+  public buildRawQuery(query: any, appBaseQuery: string) {
+    const rawQueryStr = (query.rawQuery as string).includes(appBaseQuery)
+      ? query.rawQuery
+      : this.buildQuery(appBaseQuery, query.rawQuery);
+    return rawQueryStr;
+  }
+
+  private buildQuery(baseQuery: string, currQuery: string) {
+    let fullQuery: string;
+    if (baseQuery) {
+      fullQuery = baseQuery;
+      if (currQuery) {
+        fullQuery += '| ' + currQuery;
+      }
+    } else {
+      fullQuery = currQuery;
+    }
+    return fullQuery;
+  }
+
+  private buildPatternsQuery(
+    baseQuery: string,
+    selectedPatternField?: string,
+    patternRegex?: string,
+    filteredPattern?: string
+  ) {
+    let finalQuery = baseQuery;
+    if (selectedPatternField) {
+      finalQuery += ` | patterns `;
+      if (patternRegex && patternRegex !== PPL_DEFAULT_PATTERN_REGEX_FILETER) {
+        finalQuery += `pattern='${this.escapeQuotes(patternRegex)}' `;
+      }
+      finalQuery += `\`${selectedPatternField}\` `;
+      if (filteredPattern) {
+        finalQuery += `| where patterns_field='${this.escapeQuotes(filteredPattern)}'`;
+      }
+    }
+    return finalQuery;
+  }
+
+  /**
+   * @param literal - string literal that will be put inside single quotes in PPL command
+   * @returns string with inner single quotes escaped
+   */
+  private escapeQuotes(literal: string) {
+    return literal.replaceAll("'", "''");
+  }
+}

--- a/common/utils/promql_query_util.ts
+++ b/common/utils/promql_query_util.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { QueryUtil } from './query_utils';
+
+export class PromQLQueryUtil extends QueryUtil {}

--- a/public/components/common/search/search.scss
+++ b/public/components/common/search/search.scss
@@ -56,7 +56,7 @@
   border: unset;
   position: absolute;
   top: 14px;
-  right: 15px;
+  right: 45px;
   background-color: transparent;
 }
 .ppl-link-light {
@@ -72,4 +72,8 @@
   font-size: 17px;
   margin-top: 14px;
   background-color: transparent;
+}
+
+.query-language {
+
 }

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -18,6 +18,7 @@ import {
   EuiContextMenuPanel,
   EuiToolTip,
   EuiCallOut,
+  EuiSelect,
 } from '@elastic/eui';
 import { DatePicker } from './date_picker';
 import '@algolia/autocomplete-theme-classic';
@@ -90,6 +91,7 @@ export const Search = (props: any) => {
   const appLogEvents = tabId.match(APP_ANALYTICS_TAB_ID_REGEX);
   const [isSavePanelOpen, setIsSavePanelOpen] = useState(false);
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const [queryLanguage, setQueryLanguage] = useState('ppl');
 
   const closeFlyout = () => {
     setIsFlyoutVisible(false);
@@ -164,6 +166,19 @@ export const Search = (props: any) => {
           >
             PPL
           </EuiBadge>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSelect
+            id="queryLanguage"
+            className="query-language"
+            options={[
+              { value: 'ppl', text: 'PPL' },
+              { value: 'promql', text: 'PromQl' },
+            ]}
+            value={queryLanguage}
+            onChange={(e) => setQueryLanguage(e.target.value)}
+            aria-label="Query Language"
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false} />
         <EuiFlexItem className="euiFlexItem--flexGrowZero event-date-picker" grow={false}>

--- a/public/components/custom_panels/helpers/utils.tsx
+++ b/public/components/custom_panels/helpers/utils.tsx
@@ -260,6 +260,8 @@ export const renderSavedVisualization = async (
 
   visualization = await fetchVisualizationById(http, savedVisualizationId, setIsError);
 
+  console.log('renderSavedVisualization', { visualization });
+
   if (_.isEmpty(visualization)) {
     setIsLoading(false);
     return;

--- a/public/components/event_analytics/redux/slices/query_slice.ts
+++ b/public/components/event_analytics/redux/slices/query_slice.ts
@@ -11,6 +11,8 @@ import {
   INDEX,
   PATTERN_REGEX,
   PPL_DEFAULT_PATTERN_REGEX_FILETER,
+  QUERY_LANGUAGE,
+  QUERY_LANGUAGE_PPL,
   RAW_QUERY,
   REDUX_EXPL_SLICE_QUERIES,
   SELECTED_DATE_RANGE,
@@ -22,6 +24,7 @@ import { initialTabId } from '../../../../framework/redux/store/shared_state';
 const initialQueryState = {
   [RAW_QUERY]: '',
   [FINAL_QUERY]: '',
+  [QUERY_LANGUAGE]: QUERY_LANGUAGE_PPL,
   [INDEX]: '',
   [SELECTED_PATTERN_FIELD]: '',
   [PATTERN_REGEX]: PPL_DEFAULT_PATTERN_REGEX_FILETER,
@@ -33,6 +36,7 @@ const initialQueryState = {
 const appBaseQueryState = {
   [RAW_QUERY]: '',
   [FINAL_QUERY]: '',
+  [QUERY_LANGUAGE]: QUERY_LANGUAGE_PPL,
   [INDEX]: '',
   [SELECTED_PATTERN_FIELD]: '',
   [PATTERN_REGEX]: PPL_DEFAULT_PATTERN_REGEX_FILETER,

--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -4,14 +4,11 @@
  */
 
 import { isEmpty } from 'lodash';
+import { QueryUtil } from 'common/utils/query_utils';
 import { IDefaultTimestampState, IQuery } from '../../../../common/types/explorer';
 import { IDataFetcher } from '../fetch_interface';
 import { DataFetcherBase } from '../fetcher_base';
-import {
-  buildRawQuery,
-  composeFinalQuery,
-  getIndexPatternFromRawQuery,
-} from '../../../../common/utils';
+import { composeFinalQuery, getIndexPatternFromRawQuery } from '../../../../common/utils';
 import {
   FILTERED_PATTERN,
   PATTERNS_REGEX,
@@ -24,17 +21,34 @@ import {
 } from '../../../../common/constants/explorer';
 import { PPL_STATS_REGEX } from '../../../../common/constants/shared';
 
+interface PPLDataFetcherOpts {
+  readonly query: IQuery;
+  readonly queryUtilProcessor: QueryUtil;
+  readonly storeContext;
+  readonly searchContext;
+  readonly searchParams;
+  readonly notifications;
+}
+
 export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
   protected queryIndex: string;
   protected timestamp!: string;
-  constructor(
-    protected readonly query: IQuery,
-    protected readonly storeContext,
-    protected readonly searchContext,
-    protected readonly searchParams,
-    protected readonly notifications
-  ) {
+
+  readonly query: IQuery;
+  readonly queryUtilProcessor: QueryUtil;
+  readonly storeContext;
+  readonly searchContext;
+  readonly searchParams;
+  readonly notifications;
+
+  constructor(options: PPLDataFetcherOpts) {
     super();
+    this.query = options.query;
+    this.queryUtilProcessor = options.queryUtilProcessor;
+    this.storeContext = options.storeContext;
+    this.searchContext = options.searchContext;
+    this.searchParams = options.searchParams;
+    this.notifications = options.notifications;
   }
 
   async setTimestamp(index: string) {
@@ -67,7 +81,7 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
 
     if (isEmpty(query)) return;
 
-    this.queryIndex = this.getIndex(buildRawQuery(query, appBaseQuery));
+    this.queryIndex = this.getIndex(this.queryUtilProcessor.buildRawQuery(query, appBaseQuery));
 
     if (this.queryIndex === '') return; // Returns if page is refreshed
 


### PR DESCRIPTION
Signed-off-by: Peter Fitzgibbons <peter.fitzgibbons@gmail.com>

### Description
Enable PromQL as a query-language input on Log Explorer, as an option along side of PPL.

Functions required to modify input query from Search Query box into useable PPL data request are combined into utility classes, extended from new abstract class QueryInput.

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/302

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
