### PR TITLE
(query assist) show error toasts if summary is disabled

### DIFF
--- a/public/components/event_analytics/explorer/query_assist/__tests__/input.test.tsx
+++ b/public/components/event_analytics/explorer/query_assist/__tests__/input.test.tsx
@@ -85,7 +85,7 @@ describe('<QueryAssistInput /> spec', () => {
     );
   });
 
-  it('should not call summarize if disabled', async () => {
+  it('should call add error toast if summarize is disabled', async () => {
     coreRefs.summarizeEnabled = false;
     httpMock.post.mockRejectedValueOnce({ body: { statusCode: 429 } });
 
@@ -98,6 +98,13 @@ describe('<QueryAssistInput /> spec', () => {
       body: '{"question":"test-input","index":"selected-test-index"}',
     });
     expect(httpMock.post).not.toBeCalledWith(QUERY_ASSIST_API.SUMMARIZE, expect.anything());
+    expect(coreRefs.toasts?.addError).toBeCalledWith(
+      {
+        message: 'Request is throttled. Try again later or contact your administrator',
+        statusCode: 429,
+      },
+      { title: 'Failed to generate results' }
+    );
   });
 
   it('should call summarize for generate and run errors', async () => {

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -251,7 +251,13 @@ export const QueryAssistInput: React.FC<Props> = (props) => {
       await props.handleTimePickerChange([QUERY_ASSIST_START_TIME, 'now']);
       await props.handleTimeRangePickerRefresh(undefined, true);
     } catch (error) {
-      generateSummary({ isError: true, response: JSON.stringify((error as ResponseError).body) });
+      if (coreRefs.summarizeEnabled) {
+        generateSummary({ isError: true, response: JSON.stringify((error as ResponseError).body) });
+      } else {
+        coreRefs.toasts?.addError(formatError(error as ResponseError), {
+          title: 'Failed to generate results',
+        });
+      }
     } finally {
       setGeneratingOrRunning(false);
     }


### PR DESCRIPTION
### Description
Currently we use summarization to explain PPL errors, but it won't be available if summarization feature is disabled. This PR enables sending error to toast message in that case.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
