### PR TITLE
Remove manual refresh for S3 integrations

### DIFF
--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -397,7 +397,13 @@ export function SetupBottomBar({
                     '{table_name}',
                     `${config.connectionDataSource}.default.${config.connectionTableName}`
                   );
-                  queryStr = queryStr.replaceAll('{s3_bucket_location}', config.connectionLocation);
+                  // We append to this URI in internal queries, so we normalize it to have no trailing slash
+                  let trimmedLocation = config.connectionLocation.trim();
+                  trimmedLocation = trimmedLocation.endsWith('/')
+                    ? trimmedLocation.slice(0, trimmedLocation.length - 1)
+                    : trimmedLocation;
+
+                  queryStr = queryStr.replaceAll('{s3_bucket_location}', trimmedLocation);
                   queryStr = queryStr.replaceAll('{object_name}', config.connectionTableName);
                   queryStr = queryStr.replaceAll(/\s+/g, ' ');
                   const result = await runQuery(queryStr, config.connectionDataSource, sessionId);

--- a/server/adaptors/integrations/__data__/repository/aws_elb/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_elb/assets/create_mv-1.0.0.sql
@@ -38,4 +38,10 @@ SELECT
     classification as `aws.elb.classification`,
     classification_reason as `aws.elb.classification_reason`
 FROM
-    {table_name};
+    {table_name}
+WITH (
+    auto_refresh = 'true',
+    checkpoint_location = '{s3_bucket_location}/checkpoint',
+    watermark_delay = '1 Minute',
+    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+);

--- a/server/adaptors/integrations/__data__/repository/aws_elb/assets/refresh_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_elb/assets/refresh_mv-1.0.0.sql
@@ -1,1 +1,0 @@
-REFRESH MATERIALIZED VIEW {table_name}_mview;

--- a/server/adaptors/integrations/__data__/repository/aws_elb/aws_elb-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/aws_elb/aws_elb-1.0.0.json
@@ -61,11 +61,6 @@
         "name": "create_mv",
         "version": "1.0.0",
         "language": "sql"
-      },
-      {
-        "name": "refresh_mv",
-        "version": "1.0.0",
-        "language": "sql"
       }
     ]
   },

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_mv_vpc-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/create_mv_vpc-1.0.0.sql
@@ -21,4 +21,10 @@ CREATE MATERIALIZED VIEW {table_name}_mview AS
           ELSE 'egress'
         END AS `aws.vpc.flow-direction`
 FROM
-    {table_name};
+    {table_name}
+WITH (
+    auto_refresh = 'true',
+    checkpoint_location = '{s3_bucket_location}/checkpoint',
+    watermark_delay = '1 Minute',
+    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+)

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/refresh_mv_vpc-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/refresh_mv_vpc-1.0.0.sql
@@ -1,1 +1,0 @@
-REFRESH MATERIALIZED VIEW {table_name}_mview

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/aws_vpc_flow-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/aws_vpc_flow-1.0.0.json
@@ -57,11 +57,6 @@
         "name": "create_mv_vpc",
         "version": "1.0.0",
         "language": "sql"
-      },
-      {
-        "name": "refresh_mv_vpc",
-        "version": "1.0.0",
-        "language": "sql"
       }
     ]
   },

--- a/server/adaptors/integrations/__data__/repository/nginx/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/nginx/assets/create_mv-1.0.0.sql
@@ -8,3 +8,9 @@ SELECT
     body_bytes_sent AS `http.response.bytes`,
     'nginx.access' AS `event.domain`
 FROM {table_name}
+WITH (
+    auto_refresh = 'true',
+    checkpoint_location = '{s3_bucket_location}/checkpoint',
+    watermark_delay = '1 Minute',
+    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+);

--- a/server/adaptors/integrations/__data__/repository/nginx/assets/refresh_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/nginx/assets/refresh_mv-1.0.0.sql
@@ -1,1 +1,0 @@
-REFRESH MATERIALIZED VIEW {table_name}_mview

--- a/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
@@ -49,11 +49,6 @@
         "name": "create_mv",
         "version": "1.0.0",
         "language": "sql"
-      },
-      {
-        "name": "refresh_mv",
-        "version": "1.0.0",
-        "language": "sql"
       }
     ]
   },


### PR DESCRIPTION
### Description
Instead of doing the refresh synchronously as part of integration installation, we configure the MV for autorefresh and let it run in the background. This can lead to some start-up time for integrations before showing data, but speeds up the installation process.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
