### PR TITLE
Add enforce-labels action

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -16,30 +16,23 @@ replacers:
 categories:
   - title: 'Breaking Changes'
     labels:
-      - 'Breaking Changes'
+      - 'breaking'
   - title: 'Features'
     labels:
       - 'feature'
-  - title: 'Enhancements'
-    labels:
       - 'enhancement'
   - title: 'Bug Fixes'
     labels:
       - 'bug'
   - title: 'Infrastructure'
     labels:
-      - 'infra'
-      - 'test'
-      - 'dependencies'
-      - 'github actions'
+      - 'infrastructure'
+      - 'testing'
+      - 'integ-test-failure'
+      - 'repository'
   - title: 'Documentation'
     labels:
       - 'documentation'
   - title: 'Maintenance'
     labels:
-      - "version compatibility"
       - "maintenance"
-  - title: 'Refactoring'
-    labels:
-      - 'refactor'
-      - 'code quality'

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: "breaking,feature,enhancement,bug,infrastructure,dependencies,documentation,maintenance,skip-changelog"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "A release label is required: ['breaking', 'bug', 'dependencies', 'documentation', 'enhancement', 'feature', 'infrastructure', 'maintenance', 'skip-changelog']"


### PR DESCRIPTION
### Description
Copies the mandatory PR label action from [observability](https://github.com/opensearch-project/observability/).

### Issues Resolved
Closes #1281.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
