### PR TITLE
Fix missing import 'moment' on query_utils.

### DIFF
--- a/public/components/common/query_utils/index.ts
+++ b/public/components/common/query_utils/index.ts
@@ -6,6 +6,7 @@
 import dateMath from '@elastic/datemath';
 import { Moment } from 'moment-timezone';
 import { isEmpty } from 'lodash';
+import moment from 'moment';
 import {
   DATE_PICKER_FORMAT,
   PPL_DEFAULT_PATTERN_REGEX_FILETER,


### PR DESCRIPTION
### Description
Recently added query_utils/index.ts is missing an import for moment.

### Issues Resolved

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
