### PR TITLE
Add redirect with error message if integrations template not found

### DIFF
--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -53,6 +53,11 @@ export function Integration(props: AvailableIntegrationProps) {
   async function handleDataRequest() {
     // TODO fill in ID request here
     http.get(`${INTEGRATIONS_BASE}/repository/${integrationTemplateId}`).then((exists) => {
+      if (!exists.data) {
+        window.location.hash = '#/available';
+        setToast(`Template '${integrationTemplateId}' not found`, 'danger');
+        return;
+      }
       setIntegration(exists.data);
     });
   }
@@ -70,7 +75,7 @@ export function Integration(props: AvailableIntegrationProps) {
         return parsedResponse.data.mappings[integration.type];
       })
       .then((mapping) => setMapping(mapping))
-      .catch((err: any) => {
+      .catch((err) => {
         console.error(err.message);
       });
   }, [integration]);
@@ -88,7 +93,7 @@ export function Integration(props: AvailableIntegrationProps) {
         return parsedResponse.data;
       })
       .then((assets) => setAssets(assets))
-      .catch((err: any) => {
+      .catch((err) => {
         console.error(err.message);
       });
   }, [integration]);


### PR DESCRIPTION
### Description
If a user tries to access a nonexistent integration template, they get no UI. This causes a display bug if the user adds a template, creates an instance with the template, deletes the template, and tries to navigate to it. This PR adds minimal handling to send an error message and redirect to the full template list.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
