### PR TITLE
[Backport 2.x] Add single version flag during bootstrap to fix version conflicts

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -45,7 +45,7 @@ jobs:
             chown -R 1000:1000 `pwd`
             cd ./OpenSearch-Dashboards/
             su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
-                                 yarn config set network-timeout 1000000 -g && yarn osd bootstrap"
+                                 yarn config set network-timeout 1000000 -g && yarn osd bootstrap --single-version=loose"
 
       - name: Test all dashboards-observability modules
         run: |
@@ -53,7 +53,7 @@ jobs:
           cd ./OpenSearch-Dashboards/
           su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
                                cd ./plugins/dashboards-observability &&
-                               whoami && yarn osd bootstrap && yarn test --coverage --maxWorkers=100%"
+                               whoami && yarn osd bootstrap --single-version=loose && yarn test --coverage --maxWorkers=100%"
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
@@ -125,7 +125,7 @@ jobs:
           command: |
             cd OpenSearch-Dashboards
             yarn config set network-timeout 1000000 -g
-            yarn osd bootstrap
+            yarn osd bootstrap --single-version=loose
 
       - name: Test all dashboards-observability modules
         run: |

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Bootstrap the plugin
         working-directory: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
-        run: yarn osd bootstrap
+        run: yarn osd bootstrap --single-version=loose
 
       - name: Get list of changed files using GitHub Action
         uses: lots0logs/gh-action-get-changed-files@2.2.2


### PR DESCRIPTION
### Description
Add single version flag during bootstrap to fix version conflicts

### Issues Resolved
* Backport #1454 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
