### PR TITLE
(query assist) enforce timerange to `QUERY_ASSIST_START_TIME`

### DIFF
--- a/public/components/common/search/query_area.tsx
+++ b/public/components/common/search/query_area.tsx
@@ -12,6 +12,7 @@ import { useFetchEvents } from '../../event_analytics/hooks/use_fetch_events';
 export function QueryArea({
   tabId,
   handleQueryChange,
+  handleTimePickerChange,
   handleTimeRangePickerRefresh,
   runQuery,
   tempQuery,
@@ -66,6 +67,7 @@ export function QueryArea({
           <EuiFlexItem>
             <QueryAssistInput
               tabId={tabId}
+              handleTimePickerChange={handleTimePickerChange}
               handleQueryChange={handleQueryChange}
               handleTimeRangePickerRefresh={handleTimeRangePickerRefresh}
               setNeedsUpdate={setNeedsUpdate}

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -514,6 +514,7 @@ export const Search = (props: any) => {
               <QueryArea
                 tabId={tabId}
                 handleQueryChange={handleQueryChange}
+                handleTimePickerChange={handleTimePickerChange}
                 handleTimeRangePickerRefresh={handleTimeRangePickerRefresh}
                 runQuery={query}
                 tempQuery={tempQuery}

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RAW_QUERY } from '../../../../../common/constants/explorer';
 import { QUERY_ASSIST_API } from '../../../../../common/constants/query_assist';
+import { QUERY_ASSIST_START_TIME } from '../../../../../common/constants/shared';
 import { getOSDHttp } from '../../../../../common/utils';
 import { coreRefs } from '../../../../framework/core_refs';
 import chatLogo from '../../../datasources/icons/query-assistant-logo.svg';
@@ -47,6 +48,7 @@ interface SummarizationContext {
 interface Props {
   handleQueryChange: (query: string) => void;
   handleTimeRangePickerRefresh: (availability?: boolean, setSummaryStatus?: boolean) => void;
+  handleTimePickerChange: (timeRange: string[]) => Promise<void>;
   tabId: string;
   setNeedsUpdate: any;
   selectedIndex: Array<EuiComboBoxOptionOption<string | number | string[] | undefined>>;
@@ -246,6 +248,7 @@ export const QueryAssistInput: React.FC<Props> = (props) => {
     try {
       setGeneratingOrRunning(true);
       await request();
+      await props.handleTimePickerChange([QUERY_ASSIST_START_TIME, 'now']);
       await props.handleTimeRangePickerRefresh(undefined, true);
     } catch (error) {
       generateSummary({ isError: true, response: JSON.stringify((error as ResponseError).body) });


### PR DESCRIPTION
### Description
Set timerange to be consistent as showed on UI

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
