### PR TITLE
improve lint workflow to avoid fast fail

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,18 +62,12 @@ jobs:
 
       - name: Lint Changed Files
         run: |
-          jq -r '.[]' ${HOME}/files_modified.json ${HOME}/files_added.json | sort | uniq > /tmp/changed_files.txt
-          CHANGED_FILES=$(cat /tmp/changed_files.txt)
-          echo "These are the changed files: $CHANGED_FILES"
+          CHANGED_FILES=($(jq -r '.[]' ${HOME}/files_modified.json ${HOME}/files_added.json | grep '.\+.\(js\|ts\|tsx\)$' | sort -u))
           if [[ -n "$CHANGED_FILES" ]]; then
-            echo "Linting changed files..."
-            while IFS= read -r file; do
-              if [[ $file == *.js || $file == *.ts || $file == *.tsx ]]; then
-                echo "linting file $file"
-                yarn lint "$file"
-              fi
-            done < /tmp/changed_files.txt
+            echo 'These are the changed files:'
+            printf '%s\n' "${CHANGED_FILES[@]}"
+            yarn lint "${CHANGED_FILES[@]}"
           else
             echo "No matched files to lint."
           fi
-        working-directory: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}      
+        working-directory: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}


### PR DESCRIPTION
### Description
make it fail after linting all files

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/pull/1369#issuecomment-1904937003

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
