### PR TITLE
Move query_utils to /public

### DIFF
--- a/common/utils/index.ts
+++ b/common/utils/index.ts
@@ -10,6 +10,6 @@ export {
   buildRawQuery,
   composeFinalQuery,
   removeBacktick,
-} from './query_utils';
+} from '../../public/components/common/query_utils';
 
 export * from './core_services';

--- a/public/components/application_analytics/helpers/utils.tsx
+++ b/public/components/application_analytics/helpers/utils.tsx
@@ -16,7 +16,7 @@ import { NEW_SELECTED_QUERY_TAB, TAB_CREATED_TYPE } from '../../../../common/con
 import { SPAN_REGEX } from '../../../../common/constants/shared';
 import { VisualizationType } from '../../../../common/types/custom_panels';
 import { IField } from '../../../../common/types/explorer';
-import { preprocessQuery } from '../../../../common/utils/query_utils';
+import { preprocessQuery } from '../../common/query_utils';
 import { fetchVisualizationById } from '../../../components/custom_panels/helpers/utils';
 import {
   init as initFields,

--- a/public/components/common/query_utils.ts
+++ b/public/components/common/query_utils.ts
@@ -8,12 +8,12 @@ import { isEmpty } from 'lodash';
 import {
   DATE_PICKER_FORMAT,
   PPL_DEFAULT_PATTERN_REGEX_FILETER,
-} from '../../common/constants/explorer';
+} from '../../../common/constants/explorer';
 import {
   PPL_INDEX_INSERT_POINT_REGEX,
   PPL_INDEX_REGEX,
   PPL_NEWLINE_REGEX,
-} from '../../common/constants/shared';
+} from '../../../common/constants/shared';
 
 /**
  * @param literal - string literal that will be put inside single quotes in PPL command

--- a/public/components/event_analytics/explorer/sidebar/field_insights.tsx
+++ b/public/components/event_analytics/explorer/sidebar/field_insights.tsx
@@ -6,7 +6,7 @@
 import React, { useMemo, useState, useContext, useEffect } from 'react';
 import { indexOf, last } from 'lodash';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiBasicTable } from '@elastic/eui';
-import { getIndexPatternFromRawQuery } from '../../../../../common/utils/query_utils';
+import { getIndexPatternFromRawQuery } from '../../../common/query_utils';
 import { TabContext } from '../../hooks/use_tab_context';
 
 interface IInsightsReq {

--- a/public/components/event_analytics/hooks/use_fetch_patterns.ts
+++ b/public/components/event_analytics/hooks/use_fetch_patterns.ts
@@ -15,7 +15,7 @@ import {
   SELECTED_PATTERN_FIELD,
   SELECTED_TIMESTAMP,
 } from '../../../../common/constants/explorer';
-import { buildPatternsQuery } from '../../../../common/utils/query_utils';
+import { buildPatternsQuery } from '../../common/query_utils';
 import { IPPLEventsDataSource } from '../../../../server/common/types';
 import { reset as resetPatterns, setPatterns } from '../redux/slices/patterns_slice';
 import { changeQuery, selectQueries } from '../redux/slices/query_slice';
@@ -97,7 +97,7 @@ export const useFetchPatterns = ({ pplService, requestParams }: IFetchPatternsPa
       fetchEvents({ query: anomaliesQuery }, 'jdbc', (res) => res),
     ])
       .then((res) => {
-        const [statsResp, anomaliesResp] = res as PromiseSettledResult<IPPLEventsDataSource>[];
+        const [statsResp, anomaliesResp] = res as Array<PromiseSettledResult<IPPLEventsDataSource>>;
         if (statsResp.status === 'rejected') {
           throw statsResp.reason;
         }


### PR DESCRIPTION
### Description
Move query_utils module to /public.
This module contains only functions used in browser front-end code.  Having this module in /common causes a server restart on every change.  The query_utils module will be updated extensively in Metrics Edit feature.

### Issues Resolved


### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
