### PR TITLE
disabling inspect and default pattern/timestamp buttons when using async data sources

### DIFF
--- a/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/field.test.tsx.snap
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/field.test.tsx.snap
@@ -1,154 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Field component Renders a sidebar field 1`] = `
-<Component
-  field={
+<Provider
+  store={
     Object {
-      "name": "agent",
-      "type": "string",
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(Symbol.observable): [Function],
     }
   }
-  handleOverrideTimestamp={[MockFunction]}
-  isFieldToggleButtonDisabled={false}
-  isOverridingTimestamp={false}
-  onToggleField={[MockFunction]}
-  selected={true}
-  selectedTimestamp="timestamp"
-  showTimestampOverrideButton={true}
-  showToggleButton={true}
 >
-  <EuiFlexGroup
-    alignItems="center"
-    className="dscSidebarField"
-    gutterSize="s"
-    responsive={false}
+  <Component
+    field={
+      Object {
+        "name": "agent",
+        "type": "string",
+      }
+    }
+    handleOverrideTimestamp={[MockFunction]}
+    isFieldToggleButtonDisabled={false}
+    isOverridingTimestamp={false}
+    onToggleField={[MockFunction]}
+    selected={true}
+    selectedTimestamp="timestamp"
+    showTimestampOverrideButton={true}
+    showToggleButton={true}
+    tabId="DEFAULT_INDEX_PATTERNS"
   >
-    <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow dscSidebarField"
+    <EuiFlexGroup
+      alignItems="center"
+      className="dscSidebarField"
+      gutterSize="s"
+      responsive={false}
     >
-      <EuiFlexItem
-        grow={false}
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow dscSidebarField"
       >
-        <div
-          className="euiFlexItem euiFlexItem--flexGrowZero"
+        <EuiFlexItem
+          grow={false}
         >
-          <FieldIcon
-            type="string"
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <EuiToken
-              aria-label="string"
-              className="osdFieldIcon"
-              iconType="tokenString"
-              size="s"
-              title="string"
+            <FieldIcon
+              type="string"
             >
-              <span
-                className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--small osdFieldIcon"
-                style={Object {}}
+              <EuiToken
+                aria-label="string"
+                className="osdFieldIcon"
+                iconType="tokenString"
+                size="s"
+                title="string"
               >
-                <EuiIcon
-                  aria-label="string"
-                  size="m"
-                  title="string"
-                  type="tokenString"
+                <span
+                  className="euiToken euiToken--euiColorVis1 euiToken--square euiToken--light euiToken--small osdFieldIcon"
+                  style={Object {}}
                 >
-                  <EuiIconEmpty
-                    aria-hidden={true}
+                  <EuiIcon
                     aria-label="string"
-                    className="euiIcon euiIcon--medium euiIcon-isLoading"
-                    focusable="false"
-                    role="img"
-                    style={null}
+                    size="m"
                     title="string"
+                    type="tokenString"
                   >
-                    <svg
+                    <EuiIconEmpty
                       aria-hidden={true}
                       aria-label="string"
                       className="euiIcon euiIcon--medium euiIcon-isLoading"
                       focusable="false"
-                      height={16}
                       role="img"
                       style={null}
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </EuiIconEmpty>
-                </EuiIcon>
-              </span>
-            </EuiToken>
-          </FieldIcon>
-        </div>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={true}
-      >
-        <div
-          className="euiFlexItem"
-        >
-          <EuiText
-            size="xs"
-          >
-            <div
-              className="euiText euiText--extraSmall"
-            >
-              agent
-            </div>
-          </EuiText>
-        </div>
-      </EuiFlexItem>
-      <EuiToolTip
-        content="Override default pattern"
-        delay="long"
-        id="override-pattern"
-        position="top"
-      >
-        <span
-          className="euiToolTipAnchor"
-          onKeyUp={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButtonIcon
-                aria-labelledby="override_pattern"
-                className="dscSidebarField__actionButton"
-                color="text"
-                data-test-subj="eventExplorer__overrideDefaultPattern"
-                iconType="inputOutput"
-                onClick={[Function]}
-                size="xs"
-              >
-                <button
-                  aria-labelledby="override_pattern"
-                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                  data-test-subj="eventExplorer__overrideDefaultPattern"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <EuiIcon
-                    aria-hidden="true"
-                    className="euiButtonIcon__icon"
-                    color="inherit"
-                    size="m"
-                    type="inputOutput"
-                  >
-                    <EuiIconEmpty
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
+                      title="string"
                     >
                       <svg
                         aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                        aria-label="string"
+                        className="euiIcon euiIcon--medium euiIcon-isLoading"
                         focusable="false"
                         height={16}
                         role="img"
@@ -159,188 +87,276 @@ exports[`Field component Renders a sidebar field 1`] = `
                       />
                     </EuiIconEmpty>
                   </EuiIcon>
-                </button>
-              </EuiButtonIcon>
-            </div>
-          </EuiFlexItem>
-        </span>
-      </EuiToolTip>
-      <EuiToolTip
-        content="Override default timestamp"
-        delay="long"
-        id="override-timestamp"
-        position="top"
-      >
-        <span
-          className="euiToolTipAnchor"
-          onKeyUp={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        />
-      </EuiToolTip>
-      <EuiFlexItem
-        grow={false}
-      >
-        <div
-          className="euiFlexItem euiFlexItem--flexGrowZero"
+                </span>
+              </EuiToken>
+            </FieldIcon>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
         >
-          <EuiToolTip
-            content="inspect"
-            delay="long"
-            position="top"
+          <div
+            className="euiFlexItem"
           >
-            <span
-              className="euiToolTipAnchor"
-              onKeyUp={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
+            <EuiText
+              size="xs"
             >
-              <EuiPopover
-                anchorPosition="rightUp"
-                button={
-                  <EuiButtonIcon
-                    aria-label="inspect"
-                    className="dscSidebarField__actionButton"
-                    iconType="inspect"
-                    onClick={[Function]}
-                    size="xs"
-                  />
-                }
-                closePopover={[Function]}
-                display="block"
-                hasArrow={true}
-                isOpen={false}
-                onBlur={[Function]}
-                onFocus={[Function]}
-                ownFocus={true}
-                panelClassName="explorerSidebarItem__fieldPopoverPanel"
-                panelPaddingSize="m"
+              <div
+                className="euiText euiText--extraSmall"
               >
-                <div
-                  className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
+                agent
+              </div>
+            </EuiText>
+          </div>
+        </EuiFlexItem>
+        <EuiToolTip
+          content="Override default pattern"
+          delay="long"
+          id="override-pattern"
+          position="top"
+        >
+          <span
+            className="euiToolTipAnchor"
+            onKeyUp={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiButtonIcon
+                  aria-labelledby="override_pattern"
+                  className="dscSidebarField__actionButton"
+                  color="text"
+                  data-test-subj="eventExplorer__overrideDefaultPattern"
+                  iconType="inputOutput"
+                  isDisabled={true}
+                  onClick={[Function]}
+                  size="xs"
                 >
-                  <div
-                    className="euiPopover__anchor"
+                  <button
+                    aria-labelledby="override_pattern"
+                    className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                    data-test-subj="eventExplorer__overrideDefaultPattern"
+                    disabled={true}
+                    onClick={[Function]}
+                    type="button"
                   >
+                    <EuiIcon
+                      aria-hidden="true"
+                      className="euiButtonIcon__icon"
+                      color="inherit"
+                      size="m"
+                      type="inputOutput"
+                    >
+                      <EuiIconEmpty
+                        aria-hidden={true}
+                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                        focusable="false"
+                        role="img"
+                        style={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </EuiIconEmpty>
+                    </EuiIcon>
+                  </button>
+                </EuiButtonIcon>
+              </div>
+            </EuiFlexItem>
+          </span>
+        </EuiToolTip>
+        <EuiToolTip
+          content="Override default timestamp"
+          delay="long"
+          id="override-timestamp"
+          position="top"
+        >
+          <span
+            className="euiToolTipAnchor"
+            onKeyUp={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          />
+        </EuiToolTip>
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <EuiToolTip
+              content="inspect"
+              delay="long"
+              position="top"
+            >
+              <span
+                className="euiToolTipAnchor"
+                onKeyUp={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+              >
+                <EuiPopover
+                  anchorPosition="rightUp"
+                  button={
                     <EuiButtonIcon
                       aria-label="inspect"
                       className="dscSidebarField__actionButton"
                       iconType="inspect"
+                      isDisabled={true}
                       onClick={[Function]}
                       size="xs"
+                    />
+                  }
+                  closePopover={[Function]}
+                  display="block"
+                  hasArrow={true}
+                  isOpen={false}
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  ownFocus={true}
+                  panelClassName="explorerSidebarItem__fieldPopoverPanel"
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorRightUp euiPopover--displayBlock"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                  >
+                    <div
+                      className="euiPopover__anchor"
                     >
-                      <button
+                      <EuiButtonIcon
                         aria-label="inspect"
-                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                        disabled={false}
+                        className="dscSidebarField__actionButton"
+                        iconType="inspect"
+                        isDisabled={true}
                         onClick={[Function]}
-                        type="button"
+                        size="xs"
                       >
-                        <EuiIcon
-                          aria-hidden="true"
-                          className="euiButtonIcon__icon"
-                          color="inherit"
-                          size="m"
-                          type="inspect"
+                        <button
+                          aria-label="inspect"
+                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                          disabled={true}
+                          onClick={[Function]}
+                          type="button"
                         >
-                          <EuiIconEmpty
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="inspect"
                           >
-                            <svg
+                            <EuiIconEmpty
                               aria-hidden={true}
                               className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                               focusable="false"
-                              height={16}
                               role="img"
                               style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            />
-                          </EuiIconEmpty>
-                        </EuiIcon>
-                      </button>
-                    </EuiButtonIcon>
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                            </EuiIconEmpty>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
                   </div>
-                </div>
-              </EuiPopover>
-            </span>
-          </EuiToolTip>
-        </div>
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <div
-          className="euiFlexItem euiFlexItem--flexGrowZero"
+                </EuiPopover>
+              </span>
+            </EuiToolTip>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
         >
-          <EuiToolTip
-            content="Remove field from table"
-            delay="long"
-            position="top"
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <span
-              className="euiToolTipAnchor"
-              onKeyUp={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
+            <EuiToolTip
+              content="Remove field from table"
+              delay="long"
+              position="top"
             >
-              <EuiButtonIcon
-                aria-label="Remove agent from table"
-                className="dscSidebarField__actionButton"
-                color="danger"
-                data-test-subj="fieldToggle-agent"
-                iconType="cross"
-                onClick={[Function]}
+              <span
+                className="euiToolTipAnchor"
+                onKeyUp={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
               >
-                <button
+                <EuiButtonIcon
                   aria-label="Remove agent from table"
-                  className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                  className="dscSidebarField__actionButton"
+                  color="danger"
                   data-test-subj="fieldToggle-agent"
-                  disabled={false}
+                  iconType="cross"
                   onClick={[Function]}
-                  type="button"
                 >
-                  <EuiIcon
-                    aria-hidden="true"
-                    className="euiButtonIcon__icon"
-                    color="inherit"
-                    size="m"
-                    type="cross"
+                  <button
+                    aria-label="Remove agent from table"
+                    className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                    data-test-subj="fieldToggle-agent"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <EuiIconEmpty
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
+                    <EuiIcon
+                      aria-hidden="true"
+                      className="euiButtonIcon__icon"
+                      color="inherit"
+                      size="m"
+                      type="cross"
                     >
-                      <svg
+                      <EuiIconEmpty
                         aria-hidden={true}
                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                         focusable="false"
-                        height={16}
                         role="img"
                         style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      />
-                    </EuiIconEmpty>
-                  </EuiIcon>
-                </button>
-              </EuiButtonIcon>
-            </span>
-          </EuiToolTip>
-        </div>
-      </EuiFlexItem>
-    </div>
-  </EuiFlexGroup>
-</Component>
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        />
+                      </EuiIconEmpty>
+                    </EuiIcon>
+                  </button>
+                </EuiButtonIcon>
+              </span>
+            </EuiToolTip>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+  </Component>
+</Provider>
 `;

--- a/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -701,6 +701,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
         "unselectedFields": Array [],
       }
     }
