### PR TITLE
Load PromQL Visualization on OSD Dashboard and Obs. Dashboards

### DIFF
--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -78,6 +78,10 @@ export const PPL_PATTERNS_DOCUMENTATION_URL =
 export const UI_DATE_FORMAT = 'MM/DD/YYYY hh:mm A';
 export const PPL_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSSSS';
 export const SPAN_REGEX = /span/;
+
+export const PROMQL_METRIC_SUBTYPE = 'promqlmetric';
+export const PPL_METRIC_SUBTYPE = 'metric';
+
 export const PPL_SPAN_REGEX = /by\s*span/i;
 export const PPL_STATS_REGEX = /\|\s*stats/i;
 export const PPL_INDEX_INSERT_POINT_REGEX = /(search source|source|index)\s*=\s*([^|\s]+)(.*)/i;
@@ -210,7 +214,7 @@ export const DEFAULT_CHART_STYLES: DefaultChartStylesProps = {
   FillOpacity: 100,
   MarkerSize: 5,
   ShowLegend: 'show',
-  LegendPosition: 'v',
+  LegendPosition: 'h',
   LabelAngle: 0,
   DefaultSortSectors: 'largest_to_smallest',
   DefaultModeScatter: 'markers',
@@ -243,6 +247,7 @@ export const VISUALIZATION_ERROR = {
   NO_DATA: 'No data found.',
   INVALID_DATA: 'Invalid visualization data',
   NO_SERIES: 'Add a field to start',
+  NO_METRIC: 'Invalid Metric MetaData',
 };
 
 export const S3_DATASOURCE_TYPE = 'S3_DATASOURCE';

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -193,6 +193,19 @@ export const VisualizationContainer = ({
     </EuiContextMenuItem>,
   ];
 
+  const showPPLQueryPanel = [
+    <EuiContextMenuItem
+      data-test-subj="showCatalogPPLQuery"
+      key="view_query"
+      onClick={() => {
+        closeActionsMenu();
+        showModal('catalogModal');
+      }}
+    >
+      View query
+    </EuiContextMenuItem>,
+  ];
+
   const showModelPanel = [
     <EuiContextMenuItem
       data-test-subj="showCatalogPPLQuery"
@@ -207,12 +220,14 @@ export const VisualizationContainer = ({
     </EuiContextMenuItem>,
   ];
 
-  if (usedInNotebooks) {
-    popoverPanel = catalogVisualization ? [showModelPanel] : [popoverPanel[0]];
+  if (visualizationMetaData?.sub_type === PROMQL_METRIC_SUBTYPE) {
+    popoverPanel = [showPPLQueryPanel];
+  } else if (usedInNotebooks) {
+    popoverPanel = [popoverPanel[0]];
   }
 
   const loadVisaulization = async () => {
-    if (catalogVisualization)
+    if (visualization.sub_type === PROMQL_METRIC_SUBTYPE)
       await renderCatalogVisualization({
         http,
         pplService,

--- a/public/components/metrics/redux/slices/metrics_slice.ts
+++ b/public/components/metrics/redux/slices/metrics_slice.ts
@@ -17,6 +17,7 @@ import { SavedObjectsActions } from '../../../../services/saved_objects/saved_ob
 import { ObservabilitySavedVisualization } from '../../../../services/saved_objects/saved_object_client/types';
 import { getNewVizDimensions, pplServiceRequestor, sortMetricLayout } from '../../helpers/utils';
 import { coreRefs } from '../../../../framework/core_refs';
+import { PPL_METRIC_SUBTYPE, PROMQL_METRIC_SUBTYPE } from '../../../../../common/constants/shared';
 
 export interface IconAttributes {
   color: string;
@@ -75,8 +76,8 @@ const fetchCustomMetrics = async () => {
   const dataSet = await SavedObjectsActions.getBulk<ObservabilitySavedVisualization>({
     objectType: [SAVED_VISUALIZATION],
   });
-  const savedMetrics = dataSet.observabilityObjectList.filter(
-    (obj) => obj.savedVisualization.sub_type === 'metric'
+  const savedMetrics = dataSet.observabilityObjectList.filter((obj) =>
+    [PROMQL_METRIC_SUBTYPE, PPL_METRIC_SUBTYPE].includes(obj.savedVisualization?.sub_type)
   );
   return savedMetrics.map((obj: any) => ({
     id: obj.objectId,
@@ -104,7 +105,15 @@ const fetchRemoteMetrics = async (remoteDataSources: string[]): Promise<any> => 
         id: `${obj.TABLE_CATALOG}.${obj.TABLE_NAME}`,
         name: `${obj.TABLE_CATALOG}.${obj.TABLE_NAME}`,
         catalog: `${dataSource}`,
-        type: obj.TABLE_TYPE,
+        catalogSourceName: dataSource,
+        catalogTableName: obj.TABLE_NAME,
+        index: `${dataSource}.${obj.TABLE_NAME}`,
+        query: undefined,
+        aggregation: 'avg',
+        attributesGroupBy: [],
+        availableAttributes: [],
+        type: 'line',
+        sub_type: PROMQL_METRIC_SUBTYPE,
         recentlyCreated: false,
       }))
     )


### PR DESCRIPTION
Signed-off-by: Peter Fitzgibbons <peter.fitzgibbons@gmail.com>

### Description
Correctly load PromQL metric visualization on dashboards

### Issues Resolved
References #1084

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
