### PR TITLE
[Maintenance] Bump plugin version to 2.13.0

### DIFF
--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -9,8 +9,6 @@ on:
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.12.0'
-  OPENSEARCH_PLUGIN_VERSION: '2.12.0.0'
 
 jobs:
   tests:
@@ -35,6 +33,17 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '11'
+
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+  
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
 
       - name: Download observability artifact
         uses: suisei-cn/actions-download-file@v1.4.0

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -42,7 +42,7 @@ jobs:
           opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
           echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
-          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+          echo "OPENSEARCH_PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 
       - name: Download observability artifact

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -39,8 +39,8 @@ jobs:
   
       - name: Set env
         run: |
-          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
-          plugin_version=$(node -p "require('./package.json').version")
+          opensearch_version=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
+          plugin_version=$(node -p "require('./opensearch_dashboards.json').version")
           echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "OPENSEARCH_PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -5,8 +5,6 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.12.0'
-  OPENSEARCH_PLUGIN_VERSION: '2.12.0.0'
 
 jobs:
   tests:
@@ -45,6 +43,17 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '11'
+
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
 
       - name: Download observability artifact
         uses: suisei-cn/actions-download-file@v1.4.0

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Set env
         run: |
-          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
-          plugin_version=$(node -p "require('./package.json').version")
+          opensearch_version=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
+          plugin_version=$(node -p "require('./opensearch_dashboards.json').version")
           echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "OPENSEARCH_PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -52,7 +52,7 @@ jobs:
           opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
           echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
-          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+          echo "OPENSEARCH_PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 
       - name: Download observability artifact

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
-  "version": "2.12.0.0",
-  "opensearchDashboardsVersion": "2.12.0",
+  "version": "2.13.0.0",
+  "opensearchDashboardsVersion": "2.13.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observability-dashboards",
-  "version": "2.12.0.0",
+  "version": "2.13.0.0",
   "main": "index.ts",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### Description
Bump plugin version to 2.13.0 and automated the version fetching in workflows

### Issues Resolved
* The CI failure on 2.x: https://github.com/opensearch-project/dashboards-observability/actions/runs/8192762404/job/22405015049#step:18:10

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
