### PR TITLE
Optimize searches for integration data

### DIFF
--- a/server/adaptors/integrations/repository/index_data_adaptor.ts
+++ b/server/adaptors/integrations/repository/index_data_adaptor.ts
@@ -17,37 +17,79 @@ export class IndexDataAdaptor implements CatalogDataAdaptor {
     this.client = client;
   }
 
-  private async asJsonAdaptor(): Promise<JsonCatalogDataAdaptor> {
-    const results = await this.client.find({ type: 'integration-template' });
-    const filteredIntegrations: SerializedIntegration[] = results.saved_objects
-      .map((obj) => obj.attributes as SerializedIntegration)
-      .filter((obj) => this.directory === undefined || this.directory === obj.name);
-    return new JsonCatalogDataAdaptor(filteredIntegrations);
-  }
-
   async findIntegrationVersions(dirname?: string | undefined): Promise<Result<string[], Error>> {
-    const adaptor = await this.asJsonAdaptor();
+    const integrationVersions = await this.client.find({
+      type: 'integration-template',
+      fields: ['name', 'version'],
+      search: dirname ? `"${dirname}"` : undefined,
+      searchFields: ['name'],
+    });
+    const adaptor = new JsonCatalogDataAdaptor(
+      integrationVersions.saved_objects.map((obj) => obj.attributes as SerializedIntegration)
+    );
     return await adaptor.findIntegrationVersions(dirname);
   }
 
   async readFile(filename: string, type?: IntegrationPart): Promise<Result<object[] | object>> {
-    const adaptor = await this.asJsonAdaptor();
-    return await adaptor.readFile(filename, type);
+    // Duplicates a lot of logic from the Json Adaptor version since we need to parse config
+    // for an efficient network query anyways
+    if (type !== undefined) {
+      return {
+        ok: false,
+        error: new Error('JSON adaptor does not support subtypes (isConfigLocalized: true)'),
+      };
+    }
+
+    const filenameParts = filename.match(/([\w]+)-(\d+(\.\d+)*)\.json/);
+    if (!filenameParts) {
+      return { ok: false, error: new Error(`Invalid Config filename: ${filename}`) };
+    }
+
+    const integrations = await this.client.find({
+      type: 'integration-template',
+      search: `"${filenameParts[1]}" + "${filenameParts[2]}"`,
+      searchFields: ['name', 'version'],
+    });
+    if (integrations.total === 0) {
+      return { ok: false, error: new Error('Config file not found: ' + filename) };
+    }
+
+    return { ok: true, value: integrations.saved_objects[0].attributes as object };
   }
 
-  async readFileRaw(filename: string, type?: IntegrationPart): Promise<Result<Buffer>> {
-    const adaptor = await this.asJsonAdaptor();
-    return await adaptor.readFileRaw(filename, type);
+  async readFileRaw(_filename: string, _type?: IntegrationPart): Promise<Result<Buffer>> {
+    return {
+      ok: false,
+      error: new Error('JSON adaptor does not support raw files (isConfigLocalized: true)'),
+    };
   }
 
   async findIntegrations(dirname: string = '.'): Promise<Result<string[]>> {
-    const adaptor = await this.asJsonAdaptor();
-    return await adaptor.findIntegrations(dirname);
+    const dir = dirname !== '.' ? dirname : this.directory;
+    const integrations = await this.client.find({
+      type: 'integration-template',
+      fields: ['name'],
+      search: dir ? `"${dir}"` : undefined,
+      searchFields: ['name'],
+    });
+    const names = integrations.saved_objects.map(
+      (obj) => (obj.attributes as SerializedIntegration).name
+    );
+    return {
+      ok: true,
+      value: [...new Set(names)],
+    };
   }
 
   async getDirectoryType(dirname?: string): Promise<'integration' | 'repository' | 'unknown'> {
-    const adaptor = await this.asJsonAdaptor();
-    return await adaptor.getDirectoryType(dirname);
+    const names = await this.findIntegrations(dirname ?? '.');
+    if (!names.value || names.value.length === 0) {
+      return 'unknown';
+    }
+    if (names.value.length === 1) {
+      return 'integration';
+    }
+    return 'repository';
   }
 
   join(filename: string): IndexDataAdaptor {


### PR DESCRIPTION
### Description
Based on #1389 and PR feedback from @mengweieric, this PR optimizes retrieving integration data over the network. Benchmark statistics included in the linked issue, locally it gives an 80% speedup and will scale much better to larger workloads (in the future we can also consider pagination). It's not as fast as caching everything in-memory, but compared to the relative complexity of caching I think it's a good compromise.

Existing tests pass without modification.

### Issues Resolved
Closes #1389.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
