### PR TITLE
Refactor repository reading for recursive directory searching

### DIFF
--- a/server/adaptors/integrations/__test__/local_repository.test.ts
+++ b/server/adaptors/integrations/__test__/local_repository.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RepositoryReader } from '../repository/repository';
+import { TemplateManager } from '../repository/repository';
 import { IntegrationReader } from '../repository/integration';
 import path from 'path';
 import * as fs from 'fs/promises';
@@ -27,7 +27,7 @@ describe('The local repository', () => {
   });
 
   it('Should pass deep validation for all local integrations.', async () => {
-    const repository: RepositoryReader = new RepositoryReader(
+    const repository: TemplateManager = new TemplateManager(
       path.join(__dirname, '../__data__/repository')
     );
     const integrations: IntegrationReader[] = await repository.getIntegrationList();

--- a/server/adaptors/integrations/__test__/manager.test.ts
+++ b/server/adaptors/integrations/__test__/manager.test.ts
@@ -5,14 +5,14 @@
 
 import { IntegrationsManager } from '../integrations_manager';
 import { SavedObject, SavedObjectsClientContract } from '../../../../../../src/core/server/types';
-import { RepositoryReader } from '../repository/repository';
+import { TemplateManager } from '../repository/repository';
 import { IntegrationInstanceBuilder } from '../integrations_builder';
 import { IntegrationReader } from '../repository/integration';
 import { SavedObjectsFindResponse } from '../../../../../../src/core/server';
 
 describe('IntegrationsKibanaBackend', () => {
   let mockSavedObjectsClient: jest.Mocked<SavedObjectsClientContract>;
-  let mockRepository: jest.Mocked<RepositoryReader>;
+  let mockRepository: jest.Mocked<TemplateManager>;
   let backend: IntegrationsManager;
 
   beforeEach(() => {

--- a/server/adaptors/integrations/integrations_manager.ts
+++ b/server/adaptors/integrations/integrations_manager.ts
@@ -8,17 +8,17 @@ import { addRequestToMetric } from '../../common/metrics/metrics_helper';
 import { IntegrationsAdaptor } from './integrations_adaptor';
 import { SavedObject, SavedObjectsClientContract } from '../../../../../src/core/server/types';
 import { IntegrationInstanceBuilder } from './integrations_builder';
-import { RepositoryReader } from './repository/repository';
+import { TemplateManager } from './repository/repository';
 
 export class IntegrationsManager implements IntegrationsAdaptor {
   client: SavedObjectsClientContract;
   instanceBuilder: IntegrationInstanceBuilder;
-  repository: RepositoryReader;
+  repository: TemplateManager;
 
-  constructor(client: SavedObjectsClientContract, repository?: RepositoryReader) {
+  constructor(client: SavedObjectsClientContract, repository?: TemplateManager) {
     this.client = client;
     this.repository =
-      repository ?? new RepositoryReader(path.join(__dirname, '__data__/repository'));
+      repository ?? new TemplateManager(path.join(__dirname, '__data__/repository'));
     this.instanceBuilder = new IntegrationInstanceBuilder(this.client);
   }
 

--- a/server/adaptors/integrations/repository/__test__/repository.test.ts
+++ b/server/adaptors/integrations/repository/__test__/repository.test.ts
@@ -18,6 +18,10 @@ describe('Repository', () => {
     repository = new TemplateManager('path/to/directory');
   });
 
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('getIntegrationList', () => {
     it('should return an array of Integration instances', async () => {
       jest.spyOn(fs, 'readdir').mockResolvedValue((['folder1', 'folder2'] as unknown) as Dirent[]);

--- a/server/adaptors/integrations/repository/__test__/repository.test.ts
+++ b/server/adaptors/integrations/repository/__test__/repository.test.ts
@@ -4,7 +4,7 @@
  */
 
 import * as fs from 'fs/promises';
-import { RepositoryReader } from '../repository';
+import { TemplateManager } from '../repository';
 import { IntegrationReader } from '../integration';
 import { Dirent, Stats } from 'fs';
 import path from 'path';
@@ -12,10 +12,10 @@ import path from 'path';
 jest.mock('fs/promises');
 
 describe('Repository', () => {
-  let repository: RepositoryReader;
+  let repository: TemplateManager;
 
   beforeEach(() => {
-    repository = new RepositoryReader('path/to/directory');
+    repository = new TemplateManager('path/to/directory');
   });
 
   describe('getIntegrationList', () => {

--- a/server/adaptors/integrations/repository/repository.ts
+++ b/server/adaptors/integrations/repository/repository.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { IntegrationReader } from './integration';
 import { FileSystemCatalogDataAdaptor } from './fs_data_adaptor';
 
-export class RepositoryReader {
+export class TemplateManager {
   reader: CatalogDataAdaptor;
   directory: string;
 

--- a/server/adaptors/integrations/repository/repository.ts
+++ b/server/adaptors/integrations/repository/repository.ts
@@ -24,7 +24,9 @@ export class TemplateManager {
       return [];
     }
     const integrations = await Promise.all(
-      folders.value.map((i) => this.getIntegration(path.basename(i)))
+      folders.value.map((i) =>
+        this.getIntegration(path.relative(this.directory, path.join(this.directory, i)))
+      )
     );
     return integrations.filter((x) => x !== null) as IntegrationReader[];
   }

--- a/server/adaptors/integrations/repository/repository.ts
+++ b/server/adaptors/integrations/repository/repository.ts
@@ -31,15 +31,15 @@ export class TemplateManager {
     return integrations.filter((x) => x !== null) as IntegrationReader[];
   }
 
-  async getIntegration(name: string): Promise<IntegrationReader | null> {
-    if ((await this.reader.getDirectoryType(name)) !== 'integration') {
-      console.error(`Requested integration '${name}' does not exist`);
+  async getIntegration(integPath: string): Promise<IntegrationReader | null> {
+    if ((await this.reader.getDirectoryType(integPath)) !== 'integration') {
+      console.error(`Requested integration '${integPath}' does not exist`);
       return null;
     }
-    const integ = new IntegrationReader(name, this.reader.join(name));
+    const integ = new IntegrationReader(integPath, this.reader.join(integPath));
     const checkResult = await integ.getConfig();
     if (!checkResult.ok) {
-      console.error(`Integration '${name}' is invalid:`, checkResult.error);
+      console.error(`Integration '${integPath}' is invalid:`, checkResult.error);
       return null;
     }
     return integ;


### PR DESCRIPTION
### Description
This PR does some refactoring of the repository class to better handle recursive directories and make its role more flexible. There are still some updates needed to add searching a local recursive repository (mostly regarding locating specific integrations), but that will be enabled when catalog metadata is added.

### Issues Resolved
Resolves #1236 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
