### PR TITLE
Fix trace link in event viewer

### DIFF
--- a/public/components/event_analytics/explorer/events_views/docViewer.tsx
+++ b/public/components/event_analytics/explorer/events_views/docViewer.tsx
@@ -103,7 +103,7 @@ export function DocViewer(props: IDocViewerProps) {
       setTracesLink(
         <EuiLink
           className="trace-link"
-          href={`${observabilityTracesID}#/${traceId}`}
+          href={`${observabilityTracesID}#/traces/${traceId}`}
           target="_blank"
           external
         />


### PR DESCRIPTION
### Description
Fix the trace link from event viewer (gif video included):
![traces-link](https://github.com/opensearch-project/dashboards-observability/assets/1771042/658484d8-8425-420f-a473-88c90b94289f)

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
