### PR TITLE
implements explorer data grid column reordering

### DIFF
--- a/common/constants/explorer.ts
+++ b/common/constants/explorer.ts
@@ -337,6 +337,10 @@ export const DEFAULT_TIMESTAMP_COLUMN = {
   display: 'Time',
   schema: 'datetime',
   initialWidth: 200,
+  actions: {
+    showMoveLeft: false,
+    showMoveRight: false,
+  },
 };
 
 export const DEFAULT_SOURCE_COLUMN = {
@@ -344,4 +348,8 @@ export const DEFAULT_SOURCE_COLUMN = {
   isSortable: false,
   display: 'Source',
   schema: '_source',
+  actions: {
+    showMoveLeft: false,
+    showMoveRight: false,
+  },
 };

--- a/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
+++ b/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
@@ -243,6 +243,10 @@ exports[`Datagrid component Renders data grid component 1`] = `
             columns={
               Array [
                 Object {
+                  "actions": Object {
+                    "showMoveLeft": false,
+                    "showMoveRight": false,
+                  },
                   "display": "Time",
                   "id": "timestamp",
                   "initialWidth": 200,
@@ -250,6 +254,10 @@ exports[`Datagrid component Renders data grid component 1`] = `
                   "schema": "datetime",
                 },
                 Object {
+                  "actions": Object {
+                    "showMoveLeft": false,
+                    "showMoveRight": false,
+                  },
                   "display": "Source",
                   "id": "_source",
                   "isSortable": false,
@@ -300,7 +308,7 @@ exports[`Datagrid component Renders data grid component 1`] = `
               Object {
                 "showColumnSelector": Object {
                   "allowHide": false,
-                  "allowReorder": true,
+                  "allowReorder": false,
                 },
                 "showFullScreenSelector": false,
                 "showStyleSelector": false,

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -138,6 +138,7 @@ export function DataGrid(props: DataGridProps) {
         visibleColumns: columns,
         setVisibleColumns: (visibleColumns: string[]) => {
           const fields: IField[] = [];
+          // fields within visibleColumns are re-created to be of type IField
           visibleColumns.map((col) => {
             fields.push({ name: col, type: getFieldTypes(col, explorerFields) });
           });
@@ -280,7 +281,7 @@ export function DataGrid(props: DataGridProps) {
           toolbarVisibility={{
             showColumnSelector: {
               allowHide: false,
-              allowReorder: true,
+              allowReorder: explorerFields.selectedFields.length > 0,
             },
             showFullScreenSelector: false,
             showStyleSelector: false,

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -137,20 +137,22 @@ export function DataGrid(props: DataGridProps) {
       return {
         visibleColumns: columns,
         setVisibleColumns: (visibleColumns: string[]) => {
-          const fields: IField[] = [];
-          // fields within visibleColumns are re-created to be of type IField
-          visibleColumns.map((col) => {
-            fields.push({ name: col, type: getFieldTypes(col, explorerFields) });
-          });
-          dispatch(
-            updateFields({
-              tabId,
-              data: {
-                ...explorerFields,
-                [SELECTED_FIELDS]: fields,
-              },
-            })
-          );
+          if (explorerFields.selectedFields.length > 0) {
+            const fields: IField[] = [];
+            // fields within visibleColumns are re-created to be of type IField
+            visibleColumns.map((col) => {
+              fields.push({ name: col, type: getFieldTypes(col, explorerFields) });
+            });
+            dispatch(
+              updateFields({
+                tabId,
+                data: {
+                  ...explorerFields,
+                  [SELECTED_FIELDS]: fields,
+                },
+              })
+            );
+          }
         },
       };
     }

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -140,7 +140,7 @@ export function DataGrid(props: DataGridProps) {
           if (explorerFields.selectedFields.length > 0) {
             const fields: IField[] = [];
             // fields within visibleColumns are re-created to be of type IField
-            visibleColumns.map((col) => {
+            visibleColumns.forEach((col) => {
               fields.push({ name: col, type: getFieldTypes(col, explorerFields) });
             });
             dispatch(

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -28,7 +28,7 @@ import { HttpSetup } from '../../../../../../../src/core/public';
 import PPLService from '../../../../services/requests/ppl';
 import { FlyoutButton } from './docViewRow';
 import { useFetchEvents } from '../../hooks';
-import { redoQuery } from '../../utils/utils';
+import { redoQuery, getFieldTypes } from '../../utils/utils';
 import { updateFields } from '../../redux/slices/field_slice';
 
 interface DataGridProps {
@@ -77,18 +77,6 @@ export function DataGrid(props: DataGridProps) {
   const pageFields = useRef([0, 100]);
 
   const [data, setData] = useState(rows);
-
-  // method to return the type of a field from its name
-  const getFieldTypes = (newFieldName: string) => {
-    let fieldType: string = '';
-    explorerFields.availableFields.map((field) => {
-      if (field.name === newFieldName) fieldType = field.type;
-    });
-    explorerFields.selectedFields.map((field) => {
-      if (field.name === newFieldName) fieldType = field.type;
-    });
-    return fieldType;
-  };
 
   // setSort and setPage are used to change the query and send a direct request to get data
   const setSort = (sort: EuiDataGridSorting['columns']) => {
@@ -151,7 +139,7 @@ export function DataGrid(props: DataGridProps) {
         setVisibleColumns: (visibleColumns: string[]) => {
           const fields: IField[] = [];
           visibleColumns.map((col) => {
-            fields.push({ name: col, type: getFieldTypes(col) });
+            fields.push({ name: col, type: getFieldTypes(col, explorerFields) });
           });
           dispatch(
             updateFields({

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -581,6 +581,7 @@ export const Explorer = ({
                         requestParams={requestParams}
                         startTime={appLogEvents ? startTime : dateRange[0]}
                         endTime={appLogEvents ? endTime : dateRange[1]}
+                        tabId={tabId}
                       />
                     )}
                     <a tabIndex={0} id="discoverBottomMarker">

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -900,12 +900,12 @@ export const Explorer = ({
           <EuiSplitPanel.Outer className="eui-yScroll" hasBorder={true} borderRadius="none">
             {!appLogEvents && (
               <EuiSplitPanel.Inner paddingSize="s" color="subdued" grow={false}>
-                <DataSourceSelection tabId={initialTabId} />
+                <DataSourceSelection tabId={tabId} />
               </EuiSplitPanel.Inner>
             )}
             <EuiSplitPanel.Inner paddingSize="none" color="subdued" className="eui-yScroll">
               <ObservabilitySideBar
-                tabId={initialTabId}
+                tabId={tabId}
                 pplService={pplService}
                 notifications={notifications}
               />

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -117,7 +117,6 @@ import { ExplorerVisualizations } from './visualizations';
 import { CountDistribution } from './visualizations/count_distribution';
 import { DirectQueryVisualization } from './visualizations/direct_query_vis';
 import { DataSourceSelection } from './datasources/datasources_selection';
-import { initialTabId } from '../../../framework/redux/store/shared_state';
 import { ObservabilitySideBar } from './sidebar/observability_sidebar';
 import { ExplorerSavedObjectLoader } from '../../../services/saved_objects/saved_object_loaders/explorer_saved_object_loader';
 import {

--- a/public/components/event_analytics/explorer/sidebar/sidebar.tsx
+++ b/public/components/event_analytics/explorer/sidebar/sidebar.tsx
@@ -87,25 +87,31 @@ export const Sidebar = (props: ISidebarProps) => {
     return nextFields;
   };
 
-  const updateStoreFields = (fieldsData: ExplorerFields) => {
-    dispatch(
-      updateFields({
-        tabId,
-        data: {
-          ...fieldsData,
-        },
-      })
-    );
-  };
+  const updateStoreFields = useCallback(
+    (fieldsData: ExplorerFields) => {
+      dispatch(
+        updateFields({
+          tabId,
+          data: {
+            ...fieldsData,
+          },
+        })
+      );
+    },
+    [explorerFields, tabId]
+  );
 
-  const sortStoreFields = (fieldName: string) => {
-    dispatch(
-      sortFields({
-        tabId,
-        data: [fieldName],
-      })
-    );
-  };
+  const sortStoreFields = useCallback(
+    (fieldName: string) => {
+      dispatch(
+        sortFields({
+          tabId,
+          data: [fieldName],
+        })
+      );
+    },
+    [explorerFields, tabId]
+  );
 
   // handling moving a field from available to selected
   const handleAddField = useCallback(
@@ -135,7 +141,6 @@ export const Sidebar = (props: ISidebarProps) => {
     source: any;
     draggableId: string;
   }) => {
-    console.log(destination);
     // check if the destination and source are the same area
     if (destination.droppableId !== source.droppableId) {
       // if dropped into the selected fields: add, if dropped into available: remove

--- a/public/components/event_analytics/explorer/sidebar/sidebar.tsx
+++ b/public/components/event_analytics/explorer/sidebar/sidebar.tsx
@@ -20,6 +20,7 @@ import { AVAILABLE_FIELDS, SELECTED_FIELDS } from '../../../../../common/constan
 import { ExplorerFields, IExplorerFields, IField } from '../../../../../common/types/explorer';
 import { sortFields, updateFields } from '../../redux/slices/field_slice';
 import { Field } from './field';
+import { getFieldTypes } from '../../utils/utils';
 
 interface ISidebarProps {
   query: string;
@@ -54,18 +55,6 @@ export const Sidebar = (props: ISidebarProps) => {
   const dispatch = useDispatch();
   const [showFields, setShowFields] = useState<boolean>(false);
   const [searchTerm, setSearchTerm] = useState<string>('');
-
-  // method to return the type of a field from its name
-  const getFieldTypes = (newFieldName: string) => {
-    let fieldType: string = '';
-    explorerFields.availableFields.map((field) => {
-      if (field.name === newFieldName) fieldType = field.type;
-    });
-    explorerFields.selectedFields.map((field) => {
-      if (field.name === newFieldName) fieldType = field.type;
-    });
-    return fieldType;
-  };
 
   /**
    * Toggle fields between selected and unselected sets
@@ -143,9 +132,9 @@ export const Sidebar = (props: ISidebarProps) => {
     if (destination.droppableId !== source.droppableId) {
       // if dropped into the selected fields: add, if dropped into available: remove
       if (destination.droppableId === 'SELECTED FIELDS') {
-        handleAddField({ name: draggableId, type: getFieldTypes(draggableId) });
+        handleAddField({ name: draggableId, type: getFieldTypes(draggableId, explorerFields) });
       } else if (destination.droppableId === 'AVAILABLE FIELDS') {
-        handleRemoveField({ name: draggableId, type: getFieldTypes(draggableId) });
+        handleRemoveField({ name: draggableId, type: getFieldTypes(draggableId, explorerFields) });
       }
     }
   };

--- a/public/components/event_analytics/utils/utils.tsx
+++ b/public/components/event_analytics/utils/utils.tsx
@@ -445,11 +445,11 @@ export const redoQuery = (
 
 // method to return the type of a field from its name
 export const getFieldTypes = (newFieldName: string, explorerFields: IExplorerFields) => {
-  explorerFields.availableFields.forEach((field) => {
+  for (const field of explorerFields.availableFields) {
     if (field.name === newFieldName) return field.type;
-  });
-  explorerFields.selectedFields.forEach((field) => {
+  }
+  for (const field of explorerFields.selectedFields) {
     if (field.name === newFieldName) return field.type;
-  });
+  }
   return '';
 };

--- a/public/components/event_analytics/utils/utils.tsx
+++ b/public/components/event_analytics/utils/utils.tsx
@@ -442,3 +442,15 @@ export const redoQuery = (
     setData(res.jsonData);
   });
 };
+
+// method to return the type of a field from its name
+export const getFieldTypes = (newFieldName: string, explorerFields: IExplorerFields) => {
+  let fieldType: string = '';
+  explorerFields.availableFields.map((field) => {
+    if (field.name === newFieldName) fieldType = field.type;
+  });
+  explorerFields.selectedFields.map((field) => {
+    if (field.name === newFieldName) fieldType = field.type;
+  });
+  return fieldType;
+};

--- a/public/components/event_analytics/utils/utils.tsx
+++ b/public/components/event_analytics/utils/utils.tsx
@@ -445,12 +445,11 @@ export const redoQuery = (
 
 // method to return the type of a field from its name
 export const getFieldTypes = (newFieldName: string, explorerFields: IExplorerFields) => {
-  let fieldType: string = '';
-  explorerFields.availableFields.map((field) => {
-    if (field.name === newFieldName) fieldType = field.type;
+  explorerFields.availableFields.forEach((field) => {
+    if (field.name === newFieldName) return field.type;
   });
-  explorerFields.selectedFields.map((field) => {
-    if (field.name === newFieldName) fieldType = field.type;
+  explorerFields.selectedFields.forEach((field) => {
+    if (field.name === newFieldName) return field.type;
   });
-  return fieldType;
+  return '';
 };


### PR DESCRIPTION
### Description
Implements data grid column reordering within the column toolbar drag and drop. Also implements it within the sidebar fields drag and drop, where the order of the selected fields can be manipulated but the available fields will still be sorted alphabetically.

### Issues Resolved
This PR also resolves an issue within app analytics where the sidebar isn't populated with any fields.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
