### PR TITLE
Move Metrics Explorer date span, range into redux metrics-slice

### DIFF
--- a/public/components/metrics/helpers/__tests__/utils.test.tsx
+++ b/public/components/metrics/helpers/__tests__/utils.test.tsx
@@ -34,26 +34,6 @@ import _ from 'lodash';
 describe('Utils helper functions', () => {
   configure({ adapter: new Adapter() });
 
-  it('validates onTimeChange function', () => {
-    const setRecentlyUsedRanges = jest.fn((x) => x);
-    const setStart = jest.fn();
-    const setEnd = jest.fn();
-    const recentlyUsedRanges: DurationRange[] = [];
-    onTimeChange(
-      '2022-01-30T18:44:40.577Z',
-      '2022-02-25T19:18:33.075Z',
-      recentlyUsedRanges,
-      setRecentlyUsedRanges,
-      setStart,
-      setEnd
-    );
-    expect(setRecentlyUsedRanges).toHaveBeenCalledWith([
-      { start: '2022-01-30T18:44:40.577Z', end: '2022-02-25T19:18:33.075Z' },
-    ]);
-    expect(setStart).toHaveBeenCalledWith('2022-01-30T18:44:40.577Z');
-    expect(setEnd).toHaveBeenCalledWith('2022-02-25T19:18:33.075Z');
-  });
-
   it('validates getNewVizDimensions function', () => {
     expect(getNewVizDimensions([])).toMatchObject({
       x: 0,

--- a/public/components/metrics/helpers/utils.tsx
+++ b/public/components/metrics/helpers/utils.tsx
@@ -22,24 +22,6 @@ import { VisualizationType } from '../../../../common/types/custom_panels';
 import { DEFAULT_METRIC_HEIGHT, DEFAULT_METRIC_WIDTH } from '../../../../common/constants/metrics';
 import { updateQuerySpanInterval } from '../../custom_panels/helpers/utils';
 
-export const onTimeChange = (
-  start: ShortDate,
-  end: ShortDate,
-  recentlyUsedRanges: DurationRange[],
-  setRecentlyUsedRanges: React.Dispatch<React.SetStateAction<DurationRange[]>>,
-  setStart: React.Dispatch<React.SetStateAction<string>>,
-  setEnd: React.Dispatch<React.SetStateAction<string>>
-) => {
-  const recentlyUsedRange = recentlyUsedRanges.filter((recentlyUsedRange) => {
-    const isDuplicate = recentlyUsedRange.start === start && recentlyUsedRange.end === end;
-    return !isDuplicate;
-  });
-  recentlyUsedRange.unshift({ start, end });
-  setStart(start);
-  setEnd(end);
-  setRecentlyUsedRanges(recentlyUsedRange.slice(0, 9));
-};
-
 // PPL Service requestor
 export const pplServiceRequestor = (pplService: PPLService, finalQuery: string) => {
   return pplService.fetch({ query: finalQuery, format: VISUALIZATION }).catch((error: Error) => {
@@ -58,21 +40,21 @@ export const getVisualizations = (http: CoreStart['http']) => {
     });
 };
 
-interface boxType {
+interface BoxType {
   x1: number;
   y1: number;
   x2: number;
   y2: number;
 }
 
-const calculatOverlapArea = (bb1: boxType, bb2: boxType) => {
-  const x_left = Math.max(bb1.x1, bb2.x1);
-  const y_top = Math.max(bb1.y1, bb2.y1);
-  const x_right = Math.min(bb1.x2, bb2.x2);
-  const y_bottom = Math.min(bb1.y2, bb2.y2);
+const calculatOverlapArea = (bb1: BoxType, bb2: BoxType) => {
+  const xLeft = Math.max(bb1.x1, bb2.x1);
+  const yTop = Math.max(bb1.y1, bb2.y1);
+  const xRight = Math.min(bb1.x2, bb2.x2);
+  const yBottom = Math.min(bb1.y2, bb2.y2);
 
-  if (x_right < x_left || y_bottom < y_top) return 0;
-  return (x_right - x_left) * (y_bottom - y_top);
+  if (xRight < xLeft || yBottom < yTop) return 0;
+  return (xRight - xLeft) * (yBottom - yTop);
 };
 
 const getTotalOverlapArea = (panelVisualizations: MetricType[]) => {
@@ -149,7 +131,7 @@ export const mergeLayoutAndMetrics = (
 
   for (let i = 0; i < newVisualizationList.length; i++) {
     for (let j = 0; j < layout.length; j++) {
-      if (newVisualizationList[i].id == layout[j].i) {
+      if (newVisualizationList[i].id === layout[j].i) {
         newPanelVisualizations.push({
           ...newVisualizationList[i],
           x: layout[j].x,

--- a/public/components/metrics/index.tsx
+++ b/public/components/metrics/index.tsx
@@ -13,13 +13,11 @@ import {
   OnTimeChangeProps,
   ShortDate,
 } from '@elastic/eui';
-import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
 import React, { ReactChild, useEffect, useState } from 'react';
 import { HashRouter, Route, RouteComponentProps } from 'react-router-dom';
 import { StaticContext } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { ChromeBreadcrumb, Toast } from '../../../../../src/core/public';
-import { onTimeChange } from './helpers/utils';
 import { Sidebar } from './sidebar/sidebar';
 import { EmptyMetricsView } from './view/empty_view';
 import PPLService from '../../services/requests/ppl';
@@ -44,19 +42,10 @@ export const Home = ({ chrome, parentBreadcrumb }: MetricsProps) => {
   const selectedMetrics = useSelector(selectedMetricsSelector);
   const metricsLayout = useSelector(metricsLayoutSelector);
 
-  // Date picker constants
-  const [recentlyUsedRanges, setRecentlyUsedRanges] = useState<DurationRange[]>([]);
-  const [startTime, setStartTime] = useState<ShortDate>('now-1d');
-  const [endTime, setEndTime] = useState<ShortDate>('now');
-
   // Top panel
   const [IsTopPanelDisabled, setIsTopPanelDisabled] = useState(false);
   const [editMode, setEditMode] = useState(false);
-  const [onRefresh, setOnRefresh] = useState(false);
   const [editActionType, setEditActionType] = useState('');
-  const [resolutionValue, setResolutionValue] = useState(resolutionOptions[2].value);
-  const [spanValue, setSpanValue] = useState(1);
-  const resolutionSelectId = htmlIdGenerator('resolutionSelect')();
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [toastRightSide, setToastRightSide] = useState<boolean>(true);
 
@@ -67,26 +56,6 @@ export const Home = ({ chrome, parentBreadcrumb }: MetricsProps) => {
     if (!text) text = '';
     setToastRightSide(!side);
     setToasts([...toasts, { id: new Date().toISOString(), title, text, color } as Toast]);
-  };
-
-  const onRefreshFilters = () => {
-    if (spanValue < 1) {
-      setToast('Please add a valid span interval', 'danger');
-      return;
-    }
-    setOnRefresh(!onRefresh);
-  };
-
-  const onDatePickerChange = (props: OnTimeChangeProps) => {
-    onTimeChange(
-      props.start,
-      props.end,
-      recentlyUsedRanges,
-      setRecentlyUsedRanges,
-      setStartTime,
-      setEndTime
-    );
-    onRefreshFilters();
   };
 
   const onEditClick = (savedVisualizationId: string) => {
@@ -135,20 +104,11 @@ export const Home = ({ chrome, parentBreadcrumb }: MetricsProps) => {
                 <EuiPageBody component="div">
                   <TopMenu
                     IsTopPanelDisabled={IsTopPanelDisabled}
-                    startTime={startTime}
-                    endTime={endTime}
-                    onDatePickerChange={onDatePickerChange}
-                    recentlyUsedRanges={recentlyUsedRanges}
                     editMode={editMode}
                     setEditMode={setEditMode}
                     setEditActionType={setEditActionType}
                     panelVisualizations={panelVisualizations}
                     setPanelVisualizations={setPanelVisualizations}
-                    resolutionValue={resolutionValue}
-                    setResolutionValue={setResolutionValue}
-                    spanValue={spanValue}
-                    setSpanValue={setSpanValue}
-                    resolutionSelectId={resolutionSelectId}
                     setToast={setToast}
                   />
                   <div className="dscAppContainer">
@@ -168,13 +128,9 @@ export const Home = ({ chrome, parentBreadcrumb }: MetricsProps) => {
                                 panelVisualizations={panelVisualizations}
                                 setPanelVisualizations={setPanelVisualizations}
                                 editMode={editMode}
-                                startTime={startTime}
-                                endTime={endTime}
                                 moveToEvents={onEditClick}
-                                onRefresh={onRefresh}
                                 editActionType={editActionType}
                                 setEditActionType={setEditActionType}
-                                spanParam={spanValue + resolutionValue}
                               />
                             ) : (
                               <EmptyMetricsView />

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
@@ -88,7 +88,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled in 
                     aria-label="resolutionSelect"
                     className="resolutionSelectOption"
                     data-test-subj="metrics__spanResolutionSelect"
-                    id="select_123"
                     onChange={[Function]}
                     options={
                       Array [
@@ -132,7 +131,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled in 
                       aria-label="resolutionSelect"
                       className="resolutionSelectOption"
                       data-test-subj="metrics__spanResolutionSelect"
-                      id="select_123"
                       onChange={[Function]}
                       options={
                         Array [
@@ -198,7 +196,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled in 
                       aria-label="resolutionSelect"
                       className="euiFormControlLayout__append resolutionSelectOption"
                       data-test-subj="metrics__spanResolutionSelect"
-                      id="select_123"
                       key="0/.0"
                       onChange={[Function]}
                       options={
@@ -236,7 +233,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled in 
                             "type": "arrowDown",
                           }
                         }
-                        inputId="select_123"
                         isLoading={false}
                       >
                         <div
@@ -250,7 +246,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled in 
                                 aria-label="resolutionSelect"
                                 className="euiSelect euiFormControlLayout__append resolutionSelectOption"
                                 data-test-subj="metrics__spanResolutionSelect"
-                                id="select_123"
                                 onChange={[Function]}
                                 onMouseUp={[Function]}
                                 value="h"
@@ -408,7 +403,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled in 
               isAutoRefreshOnly={false}
               isDisabled={true}
               isPaused={true}
-              onTimeChange={[MockFunction]}
+              onTimeChange={[Function]}
               recentlyUsedRanges={Array []}
               refreshInterval={0}
               showUpdateButton={true}
@@ -1255,7 +1250,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled wit
                     aria-label="resolutionSelect"
                     className="resolutionSelectOption"
                     data-test-subj="metrics__spanResolutionSelect"
-                    id="select_123"
                     onChange={[Function]}
                     options={
                       Array [
@@ -1299,7 +1293,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled wit
                       aria-label="resolutionSelect"
                       className="resolutionSelectOption"
                       data-test-subj="metrics__spanResolutionSelect"
-                      id="select_123"
                       onChange={[Function]}
                       options={
                         Array [
@@ -1365,7 +1358,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled wit
                       aria-label="resolutionSelect"
                       className="euiFormControlLayout__append resolutionSelectOption"
                       data-test-subj="metrics__spanResolutionSelect"
-                      id="select_123"
                       key="0/.0"
                       onChange={[Function]}
                       options={
@@ -1403,7 +1395,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled wit
                             "type": "arrowDown",
                           }
                         }
-                        inputId="select_123"
                         isLoading={false}
                       >
                         <div
@@ -1417,7 +1408,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled wit
                                 aria-label="resolutionSelect"
                                 className="euiSelect euiFormControlLayout__append resolutionSelectOption"
                                 data-test-subj="metrics__spanResolutionSelect"
-                                id="select_123"
                                 onChange={[Function]}
                                 onMouseUp={[Function]}
                                 value="h"
@@ -1575,7 +1565,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when disabled wit
               isAutoRefreshOnly={false}
               isDisabled={true}
               isPaused={true}
-              onTimeChange={[MockFunction]}
+              onTimeChange={[Function]}
               recentlyUsedRanges={Array []}
               refreshInterval={0}
               showUpdateButton={true}
@@ -2372,7 +2362,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                     aria-label="resolutionSelect"
                     className="resolutionSelectOption"
                     data-test-subj="metrics__spanResolutionSelect"
-                    id="select_123"
                     onChange={[Function]}
                     options={
                       Array [
@@ -2416,7 +2405,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                       aria-label="resolutionSelect"
                       className="resolutionSelectOption"
                       data-test-subj="metrics__spanResolutionSelect"
-                      id="select_123"
                       onChange={[Function]}
                       options={
                         Array [
@@ -2482,7 +2470,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                       aria-label="resolutionSelect"
                       className="euiFormControlLayout__append resolutionSelectOption"
                       data-test-subj="metrics__spanResolutionSelect"
-                      id="select_123"
                       key="0/.0"
                       onChange={[Function]}
                       options={
@@ -2520,7 +2507,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                             "type": "arrowDown",
                           }
                         }
-                        inputId="select_123"
                         isLoading={false}
                       >
                         <div
@@ -2534,7 +2520,6 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                 aria-label="resolutionSelect"
                                 className="euiSelect euiFormControlLayout__append resolutionSelectOption"
                                 data-test-subj="metrics__spanResolutionSelect"
-                                id="select_123"
                                 onChange={[Function]}
                                 onMouseUp={[Function]}
                                 value="h"
@@ -2687,7 +2672,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
               isAutoRefreshOnly={false}
               isDisabled={false}
               isPaused={true}
-              onTimeChange={[MockFunction]}
+              onTimeChange={[Function]}
               recentlyUsedRanges={Array []}
               refreshInterval={0}
               showUpdateButton={true}

--- a/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
+++ b/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
@@ -733,10 +733,10 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
               >
                 <Component
                   editMode={false}
-                  fromTime="now-30m"
+                  fromTime="now-1d"
                   key="Y4muP4QBiaYaSxpXk7r8"
                   onEditClick={[MockFunction]}
-                  onRefresh={true}
+                  onRefresh={0}
                   pplFilterValue=""
                   removeVisualization={[Function]}
                   savedVisualizationId="Y4muP4QBiaYaSxpXk7r8"
@@ -976,10 +976,10 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
               >
                 <Component
                   editMode={false}
-                  fromTime="now-30m"
+                  fromTime="now-1d"
                   key="tomAP4QBiaYaSxpXALls"
                   onEditClick={[MockFunction]}
-                  onRefresh={true}
+                  onRefresh={0}
                   pplFilterValue=""
                   removeVisualization={[Function]}
                   savedVisualizationId="tomAP4QBiaYaSxpXALls"
@@ -1220,10 +1220,10 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
                 <Component
                   catalogVisualization={true}
                   editMode={false}
-                  fromTime="now-30m"
+                  fromTime="now-1d"
                   key="prometheus.process_resident_memory_bytes"
                   onEditClick={[MockFunction]}
-                  onRefresh={true}
+                  onRefresh={0}
                   pplFilterValue=""
                   removeVisualization={[Function]}
                   savedVisualizationId="prometheus.process_resident_memory_bytes"

--- a/public/components/metrics/view/metrics_grid.tsx
+++ b/public/components/metrics/view/metrics_grid.tsx
@@ -7,12 +7,17 @@ import React, { useEffect, useState } from 'react';
 import { Layout, Layouts, Responsive, WidthProvider } from 'react-grid-layout';
 import { useObservable } from 'react-use';
 import _ from 'lodash';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { CoreStart } from '../../../../../../src/core/public';
 import { VisualizationContainer } from '../../custom_panels/panel_modules/visualization_container';
 import { MetricType } from '../../../../common/types/metrics';
 import { mergeLayoutAndVisualizations } from '../../custom_panels/helpers/utils';
-import { updateMetricsLayout, deSelectMetric } from '../redux/slices/metrics_slice';
+import {
+  updateMetricsLayout,
+  deSelectMetric,
+  dateSpanFilterSelector,
+  refreshSelector,
+} from '../redux/slices/metrics_slice';
 import { mergeLayoutAndMetrics } from '../helpers/utils';
 
 import './metrics_grid.scss';
@@ -25,13 +30,9 @@ interface MetricsGridProps {
   panelVisualizations: MetricType[];
   setPanelVisualizations: React.Dispatch<React.SetStateAction<MetricType[]>>;
   editMode: boolean;
-  startTime: string;
-  endTime: string;
   moveToEvents: (savedVisualizationId: string) => any;
-  onRefresh: boolean;
   editActionType: string;
   setEditActionType: React.Dispatch<React.SetStateAction<string>>;
-  spanParam: string;
 }
 
 export const MetricsGrid = ({
@@ -39,16 +40,15 @@ export const MetricsGrid = ({
   panelVisualizations,
   setPanelVisualizations,
   editMode,
-  startTime,
-  endTime,
   moveToEvents,
-  onRefresh,
   editActionType,
   setEditActionType,
-  spanParam,
 }: MetricsGridProps) => {
   // Redux tools
   const dispatch = useDispatch();
+  const dateSpanFilter = useSelector(dateSpanFilterSelector);
+  const refresh = useSelector(refreshSelector);
+
   const updateLayout = (metric: any) => dispatch(updateMetricsLayout(metric));
   const handleRemoveMetric = (metric: any) => {
     dispatch(deSelectMetric(metric));
@@ -73,9 +73,9 @@ export const MetricsGrid = ({
         editMode={editMode}
         visualizationId={panelVisualization.id}
         savedVisualizationId={panelVisualization.savedVisualizationId}
-        fromTime={startTime}
-        toTime={endTime}
-        onRefresh={onRefresh}
+        fromTime={dateSpanFilter.start}
+        toTime={dateSpanFilter.end}
+        onRefresh={refresh}
         onEditClick={moveToEvents}
         usedInNotebooks={true}
         pplFilterValue=""
@@ -83,7 +83,7 @@ export const MetricsGrid = ({
         catalogVisualization={
           panelVisualization.metricType === 'savedCustomMetric' ? undefined : true
         }
-        spanParam={spanParam}
+        spanParam={`${dateSpanFilter.span}${dateSpanFilter.resolution}`}
       />
     ));
     setGridData(gridDataComps);
@@ -149,7 +149,7 @@ export const MetricsGrid = ({
 
   useEffect(() => {
     loadVizComponents();
-  }, [onRefresh]);
+  }, [refresh]);
 
   useEffect(() => {
     loadVizComponents();


### PR DESCRIPTION
### Description
In order to simplify refactor of MetricsGrid, moving all date-range parsing out of props-passing and into redux MetricsSlice.

### Issues Resolved
References #1095 (not resolve)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
