### PR TITLE
feat: for data grid no need to filter stats by

### DIFF
--- a/server/parsers/ppl_parser.ts
+++ b/server/parsers/ppl_parser.ts
@@ -31,12 +31,7 @@ export const PPLParsers: MessageParser = {
 
     if (!ppls.length) return [];
 
-    const statsPPLs = ppls;
-    if (!statsPPLs.length) {
-      return [];
-    }
-
-    return statsPPLs.map((query) => {
+    return ppls.map((query) => {
       const finalQuery = query
         .replace(/`/g, '') // workaround for https://github.com/opensearch-project/dashboards-observability/issues/509, https://github.com/opensearch-project/dashboards-observability/issues/557
         .replace(/\bSPAN\(/g, 'span('); // workaround for https://github.com/opensearch-project/dashboards-observability/issues/759

--- a/server/parsers/ppl_parser.ts
+++ b/server/parsers/ppl_parser.ts
@@ -31,7 +31,7 @@ export const PPLParsers: MessageParser = {
 
     if (!ppls.length) return [];
 
-    const statsPPLs = ppls.filter((ppl) => /\|\s*stats\s+[^|]+\sby\s/i.test(ppl));
+    const statsPPLs = ppls;
     if (!statsPPLs.length) {
       return [];
     }


### PR DESCRIPTION
### Description
Before we filter ppls to make sure it includes `stats by` as ppl visualization requires two dimensions to render. However in data grid, one dimension is enough so the filter function is useless.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
