### PR TITLE
Change class name to decouple styling from discover

### DIFF
--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -117,7 +117,7 @@ import {
   selectVisualizationConfig,
 } from '../redux/slices/viualization_config_slice';
 import { getDefaultVisConfig } from '../utils';
-import { formatError, getContentTabTitle, getDateRange } from '../utils/utils';
+import { formatError, getContentTabTitle } from '../utils/utils';
 import { DataSourceSelection } from './datasources/datasources_selection';
 import { DirectQueryRunning } from './direct_query_running';
 import { DataGrid } from './events_views/data_grid';
@@ -942,7 +942,7 @@ export const Explorer = ({
       }}
     >
       <EuiPage className="deLayout" paddingSize="none">
-        <EuiPageSideBar className="deSidebar" sticky>
+        <EuiPageSideBar className="explorerSidebar" sticky>
           <EuiSplitPanel.Outer className="eui-yScroll" hasBorder={true} borderRadius="none">
             {!appLogEvents && (
               <EuiSplitPanel.Inner paddingSize="s" color="subdued" grow={false}>

--- a/public/components/event_analytics/explorer/sidebar/sidebar.scss
+++ b/public/components/event_analytics/explorer/sidebar/sidebar.scss
@@ -152,7 +152,7 @@
   padding-left: 8px;
 }
 
-.deSidebar {
+.explorerSidebar {
   height: calc(100vh - 98px);
   max-width: 462px;
   min-width: 400px;


### PR DESCRIPTION
### Description
this styling is affecting discover, and as they are changing the styling, we are for now just change the name to decouple
`.deSidebar {
  height: calc(100vh - 98px);
  max-width: 462px;
  min-width: 400px;
}`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
