### PR TITLE
WIP Attempt fix Available Metrics Spec

### DIFF
--- a/public/components/metrics/redux/slices/metrics_slice.ts
+++ b/public/components/metrics/redux/slices/metrics_slice.ts
@@ -47,8 +47,8 @@ const initialState = {
 };
 
 export const loadMetrics = () => async (dispatch) => {
-  const { http, pplService } = coreRefs;
-  const customDataRequest = fetchCustomMetrics(http);
+  const { pplService } = coreRefs;
+  const customDataRequest = fetchCustomMetrics();
   const remoteDataSourcesResponse = await pplServiceRequestor(pplService!, PPL_DATASOURCES_REQUEST);
   const remoteDataSources = remoteDataSourcesResponse.data.DATASOURCE_NAME;
 
@@ -59,7 +59,9 @@ export const loadMetrics = () => async (dispatch) => {
   );
 
   const remoteDataRequests = await fetchRemoteMetrics(remoteDataSources);
+  console.log('awaiting data responses');
   const dataResponses = await Promise.all([customDataRequest, ...remoteDataRequests]);
+  console.log('loadMetrics', JSON.stringify({ dataResponses }, '', 2));
   dispatch(setMetrics(dataResponses.flat()));
 };
 

--- a/public/components/metrics/sidebar/sidebar.tsx
+++ b/public/components/metrics/sidebar/sidebar.tsx
@@ -28,6 +28,10 @@ export const Sidebar = () => {
   const selectedMetrics = useSelector(selectedMetricsSelector);
 
   useEffect(() => {
+    console.log('availableMetrics', availableMetrics);
+  }, [availableMetrics]);
+
+  useEffect(() => {
     batch(() => {
       dispatch(loadMetrics());
     });

--- a/test/metrics_contants.ts
+++ b/test/metrics_contants.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ObservabilitySavedVisualization } from '../public/services/saved_objects/saved_object_client/types';
+
 export const sampleMetricsVisualizations = [
   {
     h: 2,
@@ -261,53 +263,59 @@ export const samplePrometheusSampleUpdateWithSelections = {
   userConfigs: '{}',
 };
 
-export const sampleSavedMetric = {
-  id: 'tomAP4QBiaYaSxpXALls',
-  name: '[Logs] Average ram usage per day by windows os ',
-  query:
-    "source = opensearch_dashboards_sample_data_logs | where match(machine.os,'win')  |  stats avg(machine.ram) by span(timestamp,1h)",
-  type: 'line',
-  timeField: 'timestamp',
-  selected_date_range: {
-    start: 'now-1d',
-    end: 'now',
-    text: '',
-  },
-  selected_fields: {
-    text: '',
-    tokens: [],
-  },
-  user_configs: {
-    dataConfig: {
-      series: [
-        {
-          label: 'machine.ram',
-          name: 'machine.ram',
-          aggregation: 'avg',
-          customLabel: '',
+export const sampleSavedMetric: ObservabilitySavedVisualization = {
+  objectId: 'tomAP4QBiaYaSxpXALls',
+  createdTimeMs: 1626867814000,
+  lastUpdatedTimeMs: 1626867814000,
+  savedVisualization: {
+    name: '[Logs] Average ram usage per day by windows os ',
+    description: '',
+    query:
+      "source = opensearch_dashboards_sample_data_logs | where match(machine.os,'win')  |  stats avg(machine.ram) by span(timestamp,1h)",
+    type: 'line',
+    timeField: 'timestamp',
+    selected_timestamp: { name: 'timestamp', type: 'timestamp', label: 'timestamp' },
+    selected_date_range: {
+      start: 'now-1d',
+      end: 'now',
+      text: '',
+    },
+    selected_fields: {
+      text: '',
+      tokens: [],
+    },
+    sub_type: 'metric',
+    user_configs: {
+      dataConfig: {
+        series: [
+          {
+            label: 'machine.ram',
+            name: 'machine.ram',
+            aggregation: 'avg',
+            customLabel: '',
+          },
+        ],
+        dimensions: [],
+        span: {
+          time_field: [
+            {
+              name: 'timestamp',
+              type: 'timestamp',
+              label: 'timestamp',
+            },
+          ],
+          unit: [
+            {
+              text: 'Day',
+              value: 'd',
+              label: 'Day',
+            },
+          ],
+          interval: '1',
         },
-      ],
-      dimensions: [],
-      span: {
-        time_field: [
-          {
-            name: 'timestamp',
-            type: 'timestamp',
-            label: 'timestamp',
-          },
-        ],
-        unit: [
-          {
-            text: 'Day',
-            value: 'd',
-            label: 'Day',
-          },
-        ],
-        interval: '1',
       },
     },
   },
-  sub_type: 'metric',
 };
 
 export const sampleSavedMetricUpdate = {


### PR DESCRIPTION
### Description
Attempt to fix Metrics Available Metric spec file.

Test should assert "Available Metrics 1 of 1" appears on page after mock loaded request of Observability Metric data from SavedObjects.

Currently, test fails - expected "Available Metrics 1 of 1" not found on string "Selected Metrics 0 of 0 Available Metrics 0 of 0"


I have not been able to determine any change that will update mocked SavedObject getBulk in a reactive way and show that the <MetricAccordion> widget recieves updated state data and re-renders.

This PR is in contrast to PR #996

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
