### PR TITLE
[CI/CD] Add single version flag during bootstrap to fix version conflicts and update the snapshots

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -49,7 +49,7 @@ jobs:
             cd ./OpenSearch-Dashboards/
             su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
                                  yarn config set network-timeout 1000000 -g &&
-                                 yarn osd bootstrap"
+                                 yarn osd bootstrap --single-version=loose"
 
       - name: Test all dashboards-observability modules
         run: |
@@ -57,7 +57,7 @@ jobs:
             cd ./OpenSearch-Dashboards/
             su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
                                  cd plugins/dashboards-observability &&
-                                 yarn osd bootstrap && yarn test --coverage --maxWorkers=100%"
+                                 yarn osd bootstrap --single-version=loose && yarn test --coverage --maxWorkers=100%"
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
@@ -131,7 +131,7 @@ jobs:
           command: |
             cd OpenSearch-Dashboards
             yarn config set network-timeout 1000000 -g
-            yarn osd bootstrap
+            yarn osd bootstrap --single-version=loose
 
       - name: Test all dashboards-observability modules
         run: |

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Bootstrap the plugin
         working-directory: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
-        run: yarn osd bootstrap
+        run: yarn osd bootstrap --single-version=loose
 
       - name: Get list of changed files using GitHub Action
         uses: lots0logs/gh-action-get-changed-files@2.2.2

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -271,6 +271,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                                 className="euiButtonContent__icon"
                                 color="inherit"
                                 size="m"
+                                title="list"
                                 type="list"
                               >
                                 <EuiIconBeaker
@@ -279,9 +280,12 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                                   focusable="false"
                                   role="img"
                                   style={null}
+                                  title="list"
+                                  titleId="random_html_id"
                                 >
                                   <svg
                                     aria-hidden={true}
+                                    aria-labelledby="random_html_id"
                                     className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                     focusable="false"
                                     height={16}
@@ -291,6 +295,11 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                                     width={16}
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
+                                    <title
+                                      id="random_html_id"
+                                    >
+                                      list
+                                    </title>
                                     <path
                                       d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
                                     />
@@ -384,6 +393,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                                 className="euiButtonContent__icon"
                                 color="inherit"
                                 size="m"
+                                title="grid"
                                 type="grid"
                               >
                                 <EuiIconBeaker
@@ -392,9 +402,12 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                                   focusable="false"
                                   role="img"
                                   style={null}
+                                  title="grid"
+                                  titleId="random_html_id"
                                 >
                                   <svg
                                     aria-hidden={true}
+                                    aria-labelledby="random_html_id"
                                     className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                     focusable="false"
                                     height={16}
@@ -404,6 +417,11 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                                     width={16}
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
+                                    <title
+                                      id="random_html_id"
+                                    >
+                                      grid
+                                    </title>
                                     <path
                                       d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
                                     />

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -473,6 +473,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                 className="euiButtonContent__icon"
                                                 color="inherit"
                                                 size="m"
+                                                title="list"
                                                 type="list"
                                               >
                                                 <EuiIconBeaker
@@ -481,9 +482,12 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
+                                                  title="list"
+                                                  titleId="random_html_id"
                                                 >
                                                   <svg
                                                     aria-hidden={true}
+                                                    aria-labelledby="random_html_id"
                                                     className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                                     focusable="false"
                                                     height={16}
@@ -493,6 +497,11 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                     width={16}
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
+                                                    <title
+                                                      id="random_html_id"
+                                                    >
+                                                      list
+                                                    </title>
                                                     <path
                                                       d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
                                                     />
@@ -586,6 +595,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                 className="euiButtonContent__icon"
                                                 color="inherit"
                                                 size="m"
+                                                title="grid"
                                                 type="grid"
                                               >
                                                 <EuiIconBeaker
@@ -594,9 +604,12 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
+                                                  title="grid"
+                                                  titleId="random_html_id"
                                                 >
                                                   <svg
                                                     aria-hidden={true}
+                                                    aria-labelledby="random_html_id"
                                                     className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                                     focusable="false"
                                                     height={16}
@@ -606,6 +619,11 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                     width={16}
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
+                                                    <title
+                                                      id="random_html_id"
+                                                    >
+                                                      grid
+                                                    </title>
                                                     <path
                                                       d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
                                                     />


### PR DESCRIPTION
### Description
- On behalf of the change in dashboards core: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5675. We need to add `--single-version=loose` flag during the bootstrap step in our CI to manipulate the behavior of single-version validation. 
- Fix the snapshot mismatch with upstream

### Issues Resolved
* Resolve the CI failure: https://github.com/opensearch-project/dashboards-observability/actions/runs/7964135017/job/21741091909?pr=1447#step:16:231

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
