### PR TITLE
fix: add default timestamp field

### DIFF
--- a/public/components/custom_panels/helpers/utils.tsx
+++ b/public/components/custom_panels/helpers/utils.tsx
@@ -120,9 +120,10 @@ const queryAccumulator = (
   }
   const indexPartOfQuery = indexMatchArray[0];
   const filterPartOfQuery = originalQuery.replace(PPL_INDEX_REGEX, '');
-  const timeQueryFilter = ` | where ${timestampField} >= '${convertDateTime(
+  const finalTimestampField = timestampField || 'timestamp';
+  const timeQueryFilter = ` | where ${finalTimestampField} >= '${convertDateTime(
     startTime
-  )}' and ${timestampField} <= '${convertDateTime(endTime, false)}'`;
+  )}' and ${finalTimestampField} <= '${convertDateTime(endTime, false)}'`;
   const pplFilterQuery = panelFilterQuery === '' ? '' : ` | ${panelFilterQuery}`;
 
   return indexPartOfQuery + timeQueryFilter + pplFilterQuery + filterPartOfQuery;


### PR DESCRIPTION
### Description
We are integrating ppl_visualization in Notebook page and found that if the timestamp field of a ppl metadata is empty string, the ppl_visualization is unable to launch and render in Notebook page, but is able to render in visualization detail page.

#### Before:
Unable to render in Notebook page:
![image](https://github.com/opensearch-project/dashboards-observability/assets/13493605/627d14aa-3582-4494-8a35-fd5dfa6725da)

able to render in visualization page:
![image](https://github.com/opensearch-project/dashboards-observability/assets/13493605/7640ef7c-c796-43cb-9b4a-a70a7160b3b4)

#### After
Able to render in Notebook page:
![image](https://github.com/opensearch-project/dashboards-observability/assets/13493605/9b6f7298-59eb-4dd3-8c45-30c64c658024)



### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
