### PR TITLE
Revert "Switch heading types on integrations setup page (#1136) (#1137)"

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -60,15 +60,13 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
+                          <EuiTitle>
+                            <h2
+                              className="euiTitle euiTitle--medium"
                             >
-                              <h3>
-                                Integration Details
-                              </h3>
-                            </div>
-                          </EuiText>
+                              Integration Details
+                            </h2>
+                          </EuiTitle>
                           <EuiSpacer>
                             <div
                               className="euiSpacer euiSpacer--l"
@@ -150,15 +148,13 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
+                          <EuiTitle>
+                            <h2
+                              className="euiTitle euiTitle--medium"
                             >
-                              <h3>
-                                Integration Connection
-                              </h3>
-                            </div>
-                          </EuiText>
+                              Integration Connection
+                            </h2>
+                          </EuiTitle>
                           <EuiSpacer>
                             <div
                               className="euiSpacer euiSpacer--l"
@@ -1045,15 +1041,13 @@ exports[`Integration Setup Page Renders the form as expected 1`] = `
           className="euiSpacer euiSpacer--l"
         />
       </EuiSpacer>
-      <EuiText>
-        <div
-          className="euiText euiText--medium"
+      <EuiTitle>
+        <h2
+          className="euiTitle euiTitle--medium"
         >
-          <h3>
-            Integration Details
-          </h3>
-        </div>
-      </EuiText>
+          Integration Details
+        </h2>
+      </EuiTitle>
       <EuiSpacer>
         <div
           className="euiSpacer euiSpacer--l"
@@ -1135,15 +1129,13 @@ exports[`Integration Setup Page Renders the form as expected 1`] = `
           className="euiSpacer euiSpacer--l"
         />
       </EuiSpacer>
-      <EuiText>
-        <div
-          className="euiText euiText--medium"
+      <EuiTitle>
+        <h2
+          className="euiTitle euiTitle--medium"
         >
-          <h3>
-            Integration Connection
-          </h3>
-        </div>
-      </EuiText>
+          Integration Connection
+        </h2>
+      </EuiTitle>
       <EuiSpacer>
         <div
           className="euiSpacer euiSpacer--l"

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -194,9 +194,9 @@ export function SetupIntegrationForm({
         <h1>Set Up Integration</h1>
       </EuiTitle>
       <EuiSpacer />
-      <EuiText>
-        <h3>Integration Details</h3>
-      </EuiText>
+      <EuiTitle>
+        <h2>Integration Details</h2>
+      </EuiTitle>
       <EuiSpacer />
       <EuiFormRow label="Display Name">
         <EuiFieldText
@@ -206,9 +206,9 @@ export function SetupIntegrationForm({
         />
       </EuiFormRow>
       <EuiSpacer />
-      <EuiText>
-        <h3>Integration Connection</h3>
-      </EuiText>
+      <EuiTitle>
+        <h2>Integration Connection</h2>
+      </EuiTitle>
       <EuiSpacer />
       <EuiFormRow label="Data Source" helpText="Select a data source to connect to.">
         <EuiSelect


### PR DESCRIPTION
This reverts commit 71967041344cd3bad4edfb86a298b29ea75c9050.

### Description
Add one missing commit.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
