### PR TITLE
update vpc flow with flint-s3 based DDL assets

### DIFF
--- a/release-notes/dashboards-observability.release-notes-2.9.0.0.md
+++ b/release-notes/dashboards-observability.release-notes-2.9.0.0.md
@@ -15,4 +15,4 @@ Compatible with OpenSearch and OpenSearch Dashboards Version 2.9.0
 - Remove deprecated layout editor ([#646](https://github.com/opensearch-project/dashboards-observability/pull/646))
 
 ### Documentation
-- Integraions Plugin Design RFC ([#644](https://github.com/opensearch-project/dashboards-observability/issues/644))
+- Integrations Plugin Design RFC ([#644](https://github.com/opensearch-project/dashboards-observability/issues/644))

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_mv_vpc-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_mv_vpc-1.0.0.sql
@@ -10,7 +10,7 @@ CREATE MATERIALIZED VIEW {table_name}_mview AS
         protocol as `aws.vpc.protocol`,
         CAST(packets AS LONG) as `aws.vpc.packets`,
         CAST(bytes AS LONG) as `aws.vpc.bytes`,
-        FROM_UNIXTIME(start) as `aws.vpc.start`,
+        FROM_UNIXTIME(start) as `@timestamp`,
         FROM_UNIXTIME(end) as `aws.vpc.end`,
         action as `aws.vpc.action`,
         log_status as `aws.vpc.log-status`

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_mv_vpc-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_mv_vpc-1.0.0.sql
@@ -1,0 +1,18 @@
+CREATE MATERIALIZED VIEW {table_name}_mview AS
+    SELECT
+        version as `aws.vpc.version`,
+        account_id as `aws.vpc.account-id`,
+        interface_id as `aws.vpc.interface-id`,
+        srcaddr as `aws.vpc.srcaddr`,
+        dstaddr as `aws.vpc.dstaddr`,
+        CAST(srcport AS LONG) as `aws.vpc.srcport`,
+        CAST(dstport AS LONG) as `aws.vpc.dstport`,
+        protocol as `aws.vpc.protocol`,
+        CAST(packets AS LONG) as `aws.vpc.packets`,
+        CAST(bytes AS LONG) as `aws.vpc.bytes`,
+        FROM_UNIXTIME(start) as `aws.vpc.start`,
+        FROM_UNIXTIME(end) as `aws.vpc.end`,
+        action as `aws.vpc.action`,
+        log_status as `aws.vpc.log-status`
+FROM
+    {table_name};

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_table_vpc-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_table_vpc-1.0.0.sql
@@ -1,0 +1,20 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS {table_name} (
+    version INT,
+    account_id STRING,
+    interface_id STRING,
+    srcaddr STRING,
+    dstaddr STRING,
+    srcport STRING,
+    dstport STRING,
+    protocol STRING,
+    packets STRING,
+    bytes STRING,
+    start BIGINT,
+    end BIGINT,
+    action STRING,
+    log_status STRING
+)USING csv
+LOCATION '{s3_bucket_location}'
+OPTIONS (
+  sep=' '
+);

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/refresh_mv_vpc-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/refresh_mv_vpc-1.0.0.sql
@@ -1,0 +1,1 @@
+REFRESH MATERIALIZED VIEW {table_name}_mview;


### PR DESCRIPTION
### Description
Add Flint-S3 based DDL statements for using vpc flow logs on top of S3 using SQL and flint - based acceleration

### Issues Resolved
- https://github.com/opensearch-project/opensearch-catalog/issues/82

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
