### PR TITLE
Switch from toast to callout for integration set up failures

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -42,6 +42,11 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                           "type": "",
                         }
                       }
+                      setupCallout={
+                        Object {
+                          "show": false,
+                        }
+                      }
                       updateConfig={[Function]}
                     >
                       <EuiForm>
@@ -55,6 +60,11 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               Set Up Integration
                             </h1>
                           </EuiTitle>
+                          <EuiSpacer>
+                            <div
+                              className="euiSpacer euiSpacer--l"
+                            />
+                          </EuiSpacer>
                           <EuiSpacer>
                             <div
                               className="euiSpacer euiSpacer--l"
@@ -685,6 +695,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
             loadingProgress={0}
             setLoading={[Function]}
             setProgress={[Function]}
+            setSetupCallout={[Function]}
           >
             <EuiBottomBar>
               <EuiPortal>
@@ -707,11 +718,11 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                             class="euiFlexItem euiFlexItem--flexGrowZero"
                           >
                             <button
-                              class="euiButton euiButton--secondary"
+                              class="euiButtonEmpty euiButtonEmpty--text"
                               type="button"
                             >
                               <span
-                                class="euiButtonContent euiButton__content"
+                                class="euiButtonContent euiButtonEmpty__content"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -724,7 +735,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                                   xmlns="http://www.w3.org/2000/svg"
                                 />
                                 <span
-                                  class="euiButton__text"
+                                  class="euiButtonEmpty__text"
                                 >
                                   Discard
                                 </span>
@@ -805,81 +816,66 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                             <div
                               className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiButton
-                                color="secondary"
+                              <EuiButtonEmpty
+                                color="text"
                                 iconType="cross"
                                 onClick={[Function]}
                               >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButton"
-                                  color="secondary"
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text"
                                   disabled={false}
-                                  element="button"
-                                  iconType="cross"
-                                  isDisabled={false}
                                   onClick={[Function]}
                                   type="button"
                                 >
-                                  <button
-                                    className="euiButton euiButton--secondary"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    style={
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="m"
+                                    iconType="cross"
+                                    textProps={
                                       Object {
-                                        "minWidth": undefined,
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
-                                    type="button"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      iconType="cross"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text",
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="cross"
                                       >
-                                        <EuiIcon
-                                          className="euiButtonContent__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="cross"
+                                        <EuiIconEmpty
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
                                         >
-                                          <EuiIconEmpty
+                                          <svg
                                             aria-hidden={true}
                                             className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                             focusable="false"
+                                            height={16}
                                             role="img"
                                             style={null}
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                              focusable="false"
-                                              height={16}
-                                              role="img"
-                                              style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            />
-                                          </EuiIconEmpty>
-                                        </EuiIcon>
-                                        <span
-                                          className="euiButton__text"
-                                        >
-                                          Discard
-                                        </span>
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          />
+                                        </EuiIconEmpty>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Discard
                                       </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonDisplay>
-                              </EuiButton>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </EuiFlexItem>
                           <EuiFlexItem
@@ -1027,6 +1023,11 @@ exports[`Integration Setup Page Renders the form as expected 1`] = `
       "version": "2.0.0",
     }
   }
+  setupCallout={
+    Object {
+      "show": false,
+    }
+  }
   updateConfig={[Function]}
 >
   <EuiForm>
@@ -1040,6 +1041,11 @@ exports[`Integration Setup Page Renders the form as expected 1`] = `
           Set Up Integration
         </h1>
       </EuiTitle>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
       <EuiSpacer>
         <div
           className="euiSpacer euiSpacer--l"

--- a/public/components/integrations/components/__tests__/setup_integration.test.tsx
+++ b/public/components/integrations/components/__tests__/setup_integration.test.tsx
@@ -30,6 +30,7 @@ describe('Integration Setup Page', () => {
         config={TEST_INTEGRATION_SETUP_INPUTS}
         updateConfig={() => {}}
         integration={TEST_INTEGRATION_CONFIG}
+        setupCallout={{ show: false }}
       />
     );
 

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -32,9 +32,9 @@ export interface AvailableIntegrationType {
   version?: string | undefined;
   displayName?: string;
   integrationType: string;
-  statics: any;
-  components: any[];
-  displayAssets: any[];
+  statics: unknown;
+  components: Array<{ name: string }>;
+  displayAssets: unknown[];
 }
 
 export interface AvailableIntegrationsTableProps {
@@ -183,7 +183,11 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
           ? AvailableIntegrationsCardView({
               data: {
                 hits: data.hits.filter((hit) =>
-                  helper.every((compon) => hit.components.map((x) => x.name).includes(compon))
+                  helper.every((compon) =>
+                    hit.components
+                      .map((x) => x.name.split('_').findLast(() => true))
+                      .includes(compon)
+                  )
                 ),
               },
               isCardView,
@@ -197,7 +201,11 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
               loading: false,
               data: {
                 hits: data.hits.filter((hit) =>
-                  helper.every((compon) => hit.components.map((x) => x.name).includes(compon))
+                  helper.every((compon) =>
+                    hit.components
+                      .map((x) => x.name.split('_').findLast(() => true))
+                      .includes(compon)
+                  )
                 ),
               },
               isCardView,

--- a/public/components/integrations/components/create_integration_helpers.ts
+++ b/public/components/integrations/components/create_integration_helpers.ts
@@ -313,16 +313,13 @@ export async function addIntegrationRequest(
     .post(`${INTEGRATIONS_BASE}/store/${templateName}`, {
       body: JSON.stringify({ name, dataSource }),
     })
-    .then((_res) => {
+    .then((res) => {
       setToast(`${name} integration successfully added!`, 'success');
-      window.location.hash = `#/installed/${_res.data?.id}`;
+      window.location.hash = `#/installed/${res.data?.id}`;
       return true;
     })
-    .catch((_err) => {
-      setToast(
-        'Failed to load integration. Check Added Integrations table for more details',
-        'danger'
-      );
+    .catch((err) => {
+      setToast('Failed to load integration', 'danger', err.message);
       return false;
     });
   if (!addSample || !response) {
@@ -333,7 +330,7 @@ export async function addIntegrationRequest(
     .then((res) => res.data)
     .catch((err) => {
       console.error(err);
-      setToast('The sample data could not be retrieved', 'danger');
+      setToast('Failed to load integration', 'danger', 'The sample data could not be retrieved.');
       return { sampleData: [] };
     });
   const requestBody =

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -6,6 +6,7 @@
 import {
   EuiBottomBar,
   EuiButton,
+  EuiButtonEmpty,
   EuiCallOut,
   EuiComboBox,
   EuiFieldText,
@@ -299,8 +300,8 @@ export function SetupBottomBar({
     <EuiBottomBar>
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton
-            color="secondary"
+          <EuiButtonEmpty
+            color="text"
             iconType="cross"
             onClick={() => {
               // TODO evil hack because props aren't set up
@@ -311,7 +312,7 @@ export function SetupBottomBar({
             }}
           >
             Discard
-          </EuiButton>
+          </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButton


### PR DESCRIPTION
### Description
Per UX feedback, instead of setting a toast when integration setup fails, we use a callout. This PR also includes minor changes to button styling and fixes a bug with integration category selection.

![image](https://github.com/opensearch-project/dashboards-observability/assets/31739405/30ec43f8-e2ff-48cb-a663-23d38962a05c)
![image](https://github.com/opensearch-project/dashboards-observability/assets/31739405/bf3e1452-d951-4284-9162-1b5a6258b27b)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
