### PR TITLE
(query assist) hide dot indices

### DIFF
--- a/public/components/event_analytics/explorer/query_assist/__tests__/hooks.test.ts
+++ b/public/components/event_analytics/explorer/query_assist/__tests__/hooks.test.ts
@@ -33,6 +33,16 @@ describe('useCatIndices', () => {
     expect(result.current.data).toEqual([{ label: 'test1' }, { label: 'test2' }]);
   });
 
+  it('should hide indices starting with dot', async () => {
+    httpMock.get.mockResolvedValueOnce([{ index: '.test1' }, { index: 'test2' }]);
+
+    const { result, waitForNextUpdate } = renderHook(() => useCatIndices());
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toEqual([{ label: 'test2' }]);
+  });
+
   it('should handle errors', async () => {
     httpMock.get.mockRejectedValueOnce('API failed');
 

--- a/public/components/event_analytics/explorer/query_assist/hooks.ts
+++ b/public/components/event_analytics/explorer/query_assist/hooks.ts
@@ -5,7 +5,7 @@
 
 import { EuiComboBoxOptionOption } from '@elastic/eui';
 import { CatIndicesResponse } from '@opensearch-project/opensearch/api/types';
-import { Reducer, useReducer, useState, useEffect } from 'react';
+import { Reducer, useEffect, useReducer, useState } from 'react';
 import { IndexPatternAttributes } from '../../../../../../../src/plugins/data/common';
 import { DSL_BASE, DSL_CAT } from '../../../../../common/constants/shared';
 import { getOSDHttp } from '../../../../../common/utils';
@@ -48,7 +48,12 @@ export const useCatIndices = () => {
     getOSDHttp()
       .get(`${DSL_BASE}${DSL_CAT}`, { query: { format: 'json' }, signal: abortController.signal })
       .then((payload: CatIndicesResponse) =>
-        dispatch({ type: 'success', payload: payload.map((meta) => ({ label: meta.index! })) })
+        dispatch({
+          type: 'success',
+          payload: payload
+            .filter((meta) => meta.index && !meta.index.startsWith('.'))
+            .map((meta) => ({ label: meta.index! })),
+        })
       )
       .catch((error) => dispatch({ type: 'failure', error }));
 


### PR DESCRIPTION
### Description
Do not display hidden indices in query assist index selector

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
