### PR TITLE
Remove Summary When Generated PPL Query Returns No Reuslts

### DIFF
--- a/public/components/event_analytics/explorer/llm/input.tsx
+++ b/public/components/event_analytics/explorer/llm/input.tsx
@@ -191,46 +191,48 @@ export const LLMInput: React.FC<Props> = (props) => {
   };
   const generateSummary = async (context?: Partial<SummarizationContext>) => {
     try {
-      const isError = summaryData.responseForSummaryStatus === 'failure';
-      const summarizationContext: SummarizationContext = {
-        question: props.nlqInput,
-        index: props.selectedIndex[0].label,
-        isError,
-        query: queryRedux.rawQuery,
-        response: isError
-          ? String(JSON.parse(explorerData.error.body.message).error.details)
-          : JSON.stringify({
-              datarows: explorerData.datarows,
-              schema: explorerData.schema,
-              size: explorerData.size,
-              total: explorerData.total,
-            }).slice(0, 7000),
-        ...context,
-      };
-      await dispatch(
-        changeSummary({
-          tabId: props.tabId,
-          data: {
-            summaryLoading: true,
-            isPPLError: isError,
-          },
-        })
-      );
-      const summary = await getOSDHttp().post<{
-        summary: string;
-        suggestedQuestions: string[];
-      }>('/api/assistant/summarize', {
-        body: JSON.stringify(summarizationContext),
-      });
-      await dispatch(
-        changeSummary({
-          tabId: props.tabId,
-          data: {
-            summary: summary.summary,
-            suggestedQuestions: summary.suggestedQuestions,
-          },
-        })
-      );
+      if (explorerData.total > 0) {
+        const isError = summaryData.responseForSummaryStatus === 'failure';
+        const summarizationContext: SummarizationContext = {
+          question: props.nlqInput,
+          index: props.selectedIndex[0].label,
+          isError,
+          query: queryRedux.rawQuery,
+          response: isError
+            ? String(JSON.parse(explorerData.error.body.message).error.details)
+            : JSON.stringify({
+                datarows: explorerData.datarows,
+                schema: explorerData.schema,
+                size: explorerData.size,
+                total: explorerData.total,
+              }).slice(0, 7000),
+          ...context,
+        };
+        await dispatch(
+          changeSummary({
+            tabId: props.tabId,
+            data: {
+              summaryLoading: true,
+              isPPLError: isError,
+            },
+          })
+        );
+        const summary = await getOSDHttp().post<{
+          summary: string;
+          suggestedQuestions: string[];
+        }>('/api/assistant/summarize', {
+          body: JSON.stringify(summarizationContext),
+        });
+        await dispatch(
+          changeSummary({
+            tabId: props.tabId,
+            data: {
+              summary: summary.summary,
+              suggestedQuestions: summary.suggestedQuestions,
+            },
+          })
+        );
+      }
     } catch (error) {
       coreRefs.toasts?.addError(formatError(error), { title: 'Failed to summarize results' });
     } finally {


### PR DESCRIPTION
### Description
Query Assistant in the Event Explorer offers AI insight when a natural language query is generated an run. This PR removes the insights when the resulting query has no returned data.

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
