### PR TITLE
Disable integration set up button if invalid

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -735,7 +735,8 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                             class="euiFlexItem euiFlexItem--flexGrowZero"
                           >
                             <button
-                              class="euiButton euiButton--primary euiButton--fill"
+                              class="euiButton euiButton--primary euiButton--fill euiButton-isDisabled"
+                              disabled=""
                               type="button"
                             >
                               <span
@@ -889,6 +890,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
                               <EuiButton
+                                disabled={true}
                                 fill={true}
                                 iconSide="right"
                                 iconType="arrowRight"
@@ -897,19 +899,19 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               >
                                 <EuiButtonDisplay
                                   baseClassName="euiButton"
-                                  disabled={false}
+                                  disabled={true}
                                   element="button"
                                   fill={true}
                                   iconSide="right"
                                   iconType="arrowRight"
-                                  isDisabled={false}
+                                  isDisabled={true}
                                   isLoading={false}
                                   onClick={[Function]}
                                   type="button"
                                 >
                                   <button
-                                    className="euiButton euiButton--primary euiButton--fill"
-                                    disabled={false}
+                                    className="euiButton euiButton--primary euiButton--fill euiButton-isDisabled"
+                                    disabled={true}
                                     onClick={[Function]}
                                     style={
                                       Object {

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -13,7 +13,6 @@ import {
   EuiForm,
   EuiFormRow,
   EuiLoadingDashboards,
-  EuiModal,
   EuiPage,
   EuiPageBody,
   EuiPageContent,
@@ -296,6 +295,7 @@ export function SetupBottomBar({
             iconType="arrowRight"
             iconSide="right"
             isLoading={loading}
+            disabled={config.displayName.length < 1 || config.connectionDataSource.length < 1}
             onClick={async () => {
               setLoading(true);
 


### PR DESCRIPTION
### Description
Per 2.11 bug bash: If an integration being set up has no display name or no data source selected, then it still adds an invalid integration. This PR adds the quick patch of disabling the button when the integration is missing required fields.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
