### PR TITLE
(query assist) get agent id through config API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -17,27 +17,9 @@ const observabilityConfig = {
   schema: schema.object({
     query_assist: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
-      ppl_agent_name: schema.conditional(
-        schema.siblingRef('enabled'),
-        true,
-        schema.string(),
-        schema.maybe(schema.string())
-      ),
     }),
     summarize: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
-      response_summary_agent_name: schema.conditional(
-        schema.siblingRef('enabled'),
-        true,
-        schema.string(),
-        schema.maybe(schema.string())
-      ),
-      error_summary_agent_name: schema.conditional(
-        schema.siblingRef('enabled'),
-        true,
-        schema.string(),
-        schema.maybe(schema.string())
-      ),
     }),
   }),
 };

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { first } from 'rxjs/operators';
-import { ObservabilityConfig } from '.';
 import {
   CoreSetup,
   CoreStart,
@@ -42,10 +40,6 @@ export class ObservabilityPlugin
     const { assistantDashboards } = deps;
     this.logger.debug('Observability: Setup');
     const router = core.http.createRouter();
-    const config = await this.initializerContext.config
-      .create<ObservabilityConfig>()
-      .pipe(first())
-      .toPromise();
     const openSearchObservabilityClient: ILegacyClusterClient = core.opensearch.legacy.createClient(
       'opensearch_observability',
       {
@@ -203,7 +197,7 @@ export class ObservabilityPlugin
     core.savedObjects.registerType(integrationTemplateType);
 
     // Register server side APIs
-    setupRoutes({ router, client: openSearchObservabilityClient, config });
+    setupRoutes({ router, client: openSearchObservabilityClient });
 
     core.savedObjects.registerType(visualizationSavedObject);
     core.savedObjects.registerType(searchSavedObject);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ObservabilityConfig } from '..';
 import { ILegacyClusterClient, IRouter } from '../../../../src/core/server';
 import { DSLFacet } from '../services/facets/dsl_facet';
 import { PPLFacet } from '../services/facets/ppl_facet';
@@ -12,8 +11,8 @@ import { QueryService } from '../services/queryService';
 import { registerAppAnalyticsRouter } from './application_analytics/app_analytics_router';
 import { PanelsRouter } from './custom_panels/panels_router';
 import { VisualizationsRouter } from './custom_panels/visualizations_router';
-import { registerDataConnectionsRoute } from './data_connections/data_connections_router';
 import { registerDatasourcesRoute } from './datasources/datasources_router';
+import { registerDataConnectionsRoute } from './data_connections/data_connections_router';
 import { registerDslRoute } from './dsl';
 import { registerEventAnalyticsRouter } from './event_analytics/event_analytics_router';
 import { registerIntegrationsRoute } from './integrations/integrations_router';
@@ -26,15 +25,7 @@ import { registerPplRoute } from './ppl';
 import { registerQueryAssistRoutes } from './query_assist/routes';
 import { registerTraceAnalyticsDslRouter } from './trace_analytics_dsl_router';
 
-export function setupRoutes({
-  router,
-  client,
-  config,
-}: {
-  router: IRouter;
-  client: ILegacyClusterClient;
-  config: ObservabilityConfig;
-}) {
+export function setupRoutes({ router, client }: { router: IRouter; client: ILegacyClusterClient }) {
   PanelsRouter(router);
   VisualizationsRouter(router);
   registerPplRoute({ router, facet: new PPLFacet(client) });
@@ -56,5 +47,5 @@ export function setupRoutes({
   registerIntegrationsRoute(router);
   registerDataConnectionsRoute(router);
   registerDatasourcesRoute(router);
-  registerQueryAssistRoutes(router, config);
+  registerQueryAssistRoutes(router);
 }

--- a/server/routes/query_assist/routes.ts
+++ b/server/routes/query_assist/routes.ts
@@ -4,7 +4,6 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { ObservabilityConfig } from '../..';
 import {
   IOpenSearchDashboardsResponse,
   IRouter,
@@ -13,15 +12,10 @@ import {
 import { isResponseError } from '../../../../../src/core/server/opensearch/client/errors';
 import { QUERY_ASSIST_API } from '../../../common/constants/query_assist';
 import { generateFieldContext } from '../../common/helpers/query_assist/generate_field_context';
-import { requestWithRetryAgentSearch, searchAgentIdByName } from './utils/agents';
+import { requestWithRetryAgentSearch, getAgentIdByConfig } from './utils/agents';
+import { AGENT_CONFIGS } from './utils/constants';
 
-export function registerQueryAssistRoutes(router: IRouter, config: ObservabilityConfig) {
-  const { ppl_agent_name: pplAgentName } = config.query_assist;
-  const {
-    response_summary_agent_name: responseSummaryAgentName,
-    error_summary_agent_name: errorSummaryAgentName,
-  } = config.summarize;
-
+export function registerQueryAssistRoutes(router: IRouter) {
   /**
    * Returns whether the PPL agent is configured.
    */
@@ -38,7 +32,7 @@ export function registerQueryAssistRoutes(router: IRouter, config: Observability
       const client = context.core.opensearch.client.asCurrentUser;
       try {
         // if the call does not throw any error, then the agent is properly configured
-        await searchAgentIdByName(client, pplAgentName!);
+        await getAgentIdByConfig(client, AGENT_CONFIGS.PPL_AGENT);
         return response.ok({ body: { configured: true } });
       } catch (error) {
         return response.ok({ body: { configured: false, error: error.message } });
@@ -61,18 +55,11 @@ export function registerQueryAssistRoutes(router: IRouter, config: Observability
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      if (!pplAgentName)
-        return response.custom({
-          statusCode: 400,
-          body:
-            'PPL agent name not found in opensearch_dashboards.yml. Expected observability.query_assist.ppl_agent_name',
-        });
-
       const client = context.core.opensearch.client.asCurrentUser;
       try {
         const pplRequest = await requestWithRetryAgentSearch({
           client,
-          agentName: pplAgentName,
+          configName: AGENT_CONFIGS.PPL_AGENT,
           body: {
             parameters: {
               index: request.body.index,
@@ -123,13 +110,6 @@ export function registerQueryAssistRoutes(router: IRouter, config: Observability
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      if (!responseSummaryAgentName || !errorSummaryAgentName)
-        return response.custom({
-          statusCode: 400,
-          body:
-            'Summary agent name not found in opensearch_dashboards.yml. Expected observability.query_assist.response_summary_agent_name and observability.query_assist.error_summary_agent_name',
-        });
-
       const client = context.core.opensearch.client.asCurrentUser;
       const { index, question, query, response: _response, isError } = request.body;
       const queryResponse = JSON.stringify(_response);
@@ -139,7 +119,7 @@ export function registerQueryAssistRoutes(router: IRouter, config: Observability
         if (!isError) {
           summaryRequest = await requestWithRetryAgentSearch({
             client,
-            agentName: responseSummaryAgentName,
+            configName: AGENT_CONFIGS.RESPONSE_SUMMARY_AGENT,
             body: {
               parameters: { index, question, query, response: queryResponse },
             },
@@ -152,7 +132,7 @@ export function registerQueryAssistRoutes(router: IRouter, config: Observability
           const fields = generateFieldContext(mappings, sampleDoc);
           summaryRequest = await requestWithRetryAgentSearch({
             client,
-            agentName: errorSummaryAgentName,
+            configName: AGENT_CONFIGS.ERROR_SUMMARY_AGENT,
             body: {
               parameters: { index, question, query, response: queryResponse, fields },
             },

--- a/server/routes/query_assist/utils/constants.ts
+++ b/server/routes/query_assist/utils/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const AGENT_CONFIGS = {
+  PPL_AGENT: 'os_query_assist_ppl',
+  RESPONSE_SUMMARY_AGENT: 'os_query_assist_response_summary',
+  ERROR_SUMMARY_AGENT: 'os_query_assist_error_summary',
+} as const;


### PR DESCRIPTION
### Description
This PR does the similar thing as https://github.com/opensearch-project/dashboards-assistant/commit/a3560318a94ec36c26e3fab23780730fb82dcfbf. Instead of setting these in config yml 
```yml
observability.query_assist.ppl_agent_name: "PPL agent"
observability.query_assist.response_summary_agent_name: "Response summary agent"
observability.query_assist.error_summary_agent_name: "Error summary agent"
```

users should send the following request as superadmin:

```http
PUT /.plugins-ml-config/_doc/os_query_assist_ppl
{
  "type":"os_query_assist_ppl_agent",
  "configuration":{
    "agent_id": "your ppl agent id"
  }
}

PUT /.plugins-ml-config/_doc/os_query_assist_response_summary
{
  "type":"os_query_assist_response_summary_agent",
  "configuration":{
    "agent_id": "your response summary agent id"
  }
}

PUT /.plugins-ml-config/_doc/os_query_assist_error_summary
{
  "type":"os_query_assist_error_summary_agent",
  "configuration":{
    "agent_id": "your error summary agent id"
  }
}
```

A PR to update documentation will be sent later.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