+    tabId="DEFAULT_INDEX_PATTERNS"
   >
     <I18nProvider>
       <IntlProvider
@@ -1152,6 +1153,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={true}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={false}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -1283,6 +1285,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -1309,13 +1312,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -1536,6 +1540,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={true}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={false}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -1667,6 +1672,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -1693,13 +1699,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -1920,6 +1927,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={true}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={false}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -2051,6 +2059,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -2077,13 +2086,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -2304,6 +2314,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={true}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={false}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -2435,6 +2446,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -2461,13 +2473,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -2688,6 +2701,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={true}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={false}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -2819,6 +2833,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -2845,13 +2860,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -3072,6 +3088,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={true}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={false}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -3203,6 +3220,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -3229,13 +3247,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -3614,6 +3633,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -3719,14 +3739,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -3800,6 +3821,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -3826,13 +3848,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -4054,6 +4077,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -4185,6 +4209,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -4211,13 +4236,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -4439,6 +4465,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -4570,6 +4597,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -4596,13 +4624,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -4824,6 +4853,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -4955,6 +4985,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -4981,13 +5012,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -5209,6 +5241,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -5314,14 +5347,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -5395,6 +5429,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -5421,13 +5456,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -5649,6 +5685,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -5780,6 +5817,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -5806,13 +5844,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -6034,6 +6073,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -6139,14 +6179,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -6220,6 +6261,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -6246,13 +6288,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -6474,6 +6517,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -6579,14 +6623,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -6660,6 +6705,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -6686,13 +6732,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -6914,6 +6961,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -7045,6 +7093,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -7071,13 +7120,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -7299,6 +7349,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -7430,6 +7481,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -7456,13 +7508,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -7684,6 +7737,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -7815,6 +7869,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -7841,13 +7896,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -8069,6 +8125,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -8174,14 +8231,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -8255,6 +8313,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -8281,13 +8340,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -8509,6 +8569,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -8640,6 +8701,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -8666,13 +8728,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -8894,6 +8957,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -8999,14 +9063,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -9080,6 +9145,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -9106,13 +9172,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -9334,6 +9401,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -9439,14 +9507,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -9520,6 +9589,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -9546,13 +9616,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -9774,6 +9845,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -9879,14 +9951,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -9960,6 +10033,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -9986,13 +10060,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -10214,6 +10289,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -10319,14 +10395,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -10400,6 +10477,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -10426,13 +10504,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -10654,6 +10733,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -10826,6 +10906,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -10852,13 +10933,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -11080,6 +11162,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -11185,14 +11268,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultPattern"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_pattern"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultPattern"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -11266,6 +11350,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -11292,13 +11377,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >
@@ -11520,6 +11606,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                           selected={false}
                                                           selectedTimestamp="timestamp"
                                                           showTimestampOverrideButton={true}
