### PR TITLE
Add nightly cron schedule to E2E workflow

### DIFF
--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -1,5 +1,7 @@
 name: Dashboards observability plugin E2E test
-on: [pull_request, push]
+on:
+  schedule:
+    - cron: '0 0 * * *'
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: 'main'


### PR DESCRIPTION
### Description
Per side-channel discussion, we're looking at re-enabling E2E tests to run nightly (as opposed to on every PR).

Part of improving our testing strategy in response to #1001.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
