### PR TITLE
Switch heading types on integrations setup page

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -60,13 +60,15 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                          <EuiTitle>
-                            <h2
-                              className="euiTitle euiTitle--medium"
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
                             >
-                              Integration Details
-                            </h2>
-                          </EuiTitle>
+                              <h3>
+                                Integration Details
+                              </h3>
+                            </div>
+                          </EuiText>
                           <EuiSpacer>
                             <div
                               className="euiSpacer euiSpacer--l"
@@ -148,13 +150,15 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                          <EuiTitle>
-                            <h2
-                              className="euiTitle euiTitle--medium"
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
                             >
-                              Integration Connection
-                            </h2>
-                          </EuiTitle>
+                              <h3>
+                                Integration Connection
+                              </h3>
+                            </div>
+                          </EuiText>
                           <EuiSpacer>
                             <div
                               className="euiSpacer euiSpacer--l"
@@ -1041,13 +1045,15 @@ exports[`Integration Setup Page Renders the form as expected 1`] = `
           className="euiSpacer euiSpacer--l"
         />
       </EuiSpacer>
-      <EuiTitle>
-        <h2
-          className="euiTitle euiTitle--medium"
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
         >
-          Integration Details
-        </h2>
-      </EuiTitle>
+          <h3>
+            Integration Details
+          </h3>
+        </div>
+      </EuiText>
       <EuiSpacer>
         <div
           className="euiSpacer euiSpacer--l"
@@ -1129,13 +1135,15 @@ exports[`Integration Setup Page Renders the form as expected 1`] = `
           className="euiSpacer euiSpacer--l"
         />
       </EuiSpacer>
-      <EuiTitle>
-        <h2
-          className="euiTitle euiTitle--medium"
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
         >
-          Integration Connection
-        </h2>
-      </EuiTitle>
+          <h3>
+            Integration Connection
+          </h3>
+        </div>
+      </EuiText>
       <EuiSpacer>
         <div
           className="euiSpacer euiSpacer--l"

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -194,9 +194,9 @@ export function SetupIntegrationForm({
         <h1>Set Up Integration</h1>
       </EuiTitle>
       <EuiSpacer />
-      <EuiTitle>
-        <h2>Integration Details</h2>
-      </EuiTitle>
+      <EuiText>
+        <h3>Integration Details</h3>
+      </EuiText>
       <EuiSpacer />
       <EuiFormRow label="Display Name">
         <EuiFieldText
@@ -206,9 +206,9 @@ export function SetupIntegrationForm({
         />
       </EuiFormRow>
       <EuiSpacer />
-      <EuiTitle>
-        <h2>Integration Connection</h2>
-      </EuiTitle>
+      <EuiText>
+        <h3>Integration Connection</h3>
+      </EuiText>
       <EuiSpacer />
       <EuiFormRow label="Data Source" helpText="Select a data source to connect to.">
         <EuiSelect


### PR DESCRIPTION
### Description
The current integrations setup page has had mismatched headers due to strange behavior of `EuiTitle`. We switch it to `EuiText` and update the header scales to look correctly matched.

Before:
![image](https://github.com/opensearch-project/dashboards-observability/assets/31739405/76847250-60cf-40ec-9e4a-4466a7dce928)

After:
![image](https://github.com/opensearch-project/dashboards-observability/assets/31739405/a9d2b485-5c1a-4926-a547-28ec48151250)

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