+                                                          tabId="DEFAULT_INDEX_PATTERNS"
                                                         >
                                                           <EuiFlexGroup
                                                             alignItems="center"
@@ -11638,14 +11725,15 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                         color="text"
                                                                         data-test-subj="eventExplorer__overrideDefaultTimestamp"
                                                                         iconType="inputOutput"
+                                                                        isDisabled={true}
                                                                         onClick={[Function]}
                                                                         size="xs"
                                                                       >
                                                                         <button
                                                                           aria-labelledby="override_timestamp"
-                                                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                          className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
                                                                           data-test-subj="eventExplorer__overrideDefaultTimestamp"
-                                                                          disabled={false}
+                                                                          disabled={true}
                                                                           onClick={[Function]}
                                                                           type="button"
                                                                         >
@@ -11706,6 +11794,7 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                             aria-label="inspect"
                                                                             className="dscSidebarField__actionButton"
                                                                             iconType="inspect"
+                                                                            isDisabled={true}
                                                                             onClick={[Function]}
                                                                             size="xs"
                                                                           />
@@ -11732,13 +11821,14 @@ exports[`Siderbar component Renders sidebar component 1`] = `
                                                                               aria-label="inspect"
                                                                               className="dscSidebarField__actionButton"
                                                                               iconType="inspect"
+                                                                              isDisabled={true}
                                                                               onClick={[Function]}
                                                                               size="xs"
                                                                             >
                                                                               <button
                                                                                 aria-label="inspect"
-                                                                                className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
-                                                                                disabled={false}
+                                                                                className="euiButtonIcon euiButtonIcon-isDisabled euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall dscSidebarField__actionButton"
+                                                                                disabled={true}
                                                                                 onClick={[Function]}
                                                                                 type="button"
                                                                               >

--- a/public/components/event_analytics/explorer/sidebar/__tests__/field.test.tsx
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/field.test.tsx
@@ -9,6 +9,11 @@ import React from 'react';
 import { waitFor } from '@testing-library/react';
 import { Field } from '../field';
 import { AGENT_FIELD } from '../../../../../../test/event_analytics_constants';
+import { applyMiddleware, createStore } from 'redux';
+import { rootReducer } from '../../../../../framework/redux/reducers';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { DEFAULT_DATA_SOURCE_TYPE } from '../../../../../../common/constants/data_sources';
 
 describe('Field component', () => {
   configure({ adapter: new Adapter() });
@@ -17,21 +22,25 @@ describe('Field component', () => {
     const onToggleField = jest.fn();
     const handleOverrideTimestamp = jest.fn();
     const selectedTimestamp = 'timestamp';
-    
+    const store = createStore(rootReducer, applyMiddleware(thunk));
+
     const wrapper = mount(
-      <Field
-        field={AGENT_FIELD}
-        selectedTimestamp={selectedTimestamp}
-        handleOverrideTimestamp={handleOverrideTimestamp}
-        isOverridingTimestamp={false}
-        isFieldToggleButtonDisabled={false}
-        showTimestampOverrideButton={true}
-        onToggleField={onToggleField}
-        selected
-        showToggleButton={true}
-      />
+      <Provider store={store}>
+        <Field
+          field={AGENT_FIELD}
+          selectedTimestamp={selectedTimestamp}
+          handleOverrideTimestamp={handleOverrideTimestamp}
+          isOverridingTimestamp={false}
+          isFieldToggleButtonDisabled={false}
+          showTimestampOverrideButton={true}
+          onToggleField={onToggleField}
+          selected
+          showToggleButton={true}
+          tabId={DEFAULT_DATA_SOURCE_TYPE}
+        />
+      </Provider>
     );
-    
+
     wrapper.update();
 
     await waitFor(() => {

--- a/public/components/event_analytics/explorer/sidebar/__tests__/sidebar.test.tsx
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/sidebar.test.tsx
@@ -22,6 +22,10 @@ import {
   JSON_DATA,
   JSON_DATA_ALL,
 } from '../../../../../../test/event_analytics_constants';
+import { applyMiddleware, createStore } from 'redux';
+import { rootReducer } from '../../../../../framework/redux/reducers';
+import thunk from 'redux-thunk';
+import { DEFAULT_DATA_SOURCE_TYPE } from '../../../../../../common/constants/data_sources';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -82,9 +86,10 @@ describe('Siderbar component', () => {
       jsonData: JSON_DATA,
       jsonDataAll: JSON_DATA_ALL,
     };
+    const astore = createStore(rootReducer, applyMiddleware(thunk));
 
     const wrapper = mount(
-      <Provider store={store}>
+      <Provider store={astore}>
         <Sidebar
           explorerFields={explorerFields}
           explorerData={explorerData}
@@ -93,6 +98,7 @@ describe('Siderbar component', () => {
           isFieldToggleButtonDisabled={false}
           isOverridingTimestamp={false}
           storedExplorerFields={explorerFields}
+          tabId={DEFAULT_DATA_SOURCE_TYPE}
         />
       </Provider>
     );

--- a/public/components/event_analytics/explorer/sidebar/field.tsx
+++ b/public/components/event_analytics/explorer/sidebar/field.tsx
@@ -40,7 +40,7 @@ interface IFieldProps {
   showTimestampOverrideButton: boolean;
   isFieldToggleButtonDisabled: boolean;
   onToggleField: (field: IField) => void;
-  tabId: any;
+  tabId: string;
 }
 
 export const Field = (props: IFieldProps) => {
@@ -64,6 +64,7 @@ export const Field = (props: IFieldProps) => {
   const explorerSearchMeta = useSelector(selectSearchMetaData)[tabId] || {};
   const isDefaultDataSourceType =
     explorerSearchMeta.datasources?.[0]?.type === DEFAULT_DATA_SOURCE_TYPE;
+  const appLogEvents = tabId.startsWith('application-analytics-tab');
 
   const addLabelAria = i18n.translate('addButtonAriaLabel', {
     defaultMessage: 'Add {field} to table',
@@ -120,7 +121,7 @@ export const Field = (props: IFieldProps) => {
                   onClick={() => handleOverridePattern(field)}
                   data-test-subj="eventExplorer__overrideDefaultPattern"
                   className="dscSidebarField__actionButton"
-                  isDisabled={!isDefaultDataSourceType}
+                  isDisabled={!(isDefaultDataSourceType || appLogEvents)}
                 >
                   Override
                 </EuiButtonIcon>
@@ -159,7 +160,7 @@ export const Field = (props: IFieldProps) => {
                   onClick={() => handleOverrideTimestamp(field)}
                   data-test-subj="eventExplorer__overrideDefaultTimestamp"
                   className="dscSidebarField__actionButton"
-                  isDisabled={!isDefaultDataSourceType}
+                  isDisabled={!(isDefaultDataSourceType || appLogEvents)}
                 >
                   Override
                 </EuiButtonIcon>
@@ -184,7 +185,7 @@ export const Field = (props: IFieldProps) => {
                 onClick={togglePopover}
                 aria-label={'inspect'}
                 className="dscSidebarField__actionButton"
-                isDisabled={!isDefaultDataSourceType}
+                isDisabled={!(isDefaultDataSourceType || appLogEvents)}
               />
             }
           >

--- a/public/components/event_analytics/explorer/sidebar/field.tsx
+++ b/public/components/event_analytics/explorer/sidebar/field.tsx
@@ -18,10 +18,13 @@ import {
   EuiText,
   EuiBadge,
 } from '@elastic/eui';
+import { useSelector } from 'react-redux';
 import { FieldButton } from '../../../common/field_button';
 import { FieldIcon } from '../../../common/field_icon';
 import { IField } from '../../../../../common/types/explorer';
 import { FieldInsights } from './field_insights';
+import { DEFAULT_DATA_SOURCE_TYPE } from '../../../../../common/constants/data_sources';
+import { selectSearchMetaData } from '../../../event_analytics/redux/slices/search_meta_data_slice';
 
 interface IFieldProps {
   query: string;
@@ -37,6 +40,7 @@ interface IFieldProps {
   showTimestampOverrideButton: boolean;
   isFieldToggleButtonDisabled: boolean;
   onToggleField: (field: IField) => void;
+  tabId: any;
 }
 
 export const Field = (props: IFieldProps) => {
@@ -53,9 +57,13 @@ export const Field = (props: IFieldProps) => {
     isFieldToggleButtonDisabled = false,
     showTimestampOverrideButton = true,
     onToggleField,
+    tabId,
   } = props;
 
   const [isFieldDetailsOpen, setIsFieldDetailsOpen] = useState(false);
+  const explorerSearchMeta = useSelector(selectSearchMetaData)[tabId] || {};
+  const isDefaultDataSourceType =
+    explorerSearchMeta.datasources?.[0]?.type === DEFAULT_DATA_SOURCE_TYPE;
 
   const addLabelAria = i18n.translate('addButtonAriaLabel', {
     defaultMessage: 'Add {field} to table',
@@ -112,6 +120,7 @@ export const Field = (props: IFieldProps) => {
                   onClick={() => handleOverridePattern(field)}
                   data-test-subj="eventExplorer__overrideDefaultPattern"
                   className="dscSidebarField__actionButton"
+                  isDisabled={!isDefaultDataSourceType}
                 >
                   Override
                 </EuiButtonIcon>
@@ -150,6 +159,7 @@ export const Field = (props: IFieldProps) => {
                   onClick={() => handleOverrideTimestamp(field)}
                   data-test-subj="eventExplorer__overrideDefaultTimestamp"
                   className="dscSidebarField__actionButton"
+                  isDisabled={!isDefaultDataSourceType}
                 >
                   Override
                 </EuiButtonIcon>
@@ -174,6 +184,7 @@ export const Field = (props: IFieldProps) => {
                 onClick={togglePopover}
                 aria-label={'inspect'}
                 className="dscSidebarField__actionButton"
+                isDisabled={!isDefaultDataSourceType}
               />
             }
           >

--- a/public/components/event_analytics/explorer/sidebar/sidebar.tsx
+++ b/public/components/event_analytics/explorer/sidebar/sidebar.tsx
@@ -34,7 +34,7 @@ interface ISidebarProps {
   handleOverrideTimestamp: (timestamp: IField) => void;
   storedExplorerFields: IExplorerFields;
   setStoredExplorerFields: (explorer: IExplorerFields) => void;
-  tabId: any;
+  tabId: string;
 }
 
 export const Sidebar = (props: ISidebarProps) => {

--- a/public/components/event_analytics/explorer/sidebar/sidebar.tsx
+++ b/public/components/event_analytics/explorer/sidebar/sidebar.tsx
@@ -34,6 +34,7 @@ interface ISidebarProps {
   handleOverrideTimestamp: (timestamp: IField) => void;
   storedExplorerFields: IExplorerFields;
   setStoredExplorerFields: (explorer: IExplorerFields) => void;
+  tabId: any;
 }
 
 export const Sidebar = (props: ISidebarProps) => {
@@ -224,6 +225,7 @@ export const Sidebar = (props: ISidebarProps) => {
                                   isFieldToggleButtonDisabled={true}
                                   showTimestampOverrideButton={false}
                                   onToggleField={handleRemoveField}
+                                  tabId={tabId}
                                 />
                               </EuiPanel>
                             </EuiDraggable>
@@ -281,6 +283,7 @@ export const Sidebar = (props: ISidebarProps) => {
                               isFieldToggleButtonDisabled={isFieldToggleButtonDisabled}
                               showTimestampOverrideButton={true}
                               onToggleField={handleRemoveField}
+                              tabId={tabId}
                             />
                           </EuiPanel>
                         </EuiDraggable>
@@ -338,6 +341,7 @@ export const Sidebar = (props: ISidebarProps) => {
                                 selected={false}
                                 isFieldToggleButtonDisabled={isFieldToggleButtonDisabled}
                                 showTimestampOverrideButton={true}
+                                tabId={tabId}
                               />
                             </EuiPanel>
                           </EuiDraggable>


### PR DESCRIPTION
### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
