### PR TITLE
support searching agent by name

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -17,9 +17,9 @@ const observabilityConfig = {
   schema: schema.object({
     query_assist: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
-      ppl_agent_id: schema.maybe(schema.string()),
-      response_summary_agent_id: schema.maybe(schema.string()),
-      error_summary_agent_id: schema.maybe(schema.string()),
+      ppl_agent_name: schema.maybe(schema.string()),
+      response_summary_agent_name: schema.maybe(schema.string()),
+      error_summary_agent_name: schema.maybe(schema.string()),
     }),
   }),
 };

--- a/server/routes/query_assist/utils/__tests__/agents.test.ts
+++ b/server/routes/query_assist/utils/__tests__/agents.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreRouteHandlerContext } from '../../../../../../../src/core/server/core_route_handler_context';
+import { coreMock, httpServerMock } from '../../../../../../../src/core/server/mocks';
+import { agentIdMap, requestWithRetryAgentSearch, searchAgentIdByName } from '../agents';
+
+describe('Agents helper functions', () => {
+  const coreContext = new CoreRouteHandlerContext(
+    coreMock.createInternalStart(),
+    httpServerMock.createOpenSearchDashboardsRequest()
+  );
+  const client = coreContext.opensearch.client.asCurrentUser;
+  const mockedTransport = client.transport.request as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('searches agent id by name', async () => {
+    mockedTransport.mockResolvedValueOnce({
+      body: { hits: { total: { value: 1 }, hits: [{ _id: 'agentId' }] } },
+    });
+    const id = await searchAgentIdByName(client, 'test agent');
+    expect(id).toEqual('agentId');
+    expect(mockedTransport.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "body": Object {
+            "query": Object {
+              "term": Object {
+                "name.keyword": "test agent",
+              },
+            },
+            "sort": Object {
+              "created_time": "desc",
+            },
+          },
+          "method": "GET",
+          "path": "/_plugins/_ml/agents/_search",
+        },
+      ]
+    `);
+  });
+
+  it('handles not found errors', async () => {
+    mockedTransport.mockResolvedValueOnce({ body: { hits: { total: 0 } } });
+    await expect(
+      searchAgentIdByName(client, 'test agent')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"search agent 'test agent' failed, reason: Error: cannot find any agent by name: test agent"`
+    );
+  });
+
+  it('handles search errors', async () => {
+    mockedTransport.mockRejectedValueOnce('request failed');
+    await expect(
+      searchAgentIdByName(client, 'test agent')
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"search agent 'test agent' failed, reason: request failed"`
+    );
+  });
+
+  it('requests with valid agent id', async () => {
+    agentIdMap['test agent'] = 'test-id';
+    mockedTransport.mockResolvedValueOnce({
+      body: { inference_results: [{ output: [{ result: 'test response' }] }] },
+    });
+    const response = await requestWithRetryAgentSearch({
+      client,
+      agentName: 'test agent',
+      shouldRetryAgentSearch: true,
+      body: { parameters: { param1: 'value1' } },
+    });
+    expect(mockedTransport).toBeCalledWith(
+      expect.objectContaining({
+        path: '/_plugins/_ml/agents/test-id/_execute',
+      }),
+      expect.anything()
+    );
+    expect(response.body.inference_results[0].output[0].result).toEqual('test response');
+  });
+
+  it('searches for agent id if not found', async () => {
+    mockedTransport
+      .mockRejectedValueOnce({ statusCode: 404, body: {}, headers: {} })
+      .mockResolvedValueOnce({ body: { hits: { total: { value: 1 }, hits: [{ _id: 'new-id' }] } } })
+      .mockResolvedValueOnce({
+        body: { inference_results: [{ output: [{ result: 'test response' }] }] },
+      });
+    const response = await requestWithRetryAgentSearch({
+      client,
+      agentName: 'new agent',
+      shouldRetryAgentSearch: true,
+      body: { parameters: { param1: 'value1' } },
+    });
+    expect(mockedTransport).toBeCalledWith(
+      expect.objectContaining({ path: '/_plugins/_ml/agents/new-id/_execute' }),
+      expect.anything()
+    );
+    expect(response.body.inference_results[0].output[0].result).toEqual('test response');
+  });
+});

--- a/server/routes/query_assist/utils/agents.ts
+++ b/server/routes/query_assist/utils/agents.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ApiResponse } from '@opensearch-project/opensearch/.';
+import { SearchResponse, SearchTotalHits } from '@opensearch-project/opensearch/api/types';
+import { RequestBody } from '@opensearch-project/opensearch/lib/Transport';
+import { OpenSearchClient } from '../../../../../../src/core/server';
+import { isResponseError } from '../../../../../../src/core/server/opensearch/client/errors';
+import { ML_COMMONS_API_PREFIX } from '../../../../common/constants/query_assist';
+
+const AGENT_REQUEST_OPTIONS = {
+  /**
+   * It is time-consuming for LLM to generate final answer
+   * Give it a large timeout window
+   */
+  requestTimeout: 5 * 60 * 1000,
+  /**
+   * Do not retry
+   */
+  maxRetries: 0,
+};
+
+type AgentResponse = ApiResponse<{
+  inference_results: Array<{
+    output: Array<{ name: string; result?: string }>;
+  }>;
+}>;
+
+export const agentIdMap: Record<string, string> = {};
+
+export const searchAgentIdByName = async (
+  opensearchClient: OpenSearchClient,
+  name: string
+): Promise<string> => {
+  try {
+    const response = (await opensearchClient.transport.request({
+      method: 'GET',
+      path: `${ML_COMMONS_API_PREFIX}/agents/_search`,
+      body: {
+        query: {
+          term: {
+            'name.keyword': name,
+          },
+        },
+        sort: {
+          created_time: 'desc',
+        },
+      },
+    })) as ApiResponse<SearchResponse>;
+
+    if (
+      !response ||
+      (typeof response.body.hits.total === 'number' && response.body.hits.total === 0) ||
+      (response.body.hits.total as SearchTotalHits).value === 0
+    ) {
+      throw new Error('cannot find any agent by name: ' + name);
+    }
+    const id = response.body.hits.hits[0]._id;
+    agentIdMap[name] = id;
+    return id;
+  } catch (error) {
+    const errorMessage = JSON.stringify(error.meta?.body) || error;
+    throw new Error(`search agent '${name}' failed, reason: ` + errorMessage);
+  }
+};
+
+export const requestWithRetryAgentSearch = async (options: {
+  client: OpenSearchClient;
+  agentName: string;
+  shouldRetryAgentSearch: boolean;
+  body: RequestBody;
+}): Promise<AgentResponse> =>
+  options.client.transport
+    .request(
+      {
+        method: 'POST',
+        path: `${ML_COMMONS_API_PREFIX}/agents/${agentIdMap[options.agentName]}/_execute`,
+        body: options.body,
+      },
+      AGENT_REQUEST_OPTIONS
+    )
+    .catch((error) =>
+      options.shouldRetryAgentSearch && isResponseError(error) && error.statusCode === 404
+        ? searchAgentIdByName(options.client, options.agentName).then(() =>
+            requestWithRetryAgentSearch({ ...options, shouldRetryAgentSearch: false })
+          )
+        : Promise.reject(error)
+    ) as Promise<AgentResponse>;


### PR DESCRIPTION
### Description
Follow up pr for #1325 
Search for agent id by name defined in opensearch_dashboards.yml. Sample config
```yml
assistant.chat.enabled: true
observability.query_assist.enabled: true
observability.query_assist.response_summary_agent_name: "Response summary agent"
observability.query_assist.error_summary_agent_name: "Error summary agent"
observability.query_assist.ppl_agent_name: "PPL agent"
```

Search triggers when no cached agent id matching the name, or when cached agent gets deleted and ml-commons returns 404 agent not found.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
