### PR TITLE
[BUG] Fix Panels PPL Filter

### DIFF
--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -290,7 +290,7 @@ export const VisualizationContainer = ({
         savedVisualizationId,
         startTime: fromTime,
         endTime: toTime,
-        pplFilterValue,
+        filterQuery: pplFilterValue,
         span,
         resolution,
         setVisualizationTitle,


### PR DESCRIPTION
### Description
PPL filters were unable to be added in Observability Dashboards since [`pplFilterValue`](https://github.com/opensearch-project/dashboards-observability/blob/main/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx#L293) is not accepted by [`renderSavedVisualization`](https://github.com/opensearch-project/dashboards-observability/blob/main/public/components/custom_panels/helpers/utils.tsx#L190). One-liner to correctly pass in the parameters, as it is done [here](https://github.com/opensearch-project/dashboards-observability/blob/main/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx#L276).

Video of Cypress test [`Add ppl filter to panel`](https://github.com/opensearch-project/dashboards-observability/blob/main/.cypress/integration/panels_test/panels.spec.ts#L352)

https://github.com/opensearch-project/dashboards-observability/assets/47805161/295d60e9-4e4c-400b-b950-b7c208bf45cd


### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
