### PR TITLE
[Forwardport main] Minor changes for cypress workflow

### DIFF
--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -1,8 +1,7 @@
 name: Dashboards observability plugin E2E test
-on:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
+
+on: [pull_request, push]
+
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
@@ -11,6 +10,7 @@ env:
 
 jobs:
   tests:
+    name: Run test group of ${{ matrix.testgroups }}
     env:
       # Prevents extra Cypress installation progress messages
       CI: 1
@@ -25,7 +25,6 @@ jobs:
         java: [11]
         testgroups: [
           app_analytics_test,
-          notebooks_test,
           datasources_test,
           event_analytics_test,
           integrations_test,
@@ -130,18 +129,12 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           cd ./OpenSearch-Dashboards
-          echo "Start checking OpenSearch Dashboards."
-          for i in {1..60}; do
-            if grep -q "bundles compiled successfully after" "dashboard.log"; then
-              echo "OpenSearch Dashboards compiled successfully."
-              break
-            fi
-            if [ $i -eq 60 ]; then
-              echo "Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling."
-              exit 1
-            fi
-            sleep 10
-          done
+          if timeout 600 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
+            echo "OpenSearch Dashboards compiled successfully."
+          else
+            echo "Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling."
+            exit 1
+          fi
 
       - name: Install Cypress
         run: |


### PR DESCRIPTION
### Description
Reference to the [comment](https://github.com/opensearch-project/dashboards-observability/pull/1299#issuecomment-1856485992) on #1299, this PR includes following minor changes:

- Change the OSD checking step by using streaming instead of looping 
- Add dynamic naming for each parallel job
- Enabled this workflow on PR
- Remove a duplicate group of notebooks_test

### Issues Resolved
* Relate #1299 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
