### PR TITLE
Separate linting rules for cypress

### DIFF
--- a/.cypress/.eslintrc.js
+++ b/.cypress/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  extends: ['plugin:cypress/recommended'],
+  env: {
+    'cypress/globals': true,
+  },
+  plugins: ['cypress'],
+  rules: {
+    // Add cypress specific rules here
+    'cypress/no-assigning-return-values': 'error',
+    'cypress/no-unnecessary-waiting': 'error',
+    'cypress/assertion-before-screenshot': 'warn',
+    'cypress/no-force': 'warn',
+    'cypress/no-async-tests': 'error',
+  },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,16 +14,10 @@ module.exports = {
     '@elastic/eslint-config-kibana',
     'plugin:@elastic/eui/recommended',
     'plugin:react-hooks/recommended',
-    "plugin:cypress/recommended",
     'plugin:jest/recommended',
     'plugin:prettier/recommended',
   ],
-  env: {
-    'cypress/globals': true,
-  },
-  plugins: [
-    'cypress',
-  ],
+  
   rules: {
     '@typescript-eslint/no-unused-vars': [
       'error',
@@ -45,12 +39,6 @@ module.exports = {
         ],
       },
     ],
-    // Add cypress specific rules here
-    'cypress/no-assigning-return-values': 'error',
-    'cypress/no-unnecessary-waiting': 'error',
-    'cypress/assertion-before-screenshot': 'warn',
-    'cypress/no-force': 'warn',
-    'cypress/no-async-tests': 'error',
   },
   overrides: [
     {


### PR DESCRIPTION
### Description
Previously, without separate rules, the root ESLint configuration file applied its rules to all matched files. This approach sometimes resulted in files being linted with irrelevant rules. This PR separates cypress rules out from root configurations and to cypress specific foolder. 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
