### PR TITLE
[Backport 2.x] Add flyout pages to associated objects table

### DIFF
--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -5,6 +5,8 @@
 
 import { EuiComboBoxOptionOption } from '@elastic/eui';
 
+export type AccelerationStatus = 'ACTIVE' | 'INACTIVE';
+
 export interface PermissionsConfigurationProps {
   roles: Role[];
   selectedRoles: Role[];
@@ -13,13 +15,33 @@ export interface PermissionsConfigurationProps {
   hasSecurityAccess: boolean;
 }
 
+export interface TableColumn {
+  name: string;
+  dataType: string;
+}
+
+export interface Acceleration {
+  name: string;
+  status: AccelerationStatus;
+  type: string;
+  database: string;
+  table: string;
+  destination: string;
+  dateCreated: number;
+  dateUpdated: number;
+  index: string;
+  sql: string;
+}
+
 export interface AssociatedObject {
+  datasource: string;
   id: string;
   name: string;
   database: string;
   type: string;
   createdByIntegration: string;
-  accelerations: string[];
+  accelerations: Acceleration[];
+  columns: TableColumn[];
 }
 
 export type Role = EuiComboBoxOptionOption;

--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -6,72 +6,216 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
     Array [
       Object {
         "accelerations": Array [
-          "skipping_index_1",
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "skipping_index_1",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
         ],
-        "createdByIntegration": "xx",
+        "columns": Array [
+          Object {
+            "dataType": "dataType1",
+            "name": "column1",
+          },
+          Object {
+            "dataType": "dataType2",
+            "name": "column2",
+          },
+          Object {
+            "dataType": "dataType3",
+            "name": "column3",
+          },
+          Object {
+            "dataType": "dataType4",
+            "name": "column4",
+          },
+        ],
+        "createdByIntegration": "integration_1",
         "database": "db1",
+        "datasource": "flint_s3",
         "id": "1",
         "name": "Table_name_1",
         "type": "Table",
       },
       Object {
         "accelerations": Array [
-          "skipping_index_1",
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "skipping_index_2",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
         ],
-        "createdByIntegration": "xx",
+        "columns": Array [],
+        "createdByIntegration": "integration_1",
         "database": "db1",
+        "datasource": "flint_s3",
         "id": "2",
         "name": "Table_name_2",
         "type": "Table",
       },
       Object {
         "accelerations": Array [
-          "skipping_index_2",
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "skipping_index_2",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
         ],
-        "createdByIntegration": "xx",
+        "columns": Array [],
+        "createdByIntegration": "integration_1",
         "database": "db1",
+        "datasource": "flint_s3",
         "id": "3",
-        "name": "Table_name_3",
-        "type": "Table",
+        "name": "skipping_index_2",
+        "type": "Skip Index",
       },
       Object {
         "accelerations": Array [
-          "skipping_index_2",
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "skipping_index_2",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
         ],
-        "createdByIntegration": "xx",
+        "columns": Array [
+          Object {
+            "dataType": "dataType1",
+            "name": "column1",
+          },
+          Object {
+            "dataType": "dataType2",
+            "name": "column2",
+          },
+        ],
+        "createdByIntegration": "integration_1",
         "database": "db2",
+        "datasource": "flint_s3",
         "id": "4",
         "name": "Table_name_4",
         "type": "Table",
       },
       Object {
-        "accelerations": Array [
-          "skipping_index_3",
+        "accelerations": Array [],
+        "columns": Array [
+          Object {
+            "dataType": "dataType1",
+            "name": "column1",
+          },
+          Object {
+            "dataType": "dataType2",
+            "name": "column2",
+          },
         ],
-        "createdByIntegration": "xx",
+        "createdByIntegration": "integration_1",
         "database": "db3",
+        "datasource": "flint_s3",
         "id": "5",
         "name": "Table_name_5",
         "type": "Table",
       },
       Object {
-        "accelerations": Array [],
-        "createdByIntegration": "",
-        "database": "db3",
-        "id": "6",
-        "name": "Table_name_5",
-        "type": "CI",
-      },
-      Object {
         "accelerations": Array [
-          "acc1",
-          "acc2",
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "covering_index_3",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
+        ],
+        "columns": Array [
+          Object {
+            "dataType": "dataType1",
+            "name": "column1",
+          },
+          Object {
+            "dataType": "dataType2",
+            "name": "column2",
+          },
         ],
         "createdByIntegration": "",
         "database": "db3",
+        "datasource": "flint_s3",
         "id": "6",
-        "name": "Table_name_5",
-        "type": "CI",
+        "name": "covering_index_3",
+        "type": "Cover Index",
+      },
+      Object {
+        "accelerations": Array [
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "skipping_index_4",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
+          Object {
+            "database": "db1",
+            "dateCreated": 1709339290,
+            "dateUpdated": 1709339290,
+            "destination": "N/A",
+            "index": "security_logs_2022",
+            "name": "skipping_index_5",
+            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+            "status": "ACTIVE",
+            "table": "Table_name_1",
+            "type": "skip",
+          },
+        ],
+        "columns": Array [
+          Object {
+            "dataType": "dataType1",
+            "name": "column1",
+          },
+          Object {
+            "dataType": "dataType2",
+            "name": "column2",
+          },
+        ],
+        "createdByIntegration": "",
+        "database": "db3",
+        "datasource": "flint_s3",
+        "id": "7",
+        "name": "Table_name_6",
+        "type": "Table",
       },
     ]
   }
@@ -403,72 +547,216 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
           Array [
             Object {
               "accelerations": Array [
-                "skipping_index_1",
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "skipping_index_1",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
               ],
-              "createdByIntegration": "xx",
+              "columns": Array [
+                Object {
+                  "dataType": "dataType1",
+                  "name": "column1",
+                },
+                Object {
+                  "dataType": "dataType2",
+                  "name": "column2",
+                },
+                Object {
+                  "dataType": "dataType3",
+                  "name": "column3",
+                },
+                Object {
+                  "dataType": "dataType4",
+                  "name": "column4",
+                },
+              ],
+              "createdByIntegration": "integration_1",
               "database": "db1",
+              "datasource": "flint_s3",
               "id": "1",
               "name": "Table_name_1",
               "type": "Table",
             },
             Object {
               "accelerations": Array [
-                "skipping_index_1",
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "skipping_index_2",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
               ],
-              "createdByIntegration": "xx",
+              "columns": Array [],
+              "createdByIntegration": "integration_1",
               "database": "db1",
+              "datasource": "flint_s3",
               "id": "2",
               "name": "Table_name_2",
               "type": "Table",
             },
             Object {
               "accelerations": Array [
-                "skipping_index_2",
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "skipping_index_2",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
               ],
-              "createdByIntegration": "xx",
+              "columns": Array [],
+              "createdByIntegration": "integration_1",
               "database": "db1",
+              "datasource": "flint_s3",
               "id": "3",
-              "name": "Table_name_3",
-              "type": "Table",
+              "name": "skipping_index_2",
+              "type": "Skip Index",
             },
             Object {
               "accelerations": Array [
-                "skipping_index_2",
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "skipping_index_2",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
               ],
-              "createdByIntegration": "xx",
+              "columns": Array [
+                Object {
+                  "dataType": "dataType1",
+                  "name": "column1",
+                },
+                Object {
+                  "dataType": "dataType2",
+                  "name": "column2",
+                },
+              ],
+              "createdByIntegration": "integration_1",
               "database": "db2",
+              "datasource": "flint_s3",
               "id": "4",
               "name": "Table_name_4",
               "type": "Table",
             },
             Object {
-              "accelerations": Array [
-                "skipping_index_3",
+              "accelerations": Array [],
+              "columns": Array [
+                Object {
+                  "dataType": "dataType1",
+                  "name": "column1",
+                },
+                Object {
+                  "dataType": "dataType2",
+                  "name": "column2",
+                },
               ],
-              "createdByIntegration": "xx",
+              "createdByIntegration": "integration_1",
               "database": "db3",
+              "datasource": "flint_s3",
               "id": "5",
               "name": "Table_name_5",
               "type": "Table",
             },
             Object {
-              "accelerations": Array [],
-              "createdByIntegration": "",
-              "database": "db3",
-              "id": "6",
-              "name": "Table_name_5",
-              "type": "CI",
-            },
-            Object {
               "accelerations": Array [
-                "acc1",
-                "acc2",
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "covering_index_3",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
+              ],
+              "columns": Array [
+                Object {
+                  "dataType": "dataType1",
+                  "name": "column1",
+                },
+                Object {
+                  "dataType": "dataType2",
+                  "name": "column2",
+                },
               ],
               "createdByIntegration": "",
               "database": "db3",
+              "datasource": "flint_s3",
               "id": "6",
-              "name": "Table_name_5",
-              "type": "CI",
+              "name": "covering_index_3",
+              "type": "Cover Index",
+            },
+            Object {
+              "accelerations": Array [
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "skipping_index_4",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
+                Object {
+                  "database": "db1",
+                  "dateCreated": 1709339290,
+                  "dateUpdated": 1709339290,
+                  "destination": "N/A",
+                  "index": "security_logs_2022",
+                  "name": "skipping_index_5",
+                  "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                  "status": "ACTIVE",
+                  "table": "Table_name_1",
+                  "type": "skip",
+                },
+              ],
+              "columns": Array [
+                Object {
+                  "dataType": "dataType1",
+                  "name": "column1",
+                },
+                Object {
+                  "dataType": "dataType2",
+                  "name": "column2",
+                },
+              ],
+              "createdByIntegration": "",
+              "database": "db3",
+              "datasource": "flint_s3",
+              "id": "7",
+              "name": "Table_name_6",
+              "type": "Table",
             },
           ]
         }
@@ -528,12 +816,8 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                 "name": "Accelerations",
                 "options": Array [
                   Object {
-                    "text": "acc1",
-                    "value": "acc1",
-                  },
-                  Object {
-                    "text": "acc2",
-                    "value": "acc2",
+                    "text": "covering_index_3",
+                    "value": "covering_index_3",
                   },
                   Object {
                     "text": "skipping_index_1",
@@ -544,8 +828,12 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                     "value": "skipping_index_2",
                   },
                   Object {
-                    "text": "skipping_index_3",
-                    "value": "skipping_index_3",
+                    "text": "skipping_index_4",
+                    "value": "skipping_index_4",
+                  },
+                  Object {
+                    "text": "skipping_index_5",
+                    "value": "skipping_index_5",
                   },
                 ],
                 "type": "field_value_selection",
@@ -612,12 +900,8 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                   "name": "Accelerations",
                   "options": Array [
                     Object {
-                      "text": "acc1",
-                      "value": "acc1",
-                    },
-                    Object {
-                      "text": "acc2",
-                      "value": "acc2",
+                      "text": "covering_index_3",
+                      "value": "covering_index_3",
                     },
                     Object {
                       "text": "skipping_index_1",
@@ -628,8 +912,12 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                       "value": "skipping_index_2",
                     },
                     Object {
-                      "text": "skipping_index_3",
-                      "value": "skipping_index_3",
+                      "text": "skipping_index_4",
+                      "value": "skipping_index_4",
+                    },
+                    Object {
+                      "text": "skipping_index_5",
+                      "value": "skipping_index_5",
                     },
                   ],
                   "type": "field_value_selection",
@@ -791,12 +1079,8 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                             "name": "Accelerations",
                             "options": Array [
                               Object {
-                                "text": "acc1",
-                                "value": "acc1",
-                              },
-                              Object {
-                                "text": "acc2",
-                                "value": "acc2",
+                                "text": "covering_index_3",
+                                "value": "covering_index_3",
                               },
                               Object {
                                 "text": "skipping_index_1",
@@ -807,8 +1091,12 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 "value": "skipping_index_2",
                               },
                               Object {
-                                "text": "skipping_index_3",
-                                "value": "skipping_index_3",
+                                "text": "skipping_index_4",
+                                "value": "skipping_index_4",
+                              },
+                              Object {
+                                "text": "skipping_index_5",
+                                "value": "skipping_index_5",
                               },
                             ],
                             "type": "field_value_selection",
@@ -1014,12 +1302,8 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 "name": "Accelerations",
                                 "options": Array [
                                   Object {
-                                    "text": "acc1",
-                                    "value": "acc1",
-                                  },
-                                  Object {
-                                    "text": "acc2",
-                                    "value": "acc2",
+                                    "text": "covering_index_3",
+                                    "value": "covering_index_3",
                                   },
                                   Object {
                                     "text": "skipping_index_1",
@@ -1030,8 +1314,12 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     "value": "skipping_index_2",
                                   },
                                   Object {
-                                    "text": "skipping_index_3",
-                                    "value": "skipping_index_3",
+                                    "text": "skipping_index_4",
+                                    "value": "skipping_index_4",
+                                  },
+                                  Object {
+                                    "text": "skipping_index_5",
+                                    "value": "skipping_index_5",
                                   },
                                 ],
                                 "type": "field_value_selection",
@@ -1252,72 +1540,216 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
               Array [
                 Object {
                   "accelerations": Array [
-                    "skipping_index_1",
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "skipping_index_1",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
                   ],
-                  "createdByIntegration": "xx",
+                  "columns": Array [
+                    Object {
+                      "dataType": "dataType1",
+                      "name": "column1",
+                    },
+                    Object {
+                      "dataType": "dataType2",
+                      "name": "column2",
+                    },
+                    Object {
+                      "dataType": "dataType3",
+                      "name": "column3",
+                    },
+                    Object {
+                      "dataType": "dataType4",
+                      "name": "column4",
+                    },
+                  ],
+                  "createdByIntegration": "integration_1",
                   "database": "db1",
+                  "datasource": "flint_s3",
                   "id": "1",
                   "name": "Table_name_1",
                   "type": "Table",
                 },
                 Object {
                   "accelerations": Array [
-                    "skipping_index_1",
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "skipping_index_2",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
                   ],
-                  "createdByIntegration": "xx",
+                  "columns": Array [],
+                  "createdByIntegration": "integration_1",
                   "database": "db1",
+                  "datasource": "flint_s3",
                   "id": "2",
                   "name": "Table_name_2",
                   "type": "Table",
                 },
                 Object {
                   "accelerations": Array [
-                    "skipping_index_2",
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "skipping_index_2",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
                   ],
-                  "createdByIntegration": "xx",
-                  "database": "db1",
-                  "id": "3",
-                  "name": "Table_name_3",
-                  "type": "Table",
-                },
-                Object {
-                  "accelerations": Array [
-                    "skipping_index_2",
+                  "columns": Array [
+                    Object {
+                      "dataType": "dataType1",
+                      "name": "column1",
+                    },
+                    Object {
+                      "dataType": "dataType2",
+                      "name": "column2",
+                    },
                   ],
-                  "createdByIntegration": "xx",
+                  "createdByIntegration": "integration_1",
                   "database": "db2",
+                  "datasource": "flint_s3",
                   "id": "4",
                   "name": "Table_name_4",
                   "type": "Table",
                 },
                 Object {
-                  "accelerations": Array [
-                    "skipping_index_3",
+                  "accelerations": Array [],
+                  "columns": Array [
+                    Object {
+                      "dataType": "dataType1",
+                      "name": "column1",
+                    },
+                    Object {
+                      "dataType": "dataType2",
+                      "name": "column2",
+                    },
                   ],
-                  "createdByIntegration": "xx",
+                  "createdByIntegration": "integration_1",
                   "database": "db3",
+                  "datasource": "flint_s3",
                   "id": "5",
                   "name": "Table_name_5",
                   "type": "Table",
                 },
                 Object {
-                  "accelerations": Array [],
-                  "createdByIntegration": "",
-                  "database": "db3",
-                  "id": "6",
-                  "name": "Table_name_5",
-                  "type": "CI",
-                },
-                Object {
                   "accelerations": Array [
-                    "acc1",
-                    "acc2",
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "skipping_index_4",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "skipping_index_5",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
+                  ],
+                  "columns": Array [
+                    Object {
+                      "dataType": "dataType1",
+                      "name": "column1",
+                    },
+                    Object {
+                      "dataType": "dataType2",
+                      "name": "column2",
+                    },
                   ],
                   "createdByIntegration": "",
                   "database": "db3",
+                  "datasource": "flint_s3",
+                  "id": "7",
+                  "name": "Table_name_6",
+                  "type": "Table",
+                },
+                Object {
+                  "accelerations": Array [
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "covering_index_3",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
+                  ],
+                  "columns": Array [
+                    Object {
+                      "dataType": "dataType1",
+                      "name": "column1",
+                    },
+                    Object {
+                      "dataType": "dataType2",
+                      "name": "column2",
+                    },
+                  ],
+                  "createdByIntegration": "",
+                  "database": "db3",
+                  "datasource": "flint_s3",
                   "id": "6",
-                  "name": "Table_name_5",
-                  "type": "CI",
+                  "name": "covering_index_3",
+                  "type": "Cover Index",
+                },
+                Object {
+                  "accelerations": Array [
+                    Object {
+                      "database": "db1",
+                      "dateCreated": 1709339290,
+                      "dateUpdated": 1709339290,
+                      "destination": "N/A",
+                      "index": "security_logs_2022",
+                      "name": "skipping_index_2",
+                      "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                      "status": "ACTIVE",
+                      "table": "Table_name_1",
+                      "type": "skip",
+                    },
+                  ],
+                  "columns": Array [],
+                  "createdByIntegration": "integration_1",
+                  "database": "db1",
+                  "datasource": "flint_s3",
+                  "id": "3",
+                  "name": "skipping_index_2",
+                  "type": "Skip Index",
                 },
               ]
             }
@@ -1966,16 +2398,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
                                       Table_name_1
-                                    </a>
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -2091,7 +2524,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      xx
+                                      integration_1
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -2183,10 +2616,40 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     item={
                                       Object {
                                         "accelerations": Array [
-                                          "skipping_index_1",
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "skipping_index_1",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
                                         ],
-                                        "createdByIntegration": "xx",
+                                        "columns": Array [
+                                          Object {
+                                            "dataType": "dataType1",
+                                            "name": "column1",
+                                          },
+                                          Object {
+                                            "dataType": "dataType2",
+                                            "name": "column2",
+                                          },
+                                          Object {
+                                            "dataType": "dataType3",
+                                            "name": "column3",
+                                          },
+                                          Object {
+                                            "dataType": "dataType4",
+                                            "name": "column4",
+                                          },
+                                        ],
+                                        "createdByIntegration": "integration_1",
                                         "database": "db1",
+                                        "datasource": "flint_s3",
                                         "id": "1",
                                         "name": "Table_name_1",
                                         "type": "Table",
@@ -2210,10 +2673,40 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_1",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_1",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                            Object {
+                                              "dataType": "dataType3",
+                                              "name": "column3",
+                                            },
+                                            Object {
+                                              "dataType": "dataType4",
+                                              "name": "column4",
+                                            },
+                                          ],
+                                          "createdByIntegration": "integration_1",
                                           "database": "db1",
+                                          "datasource": "flint_s3",
                                           "id": "1",
                                           "name": "Table_name_1",
                                           "type": "Table",
@@ -2307,10 +2800,40 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_1",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_1",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                            Object {
+                                              "dataType": "dataType3",
+                                              "name": "column3",
+                                            },
+                                            Object {
+                                              "dataType": "dataType4",
+                                              "name": "column4",
+                                            },
+                                          ],
+                                          "createdByIntegration": "integration_1",
                                           "database": "db1",
+                                          "datasource": "flint_s3",
                                           "id": "1",
                                           "name": "Table_name_1",
                                           "type": "Table",
@@ -2433,16 +2956,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
                                       Table_name_2
-                                    </a>
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -2558,7 +3082,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      xx
+                                      integration_1
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -2601,7 +3125,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      skipping_index_1
+                                      skipping_index_2
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -2650,10 +3174,23 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     item={
                                       Object {
                                         "accelerations": Array [
-                                          "skipping_index_1",
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "skipping_index_2",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
                                         ],
-                                        "createdByIntegration": "xx",
+                                        "columns": Array [],
+                                        "createdByIntegration": "integration_1",
                                         "database": "db1",
+                                        "datasource": "flint_s3",
                                         "id": "2",
                                         "name": "Table_name_2",
                                         "type": "Table",
@@ -2677,10 +3214,23 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_1",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_2",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
+                                          "columns": Array [],
+                                          "createdByIntegration": "integration_1",
                                           "database": "db1",
+                                          "datasource": "flint_s3",
                                           "id": "2",
                                           "name": "Table_name_2",
                                           "type": "Table",
@@ -2774,10 +3324,23 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_1",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_2",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
+                                          "columns": Array [],
+                                          "createdByIntegration": "integration_1",
                                           "database": "db1",
+                                          "datasource": "flint_s3",
                                           "id": "2",
                                           "name": "Table_name_2",
                                           "type": "Table",
@@ -2900,16 +3463,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      Table_name_3
-                                    </a>
+                                      Table_name_4
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -2945,7 +3509,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                   <span
                                     className="euiTableCellContent__text"
                                   >
-                                    db1
+                                    db2
                                   </span>
                                 </div>
                               </td>
@@ -3025,7 +3589,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      xx
+                                      integration_1
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -3117,12 +3681,34 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     item={
                                       Object {
                                         "accelerations": Array [
-                                          "skipping_index_2",
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "skipping_index_2",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
                                         ],
-                                        "createdByIntegration": "xx",
-                                        "database": "db1",
-                                        "id": "3",
-                                        "name": "Table_name_3",
+                                        "columns": Array [
+                                          Object {
+                                            "dataType": "dataType1",
+                                            "name": "column1",
+                                          },
+                                          Object {
+                                            "dataType": "dataType2",
+                                            "name": "column2",
+                                          },
+                                        ],
+                                        "createdByIntegration": "integration_1",
+                                        "database": "db2",
+                                        "datasource": "flint_s3",
+                                        "id": "4",
+                                        "name": "Table_name_4",
                                         "type": "Table",
                                       }
                                     }
@@ -3144,12 +3730,34 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_2",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_2",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
-                                          "database": "db1",
-                                          "id": "3",
-                                          "name": "Table_name_3",
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                          ],
+                                          "createdByIntegration": "integration_1",
+                                          "database": "db2",
+                                          "datasource": "flint_s3",
+                                          "id": "4",
+                                          "name": "Table_name_4",
                                           "type": "Table",
                                         }
                                       }
@@ -3241,12 +3849,34 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_2",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_2",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
-                                          "database": "db1",
-                                          "id": "3",
-                                          "name": "Table_name_3",
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                          ],
+                                          "createdByIntegration": "integration_1",
+                                          "database": "db2",
+                                          "datasource": "flint_s3",
+                                          "id": "4",
+                                          "name": "Table_name_4",
                                           "type": "Table",
                                         }
                                       }
@@ -3367,16 +3997,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      Table_name_4
-                                    </a>
+                                      Table_name_5
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -3412,7 +4043,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                   <span
                                     className="euiTableCellContent__text"
                                   >
-                                    db2
+                                    db3
                                   </span>
                                 </div>
                               </td>
@@ -3492,7 +4123,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      xx
+                                      integration_1
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -3526,18 +4157,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 <div
                                   className="euiTableCellContent euiTableCellContent--overflowingContent"
                                 >
-                                  <EuiLink
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      skipping_index_2
-                                    </button>
-                                  </EuiLink>
+                                  -
                                 </div>
                               </td>
                             </EuiTableRowCell>
@@ -3583,13 +4203,22 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     className="euiTableCellContent__hoverItem"
                                     item={
                                       Object {
-                                        "accelerations": Array [
-                                          "skipping_index_2",
+                                        "accelerations": Array [],
+                                        "columns": Array [
+                                          Object {
+                                            "dataType": "dataType1",
+                                            "name": "column1",
+                                          },
+                                          Object {
+                                            "dataType": "dataType2",
+                                            "name": "column2",
+                                          },
                                         ],
-                                        "createdByIntegration": "xx",
-                                        "database": "db2",
-                                        "id": "4",
-                                        "name": "Table_name_4",
+                                        "createdByIntegration": "integration_1",
+                                        "database": "db3",
+                                        "datasource": "flint_s3",
+                                        "id": "5",
+                                        "name": "Table_name_5",
                                         "type": "Table",
                                       }
                                     }
@@ -3610,13 +4239,22 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       enabled={true}
                                       item={
                                         Object {
-                                          "accelerations": Array [
-                                            "skipping_index_2",
+                                          "accelerations": Array [],
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
-                                          "database": "db2",
-                                          "id": "4",
-                                          "name": "Table_name_4",
+                                          "createdByIntegration": "integration_1",
+                                          "database": "db3",
+                                          "datasource": "flint_s3",
+                                          "id": "5",
+                                          "name": "Table_name_5",
                                           "type": "Table",
                                         }
                                       }
@@ -3707,13 +4345,22 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       enabled={true}
                                       item={
                                         Object {
-                                          "accelerations": Array [
-                                            "skipping_index_2",
+                                          "accelerations": Array [],
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
-                                          "database": "db2",
-                                          "id": "4",
-                                          "name": "Table_name_4",
+                                          "createdByIntegration": "integration_1",
+                                          "database": "db3",
+                                          "datasource": "flint_s3",
+                                          "id": "5",
+                                          "name": "Table_name_5",
                                           "type": "Table",
                                         }
                                       }
@@ -3834,16 +4481,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      Table_name_5
-                                    </a>
+                                      Table_name_6
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -3948,20 +4596,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 <div
                                   className="euiTableCellContent euiTableCellContent--overflowingContent"
                                 >
-                                  <EuiLink
-                                    className=""
-                                    key=".0"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      xx
-                                    </button>
-                                  </EuiLink>
+                                  -
                                 </div>
                               </td>
                             </EuiTableRowCell>
@@ -4002,7 +4637,20 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      skipping_index_3
+                                      skipping_index_4
+                                    </button>
+                                  </EuiLink>
+                                  , 
+                                  <EuiLink
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      skipping_index_5
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -4051,12 +4699,46 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     item={
                                       Object {
                                         "accelerations": Array [
-                                          "skipping_index_3",
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "skipping_index_4",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "skipping_index_5",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
                                         ],
-                                        "createdByIntegration": "xx",
+                                        "columns": Array [
+                                          Object {
+                                            "dataType": "dataType1",
+                                            "name": "column1",
+                                          },
+                                          Object {
+                                            "dataType": "dataType2",
+                                            "name": "column2",
+                                          },
+                                        ],
+                                        "createdByIntegration": "",
                                         "database": "db3",
-                                        "id": "5",
-                                        "name": "Table_name_5",
+                                        "datasource": "flint_s3",
+                                        "id": "7",
+                                        "name": "Table_name_6",
                                         "type": "Table",
                                       }
                                     }
@@ -4078,12 +4760,46 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_3",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_4",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_5",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                          ],
+                                          "createdByIntegration": "",
                                           "database": "db3",
-                                          "id": "5",
-                                          "name": "Table_name_5",
+                                          "datasource": "flint_s3",
+                                          "id": "7",
+                                          "name": "Table_name_6",
                                           "type": "Table",
                                         }
                                       }
@@ -4175,12 +4891,46 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "skipping_index_3",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_4",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_5",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "xx",
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                          ],
+                                          "createdByIntegration": "",
                                           "database": "db3",
-                                          "id": "5",
-                                          "name": "Table_name_5",
+                                          "datasource": "flint_s3",
+                                          "id": "7",
+                                          "name": "Table_name_6",
                                           "type": "Table",
                                         }
                                       }
@@ -4301,16 +5051,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      Table_name_5
-                                    </a>
+                                      covering_index_3
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -4382,7 +5133,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                   <span
                                     className="euiTableCellContent__text"
                                   >
-                                    CI
+                                    Cover Index
                                   </span>
                                 </div>
                               </td>
@@ -4447,7 +5198,18 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 <div
                                   className="euiTableCellContent euiTableCellContent--overflowingContent"
                                 >
-                                  -
+                                  <EuiLink
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      covering_index_3
+                                    </button>
+                                  </EuiLink>
                                 </div>
                               </td>
                             </EuiTableRowCell>
@@ -4485,12 +5247,36 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     className="euiTableCellContent__hoverItem"
                                     item={
                                       Object {
-                                        "accelerations": Array [],
+                                        "accelerations": Array [
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "covering_index_3",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
+                                        ],
+                                        "columns": Array [
+                                          Object {
+                                            "dataType": "dataType1",
+                                            "name": "column1",
+                                          },
+                                          Object {
+                                            "dataType": "dataType2",
+                                            "name": "column2",
+                                          },
+                                        ],
                                         "createdByIntegration": "",
                                         "database": "db3",
+                                        "datasource": "flint_s3",
                                         "id": "6",
-                                        "name": "Table_name_5",
-                                        "type": "CI",
+                                        "name": "covering_index_3",
+                                        "type": "Cover Index",
                                       }
                                     }
                                     itemId={5}
@@ -4510,12 +5296,36 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       enabled={true}
                                       item={
                                         Object {
-                                          "accelerations": Array [],
+                                          "accelerations": Array [
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "covering_index_3",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
+                                          ],
+                                          "columns": Array [
+                                            Object {
+                                              "dataType": "dataType1",
+                                              "name": "column1",
+                                            },
+                                            Object {
+                                              "dataType": "dataType2",
+                                              "name": "column2",
+                                            },
+                                          ],
                                           "createdByIntegration": "",
                                           "database": "db3",
+                                          "datasource": "flint_s3",
                                           "id": "6",
-                                          "name": "Table_name_5",
-                                          "type": "CI",
+                                          "name": "covering_index_3",
+                                          "type": "Cover Index",
                                         }
                                       }
                                       key="item_action_5_0"
@@ -4635,16 +5445,17 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 >
                                   <EuiLink
                                     className=""
-                                    href="https://example.com"
                                     key=".0"
+                                    onClick={[Function]}
                                   >
-                                    <a
+                                    <button
                                       className="euiLink euiLink--primary"
-                                      href="https://example.com"
-                                      rel="noreferrer"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      Table_name_5
-                                    </a>
+                                      skipping_index_2
+                                    </button>
                                   </EuiLink>
                                 </div>
                               </td>
@@ -4680,7 +5491,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                   <span
                                     className="euiTableCellContent__text"
                                   >
-                                    db3
+                                    db1
                                   </span>
                                 </div>
                               </td>
@@ -4716,7 +5527,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                   <span
                                     className="euiTableCellContent__text"
                                   >
-                                    CI
+                                    Skip Index
                                   </span>
                                 </div>
                               </td>
@@ -4749,7 +5560,20 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                 <div
                                   className="euiTableCellContent euiTableCellContent--overflowingContent"
                                 >
-                                  -
+                                  <EuiLink
+                                    className=""
+                                    key=".0"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      integration_1
+                                    </button>
+                                  </EuiLink>
                                 </div>
                               </td>
                             </EuiTableRowCell>
@@ -4790,20 +5614,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       onClick={[Function]}
                                       type="button"
                                     >
-                                      acc1
-                                    </button>
-                                  </EuiLink>
-                                  , 
-                                  <EuiLink
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      acc2
+                                      skipping_index_2
                                     </button>
                                   </EuiLink>
                                 </div>
@@ -4844,14 +5655,26 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                     item={
                                       Object {
                                         "accelerations": Array [
-                                          "acc1",
-                                          "acc2",
+                                          Object {
+                                            "database": "db1",
+                                            "dateCreated": 1709339290,
+                                            "dateUpdated": 1709339290,
+                                            "destination": "N/A",
+                                            "index": "security_logs_2022",
+                                            "name": "skipping_index_2",
+                                            "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                            "status": "ACTIVE",
+                                            "table": "Table_name_1",
+                                            "type": "skip",
+                                          },
                                         ],
-                                        "createdByIntegration": "",
-                                        "database": "db3",
-                                        "id": "6",
-                                        "name": "Table_name_5",
-                                        "type": "CI",
+                                        "columns": Array [],
+                                        "createdByIntegration": "integration_1",
+                                        "database": "db1",
+                                        "datasource": "flint_s3",
+                                        "id": "3",
+                                        "name": "skipping_index_2",
+                                        "type": "Skip Index",
                                       }
                                     }
                                     itemId={6}
@@ -4872,14 +5695,26 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       item={
                                         Object {
                                           "accelerations": Array [
-                                            "acc1",
-                                            "acc2",
+                                            Object {
+                                              "database": "db1",
+                                              "dateCreated": 1709339290,
+                                              "dateUpdated": 1709339290,
+                                              "destination": "N/A",
+                                              "index": "security_logs_2022",
+                                              "name": "skipping_index_2",
+                                              "sql": "SELECT * FROM Table_name_1 WHERE ...",
+                                              "status": "ACTIVE",
+                                              "table": "Table_name_1",
+                                              "type": "skip",
+                                            },
                                           ],
-                                          "createdByIntegration": "",
-                                          "database": "db3",
-                                          "id": "6",
-                                          "name": "Table_name_5",
-                                          "type": "CI",
+                                          "columns": Array [],
+                                          "createdByIntegration": "integration_1",
+                                          "database": "db1",
+                                          "datasource": "flint_s3",
+                                          "id": "3",
+                                          "name": "skipping_index_2",
+                                          "type": "Skip Index",
                                         }
                                       }
                                       key="item_action_6_0"

--- a/public/components/datasources/components/__tests__/__snapshots__/data_connection.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/data_connection.test.tsx.snap
@@ -789,13 +789,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_1
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -849,7 +848,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
+                              integration_1
                             </button>
                           </div>
                         </td>
@@ -957,13 +956,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_2
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -1017,175 +1015,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
-                            </button>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Accelerations
-                          </div>
-                          <div
-                            class="euiTableCellContent euiTableCellContent--overflowingContent"
-                          >
-                            <button
-                              class="euiLink euiLink--primary"
-                              type="button"
-                            >
-                              skipping_index_1
-                            </button>
-                            
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell euiTableRowCell--hasActions"
-                        >
-                          <div
-                            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                          >
-                            <span
-                              class="euiToolTipAnchor"
-                            >
-                              <button
-                                aria-labelledby="random_html_id"
-                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                  />
-                                </svg>
-                              </button>
-                              <span
-                                class="euiScreenReaderOnly"
-                                id="random_html_id"
-                              >
-                                Discover
-                              </span>
-                            </span>
-                            <span
-                              class="euiToolTipAnchor"
-                            >
-                              <button
-                                aria-labelledby="random_html_id"
-                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                  />
-                                </svg>
-                              </button>
-                              <span
-                                class="euiScreenReaderOnly"
-                                id="random_html_id"
-                              >
-                                Accelerate
-                              </span>
-                            </span>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        class="euiTableRow euiTableRow-hasActions"
-                      >
-                        <td
-                          class="euiTableRowCell"
-                          data-test-subj="nameCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Name
-                          </div>
-                          <div
-                            class="euiTableCellContent euiTableCellContent--overflowingContent"
-                          >
-                            <a
-                              class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
-                            >
-                              Table_name_3
-                            </a>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Database
-                          </div>
-                          <div
-                            class="euiTableCellContent"
-                          >
-                            <span
-                              class="euiTableCellContent__text"
-                            >
-                              db1
-                            </span>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Type
-                          </div>
-                          <div
-                            class="euiTableCellContent"
-                          >
-                            <span
-                              class="euiTableCellContent__text"
-                            >
-                              Table
-                            </span>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Created by Integration
-                          </div>
-                          <div
-                            class="euiTableCellContent euiTableCellContent--overflowingContent"
-                          >
-                            <button
-                              class="euiLink euiLink--primary"
-                              type="button"
-                            >
-                              xx
+                              integration_1
                             </button>
                           </div>
                         </td>
@@ -1293,13 +1123,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_4
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -1353,7 +1182,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
+                              integration_1
                             </button>
                           </div>
                         </td>
@@ -1461,13 +1290,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_5
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -1521,8 +1349,164 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
+                              integration_1
                             </button>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Accelerations
+                          </div>
+                          <div
+                            class="euiTableCellContent euiTableCellContent--overflowingContent"
+                          >
+                            -
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell euiTableRowCell--hasActions"
+                        >
+                          <div
+                            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                          >
+                            <span
+                              class="euiToolTipAnchor"
+                            >
+                              <button
+                                aria-labelledby="random_html_id"
+                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </button>
+                              <span
+                                class="euiScreenReaderOnly"
+                                id="random_html_id"
+                              >
+                                Discover
+                              </span>
+                            </span>
+                            <span
+                              class="euiToolTipAnchor"
+                            >
+                              <button
+                                aria-labelledby="random_html_id"
+                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </button>
+                              <span
+                                class="euiScreenReaderOnly"
+                                id="random_html_id"
+                              >
+                                Accelerate
+                              </span>
+                            </span>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="euiTableRow euiTableRow-hasActions"
+                      >
+                        <td
+                          class="euiTableRowCell"
+                          data-test-subj="nameCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Name
+                          </div>
+                          <div
+                            class="euiTableCellContent euiTableCellContent--overflowingContent"
+                          >
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              Table_name_6
+                            </button>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Database
+                          </div>
+                          <div
+                            class="euiTableCellContent"
+                          >
+                            <span
+                              class="euiTableCellContent__text"
+                            >
+                              db3
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Type
+                          </div>
+                          <div
+                            class="euiTableCellContent"
+                          >
+                            <span
+                              class="euiTableCellContent__text"
+                            >
+                              Table
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Created by Integration
+                          </div>
+                          <div
+                            class="euiTableCellContent euiTableCellContent--overflowingContent"
+                          >
+                            -
                           </div>
                         </td>
                         <td
@@ -1540,7 +1524,14 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              skipping_index_3
+                              skipping_index_4
+                            </button>
+                            , 
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              skipping_index_5
                             </button>
                             
                           </div>
@@ -1629,13 +1620,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
-                              Table_name_5
-                            </a>
+                              covering_index_3
+                            </button>
                           </div>
                         </td>
                         <td
@@ -1670,7 +1660,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                             <span
                               class="euiTableCellContent__text"
                             >
-                              CI
+                              Cover Index
                             </span>
                           </div>
                         </td>
@@ -1699,7 +1689,13 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            -
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              covering_index_3
+                            </button>
+                            
                           </div>
                         </td>
                         <td
@@ -1756,13 +1752,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
-                              Table_name_5
-                            </a>
+                              skipping_index_2
+                            </button>
                           </div>
                         </td>
                         <td
@@ -1779,7 +1774,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                             <span
                               class="euiTableCellContent__text"
                             >
-                              db3
+                              db1
                             </span>
                           </div>
                         </td>
@@ -1797,7 +1792,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                             <span
                               class="euiTableCellContent__text"
                             >
-                              CI
+                              Skip Index
                             </span>
                           </div>
                         </td>
@@ -1812,7 +1807,12 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            -
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              integration_1
+                            </button>
                           </div>
                         </td>
                         <td
@@ -1830,14 +1830,7 @@ exports[`Data Connection Page test Renders Prometheus data connection page with 
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              acc1
-                            </button>
-                            , 
-                            <button
-                              class="euiLink euiLink--primary"
-                              type="button"
-                            >
-                              acc2
+                              skipping_index_2
                             </button>
                             
                           </div>
@@ -2964,13 +2957,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_1
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -3024,7 +3016,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
+                              integration_1
                             </button>
                           </div>
                         </td>
@@ -3136,13 +3128,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_2
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -3196,179 +3187,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
-                            </button>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Accelerations
-                          </div>
-                          <div
-                            class="euiTableCellContent euiTableCellContent--overflowingContent"
-                          >
-                            <button
-                              class="euiLink euiLink--primary"
-                              type="button"
-                            >
-                              skipping_index_1
-                            </button>
-                            
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell euiTableRowCell--hasActions"
-                        >
-                          <div
-                            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                          >
-                            <span
-                              class="euiToolTipAnchor"
-                            >
-                              <button
-                                aria-labelledby="random_html_id"
-                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  height="32"
-                                  role="img"
-                                  viewBox="0 0 32 32"
-                                  width="32"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    class="euiIcon__fillSecondary"
-                                    d="m8.33 23.67 4.79-10.55 10.55-4.79-4.79 10.55-10.55 4.79Zm6.3-9-2.28 5 5-2.28 2.28-5-5 2.28Z"
-                                  />
-                                  <path
-                                    d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16A16 16 0 0 0 16 0Zm1 29.95V28h-2v1.95A14 14 0 0 1 2.05 17H4v-2H2.05A14 14 0 0 1 15 2.05V4h2V2.05A14 14 0 0 1 29.95 15H28v2h1.95A14 14 0 0 1 17 29.95Z"
-                                  />
-                                </svg>
-                              </button>
-                              <span
-                                class="euiScreenReaderOnly"
-                                id="random_html_id"
-                              >
-                                Discover
-                              </span>
-                            </span>
-                            <span
-                              class="euiToolTipAnchor"
-                            >
-                              <button
-                                aria-labelledby="random_html_id"
-                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M7.04 13.274a.5.5 0 1 0 .892.453l3.014-5.931a.5.5 0 0 0-.445-.727H5.316L8.03 1.727a.5.5 0 1 0-.892-.453L4.055 7.343a.5.5 0 0 0 .446.726h5.185L7.04 13.274Z"
-                                  />
-                                </svg>
-                              </button>
-                              <span
-                                class="euiScreenReaderOnly"
-                                id="random_html_id"
-                              >
-                                Accelerate
-                              </span>
-                            </span>
-                          </div>
-                        </td>
-                      </tr>
-                      <tr
-                        class="euiTableRow euiTableRow-hasActions"
-                      >
-                        <td
-                          class="euiTableRowCell"
-                          data-test-subj="nameCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Name
-                          </div>
-                          <div
-                            class="euiTableCellContent euiTableCellContent--overflowingContent"
-                          >
-                            <a
-                              class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
-                            >
-                              Table_name_3
-                            </a>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Database
-                          </div>
-                          <div
-                            class="euiTableCellContent"
-                          >
-                            <span
-                              class="euiTableCellContent__text"
-                            >
-                              db1
-                            </span>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Type
-                          </div>
-                          <div
-                            class="euiTableCellContent"
-                          >
-                            <span
-                              class="euiTableCellContent__text"
-                            >
-                              Table
-                            </span>
-                          </div>
-                        </td>
-                        <td
-                          class="euiTableRowCell"
-                        >
-                          <div
-                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                          >
-                            Created by Integration
-                          </div>
-                          <div
-                            class="euiTableCellContent euiTableCellContent--overflowingContent"
-                          >
-                            <button
-                              class="euiLink euiLink--primary"
-                              type="button"
-                            >
-                              xx
+                              integration_1
                             </button>
                           </div>
                         </td>
@@ -3480,13 +3299,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_4
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -3540,7 +3358,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
+                              integration_1
                             </button>
                           </div>
                         </td>
@@ -3652,13 +3470,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
                               Table_name_5
-                            </a>
+                            </button>
                           </div>
                         </td>
                         <td
@@ -3712,8 +3529,168 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              xx
+                              integration_1
                             </button>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Accelerations
+                          </div>
+                          <div
+                            class="euiTableCellContent euiTableCellContent--overflowingContent"
+                          >
+                            -
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell euiTableRowCell--hasActions"
+                        >
+                          <div
+                            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                          >
+                            <span
+                              class="euiToolTipAnchor"
+                            >
+                              <button
+                                aria-labelledby="random_html_id"
+                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="32"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width="32"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    class="euiIcon__fillSecondary"
+                                    d="m8.33 23.67 4.79-10.55 10.55-4.79-4.79 10.55-10.55 4.79Zm6.3-9-2.28 5 5-2.28 2.28-5-5 2.28Z"
+                                  />
+                                  <path
+                                    d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16A16 16 0 0 0 16 0Zm1 29.95V28h-2v1.95A14 14 0 0 1 2.05 17H4v-2H2.05A14 14 0 0 1 15 2.05V4h2V2.05A14 14 0 0 1 29.95 15H28v2h1.95A14 14 0 0 1 17 29.95Z"
+                                  />
+                                </svg>
+                              </button>
+                              <span
+                                class="euiScreenReaderOnly"
+                                id="random_html_id"
+                              >
+                                Discover
+                              </span>
+                            </span>
+                            <span
+                              class="euiToolTipAnchor"
+                            >
+                              <button
+                                aria-labelledby="random_html_id"
+                                class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M7.04 13.274a.5.5 0 1 0 .892.453l3.014-5.931a.5.5 0 0 0-.445-.727H5.316L8.03 1.727a.5.5 0 1 0-.892-.453L4.055 7.343a.5.5 0 0 0 .446.726h5.185L7.04 13.274Z"
+                                  />
+                                </svg>
+                              </button>
+                              <span
+                                class="euiScreenReaderOnly"
+                                id="random_html_id"
+                              >
+                                Accelerate
+                              </span>
+                            </span>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="euiTableRow euiTableRow-hasActions"
+                      >
+                        <td
+                          class="euiTableRowCell"
+                          data-test-subj="nameCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Name
+                          </div>
+                          <div
+                            class="euiTableCellContent euiTableCellContent--overflowingContent"
+                          >
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              Table_name_6
+                            </button>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Database
+                          </div>
+                          <div
+                            class="euiTableCellContent"
+                          >
+                            <span
+                              class="euiTableCellContent__text"
+                            >
+                              db3
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Type
+                          </div>
+                          <div
+                            class="euiTableCellContent"
+                          >
+                            <span
+                              class="euiTableCellContent__text"
+                            >
+                              Table
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="euiTableRowCell"
+                        >
+                          <div
+                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                          >
+                            Created by Integration
+                          </div>
+                          <div
+                            class="euiTableCellContent euiTableCellContent--overflowingContent"
+                          >
+                            -
                           </div>
                         </td>
                         <td
@@ -3731,7 +3708,14 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              skipping_index_3
+                              skipping_index_4
+                            </button>
+                            , 
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              skipping_index_5
                             </button>
                             
                           </div>
@@ -3824,13 +3808,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
-                              Table_name_5
-                            </a>
+                              covering_index_3
+                            </button>
                           </div>
                         </td>
                         <td
@@ -3865,7 +3848,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                             <span
                               class="euiTableCellContent__text"
                             >
-                              CI
+                              Cover Index
                             </span>
                           </div>
                         </td>
@@ -3894,7 +3877,13 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            -
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              covering_index_3
+                            </button>
+                            
                           </div>
                         </td>
                         <td
@@ -3955,13 +3944,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            <a
+                            <button
                               class="euiLink euiLink--primary"
-                              href="https://example.com"
-                              rel="noreferrer"
+                              type="button"
                             >
-                              Table_name_5
-                            </a>
+                              skipping_index_2
+                            </button>
                           </div>
                         </td>
                         <td
@@ -3978,7 +3966,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                             <span
                               class="euiTableCellContent__text"
                             >
-                              db3
+                              db1
                             </span>
                           </div>
                         </td>
@@ -3996,7 +3984,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                             <span
                               class="euiTableCellContent__text"
                             >
-                              CI
+                              Skip Index
                             </span>
                           </div>
                         </td>
@@ -4011,7 +3999,12 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                           <div
                             class="euiTableCellContent euiTableCellContent--overflowingContent"
                           >
-                            -
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              integration_1
+                            </button>
                           </div>
                         </td>
                         <td
@@ -4029,14 +4022,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                               class="euiLink euiLink--primary"
                               type="button"
                             >
-                              acc1
-                            </button>
-                            , 
-                            <button
-                              class="euiLink euiLink--primary"
-                              type="button"
-                            >
-                              acc2
+                              skipping_index_2
                             </button>
                             
                           </div>

--- a/public/components/datasources/components/__tests__/associated_objects_flyout.test.tsx
+++ b/public/components/datasources/components/__tests__/associated_objects_flyout.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { mount, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { AssociatedObjectsDetailsFlyout } from '../manage/associated_objects/associated_objects_details_flyout';
+import { mockAssociatedObjects } from '../manage/associated_objects/utils/associated_objects_tab_utils';
+import * as plugin from '../../../../plugin';
+import { act } from '@testing-library/react';
+
+configure({ adapter: new Adapter() });
+
+jest.mock('../../../../plugin', () => ({
+  getRenderAccelerationDetailsFlyout: jest.fn(() => jest.fn()),
+  getRenderAssociatedObjectsDetailsFlyout: jest.fn(() => jest.fn()),
+}));
+
+describe('AssociatedObjectsDetailsFlyout Integration Tests', () => {
+  const mockTableDetail = mockAssociatedObjects[0];
+
+  beforeEach(() => {
+    plugin.getRenderAccelerationDetailsFlyout.mockClear();
+  });
+
+  it('renders acceleration details correctly and triggers flyout on click', () => {
+    const wrapper = mount(<AssociatedObjectsDetailsFlyout tableDetail={mockTableDetail} />);
+    expect(wrapper.find('EuiInMemoryTable').at(0).find('EuiLink').length).toBeGreaterThan(0);
+
+    wrapper.find('EuiInMemoryTable').at(0).find('EuiLink').first().simulate('click');
+    expect(plugin.getRenderAccelerationDetailsFlyout).toHaveBeenCalled();
+  });
+
+  it('displays no data message for accelerations but still renders schema table', () => {
+    const mockDetailNoAccelerations = {
+      ...mockTableDetail,
+      accelerations: [],
+      columns: [
+        { name: 'column1', dataType: 'string' },
+        { name: 'column2', dataType: 'number' },
+      ],
+    };
+
+    const wrapper = mount(
+      <AssociatedObjectsDetailsFlyout tableDetail={mockDetailNoAccelerations} />
+    );
+
+    expect(wrapper.text()).toContain('You have no accelerations');
+    expect(wrapper.find('EuiInMemoryTable').exists()).toBe(true);
+    expect(wrapper.text()).toContain('column1');
+    expect(wrapper.text()).toContain('column2');
+  });
+
+  it('renders schema table correctly with column data', () => {
+    const wrapper = mount(<AssociatedObjectsDetailsFlyout tableDetail={mockTableDetail} />);
+
+    expect(wrapper.find('EuiInMemoryTable').at(1).exists()).toBe(true);
+    expect(wrapper.find('EuiInMemoryTable').at(1).text()).toContain(
+      mockTableDetail.columns[0].name
+    );
+  });
+
+  it('triggers details flyout on acceleration link click', async () => {
+    const wrapper = mount(<AssociatedObjectsDetailsFlyout tableDetail={mockTableDetail} />);
+
+    await act(async () => {
+      // Wait a tick for async updates
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      wrapper.update();
+    });
+
+    const accName = mockTableDetail.accelerations[0]?.name;
+    const accLink = wrapper
+      .find('EuiLink')
+      .findWhere((node) => node.text() === accName)
+      .first();
+    expect(accLink.exists()).toBe(true);
+
+    accLink.simulate('click');
+    expect(plugin.getRenderAccelerationDetailsFlyout).toHaveBeenCalled();
+  });
+});

--- a/public/components/datasources/components/__tests__/data_connection.test.tsx
+++ b/public/components/datasources/components/__tests__/data_connection.test.tsx
@@ -15,6 +15,15 @@ import { DataConnection } from '../manage/data_connection';
 import ReactDOM from 'react-dom';
 import { coreRefs } from '../../../../../public/framework/core_refs';
 
+jest.mock('../../../../plugin', () => ({
+  getRenderAccelerationDetailsFlyout: jest.fn(() =>
+    jest.fn().mockImplementation(() => console.log('Acceleration Details Flyout Rendered'))
+  ),
+  getRenderAssociatedObjectsDetailsFlyout: jest.fn(() =>
+    jest.fn().mockImplementation(() => console.log('Associated Objects Details Flyout Rendered'))
+  ),
+}));
+
 jest.mock('../../../../../public/framework/core_refs', () => ({
   coreRefs: {
     chrome: {

--- a/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiSpacer,
+  EuiText,
+  EuiIcon,
+  EuiButtonEmpty,
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+  EuiHorizontalRule,
+  EuiTitle,
+  EuiTableFieldDataColumnType,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiButton,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+import { AssociatedObject } from 'common/types/data_connections';
+import { i18n } from '@osd/i18n';
+import {
+  onAccelerateButtonClick,
+  onDeleteButtonClick,
+  onDiscoverButtonClick,
+} from './utils/associated_objects_tab_utils';
+import { getRenderAccelerationDetailsFlyout } from '../../../../../plugin';
+import { AccelerationStatus } from '../accelerations/helpers/utils';
+import {
+  ACCE_NO_DATA_TITLE,
+  ACCE_NO_DATA_DESCRIPTION,
+  CREATE_ACCELERATION_DESCRIPTION,
+} from '../associated_objects/utils/associated_objects_tab_utils';
+
+export interface AssociatedObjectsFlyoutProps {
+  tableDetail: AssociatedObject;
+}
+
+export const AssociatedObjectsDetailsFlyout = ({ tableDetail }: AssociatedObjectsFlyoutProps) => {
+  const DiscoverButton = () => {
+    // TODO: display button if can be sent to discover
+    return (
+      <EuiButtonEmpty onClick={onDiscoverButtonClick}>
+        <EuiIcon type={'discoverApp'} size="m" />
+      </EuiButtonEmpty>
+    );
+  };
+
+  const AccelerateButton = () => {
+    return (
+      <EuiButtonEmpty onClick={onAccelerateButtonClick}>
+        <EuiIcon type={'bolt'} size="m" />
+      </EuiButtonEmpty>
+    );
+  };
+
+  const DeleteButton = () => {
+    return (
+      <EuiButtonEmpty onClick={onDeleteButtonClick}>
+        <EuiIcon type="trash" size="m" />
+      </EuiButtonEmpty>
+    );
+  };
+
+  const DetailComponent = (detailProps: { title: string; description: any }) => {
+    const { title, description } = detailProps;
+    return (
+      <EuiFlexItem>
+        <EuiDescriptionList>
+          <EuiDescriptionListTitle>{title}</EuiDescriptionListTitle>
+          <EuiDescriptionListDescription>{description}</EuiDescriptionListDescription>
+        </EuiDescriptionList>
+      </EuiFlexItem>
+    );
+  };
+
+  const ConnectionComponent = () => {
+    return (
+      <EuiFlexGroup direction="row">
+        <DetailComponent title="Datasource connection" description={tableDetail.datasource} />
+        <DetailComponent title="Database" description={tableDetail.database} />
+        <DetailComponent title="Table" description={tableDetail.name} />
+      </EuiFlexGroup>
+    );
+  };
+
+  const TableTitleComponent = (titleProps: { title: string }) => {
+    const { title } = titleProps;
+    return (
+      <>
+        <EuiTitle size="s">
+          <h4>{title}</h4>
+        </EuiTitle>
+        <EuiHorizontalRule margin="s" />
+      </>
+    );
+  };
+
+  const accelerationData = tableDetail.accelerations.map((acc, index) => ({
+    ...acc,
+    id: index,
+  }));
+
+  const schemaData = tableDetail.columns.map((column, index) => ({
+    ...column,
+    id: index,
+  }));
+
+  const accelerationColumns = [
+    {
+      field: 'name',
+      name: 'Name',
+      'data-test-subj': 'accelerationName',
+      render: (name: string, item: AssociatedObject) => (
+        <EuiLink onClick={() => renderAccelerationDetailsFlyout(item)}>{name}</EuiLink>
+      ),
+    },
+    {
+      field: 'status',
+      name: 'Status',
+      render: (status) => <AccelerationStatus status={status} />,
+    },
+    {
+      field: 'type',
+      name: 'Type',
+    },
+  ] as Array<EuiTableFieldDataColumnType<any>>;
+
+  const noDataMessage = (
+    <EuiEmptyPrompt
+      title={
+        <h2>
+          {i18n.translate('datasources.associatedObjectsFlyout.noAccelerationTitle', {
+            defaultMessage: ACCE_NO_DATA_TITLE,
+          })}
+        </h2>
+      }
+      body={
+        <p>
+          {i18n.translate('datasources.associatedObjectsFlyout.noAccelerationDescription', {
+            defaultMessage: ACCE_NO_DATA_DESCRIPTION,
+          })}
+        </p>
+      }
+      actions={
+        <EuiButton
+          color="primary"
+          fill
+          onClick={() => window.open('https://example.com', '_blank')}
+          iconType="popout"
+          iconSide="left"
+        >
+          {i18n.translate('datasources.associatedObjectsFlyout.createAccelerationButton', {
+            defaultMessage: CREATE_ACCELERATION_DESCRIPTION,
+          })}
+        </EuiButton>
+      }
+    />
+  );
+
+  const schemaColumns = [
+    {
+      field: 'name',
+      name: 'Column Name',
+      'data-test-subj': 'columnName',
+    },
+    {
+      field: 'dataType',
+      name: 'Data Type',
+      'data-test-subj': 'columnDataType',
+    },
+  ] as Array<EuiTableFieldDataColumnType<any>>;
+
+  const renderAccelerationDetailsFlyout = getRenderAccelerationDetailsFlyout();
+
+  return (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiFlexGroup direction="row" alignItems="center" gutterSize="m">
+          <EuiFlexItem>
+            <EuiText size="m">
+              <h2 className="accsDetailFlyoutTitle">{tableDetail.name}</h2>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <DiscoverButton />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <AccelerateButton />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <DeleteButton />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <ConnectionComponent />
+        <EuiSpacer />
+        <TableTitleComponent title="Accelerations" />
+        {accelerationData.length > 0 ? (
+          <>
+            <EuiInMemoryTable
+              items={accelerationData}
+              columns={accelerationColumns}
+              pagination={true}
+              sorting={true}
+            />
+          </>
+        ) : (
+          noDataMessage
+        )}
+        <EuiSpacer />
+        <TableTitleComponent title="Schema" />
+        <EuiInMemoryTable
+          items={schemaData}
+          columns={schemaColumns}
+          pagination={true}
+          sorting={true}
+        />
+      </EuiFlyoutBody>
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/associated_objects/utils/associated_objects_tab_utils.tsx
+++ b/public/components/datasources/components/manage/associated_objects/utils/associated_objects_tab_utils.tsx
@@ -6,59 +6,216 @@
 export const mockAssociatedObjects = [
   {
     id: '1',
+    datasource: 'flint_s3',
     name: 'Table_name_1',
     database: 'db1',
     type: 'Table',
-    createdByIntegration: 'xx',
-    accelerations: ['skipping_index_1'],
+    createdByIntegration: 'integration_1',
+    accelerations: [
+      {
+        name: 'skipping_index_1',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+    ],
+    columns: [
+      {
+        name: 'column1',
+        dataType: 'dataType1',
+      },
+      {
+        name: 'column2',
+        dataType: 'dataType2',
+      },
+      {
+        name: 'column3',
+        dataType: 'dataType3',
+      },
+      {
+        name: 'column4',
+        dataType: 'dataType4',
+      },
+    ],
   },
   {
     id: '2',
+    datasource: 'flint_s3',
     name: 'Table_name_2',
     database: 'db1',
     type: 'Table',
-    createdByIntegration: 'xx',
-    accelerations: ['skipping_index_1'],
+    createdByIntegration: 'integration_1',
+    accelerations: [
+      {
+        name: 'skipping_index_2',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+    ],
+    columns: [],
   },
   {
     id: '3',
-    name: 'Table_name_3',
+    datasource: 'flint_s3',
+    name: 'skipping_index_2',
     database: 'db1',
-    type: 'Table',
-    createdByIntegration: 'xx',
-    accelerations: ['skipping_index_2'],
+    type: 'Skip Index',
+    createdByIntegration: 'integration_1',
+    accelerations: [
+      {
+        name: 'skipping_index_2',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+    ],
+    columns: [],
   },
   {
     id: '4',
+    datasource: 'flint_s3',
     name: 'Table_name_4',
     database: 'db2',
     type: 'Table',
-    createdByIntegration: 'xx',
-    accelerations: ['skipping_index_2'],
+    createdByIntegration: 'integration_1',
+    accelerations: [
+      {
+        name: 'skipping_index_2',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+    ],
+    columns: [
+      {
+        name: 'column1',
+        dataType: 'dataType1',
+      },
+      {
+        name: 'column2',
+        dataType: 'dataType2',
+      },
+    ],
   },
   {
     id: '5',
+    datasource: 'flint_s3',
     name: 'Table_name_5',
     database: 'db3',
     type: 'Table',
-    createdByIntegration: 'xx',
-    accelerations: ['skipping_index_3'],
-  },
-  {
-    id: '6',
-    name: 'Table_name_5',
-    database: 'db3',
-    type: 'CI',
-    createdByIntegration: '',
+    createdByIntegration: 'integration_1',
     accelerations: [],
+    columns: [
+      {
+        name: 'column1',
+        dataType: 'dataType1',
+      },
+      {
+        name: 'column2',
+        dataType: 'dataType2',
+      },
+    ],
   },
   {
     id: '6',
-    name: 'Table_name_5',
+    datasource: 'flint_s3',
+    name: 'covering_index_3',
     database: 'db3',
-    type: 'CI',
+    type: 'Cover Index',
     createdByIntegration: '',
-    accelerations: ['acc1', 'acc2'],
+    accelerations: [
+      {
+        name: 'covering_index_3',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+    ],
+    columns: [
+      {
+        name: 'column1',
+        dataType: 'dataType1',
+      },
+      {
+        name: 'column2',
+        dataType: 'dataType2',
+      },
+    ],
+  },
+  {
+    id: '7',
+    datasource: 'flint_s3',
+    name: 'Table_name_6',
+    database: 'db3',
+    type: 'Table',
+    createdByIntegration: '',
+    accelerations: [
+      {
+        name: 'skipping_index_4',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+      {
+        name: 'skipping_index_5',
+        status: 'ACTIVE',
+        type: 'skip',
+        database: 'db1',
+        table: 'Table_name_1',
+        destination: 'N/A',
+        dateCreated: 1709339290,
+        dateUpdated: 1709339290,
+        index: 'security_logs_2022',
+        sql: 'SELECT * FROM Table_name_1 WHERE ...',
+      },
+    ],
+    columns: [
+      {
+        name: 'column1',
+        dataType: 'dataType1',
+      },
+      {
+        name: 'column2',
+        dataType: 'dataType2',
+      },
+    ],
   },
 ];
 
@@ -81,3 +238,24 @@ export const ASSC_OBJ_NO_DATA_DESCRIPTION =
 export const ASSC_OBJ_REFRESH_BTN = 'Refresh';
 
 export const ASSC_OBJ_FRESH_MSG = 'Last updated at:';
+
+export const ACCE_NO_DATA_TITLE = 'You have no accelerations';
+
+export const ACCE_NO_DATA_DESCRIPTION = 'Accelerate query performing through OpenSearch Indexing';
+
+export const CREATE_ACCELERATION_DESCRIPTION = 'Create Acceleration';
+
+export const onAccelerateButtonClick = (tableDetail: any) => {
+  // TODO: create acceleration of this table
+  console.log('accelerating', tableDetail.name);
+};
+
+export const onDiscoverButtonClick = (tabaleDetail: any) => {
+  // TODO: send user to Discover
+  console.log('sending user to discover for', tabaleDetail.name);
+};
+
+export const onDeleteButtonClick = (tableDetail: any) => {
+  // TODO: delete table
+  console.log('deleting', tableDetail.name);
+};

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -84,6 +84,10 @@ import {
   ObservabilityStart,
   SetupDependencies,
 } from './types';
+import {
+  AssociatedObjectsDetailsFlyout,
+  AssociatedObjectsFlyoutProps,
+} from './components/datasources/components/manage/associated_objects/associated_objects_details_flyout';
 
 interface PublicConfig {
   query_assist: {
@@ -98,6 +102,11 @@ export const [
   getRenderAccelerationDetailsFlyout,
   setRenderAccelerationDetailsFlyout,
 ] = createGetterSetter('renderAccelerationDetailsFlyout');
+
+export const [
+  getRenderAssociatedObjectsDetailsFlyout,
+  setRenderAssociatedObjectsDetailsFlyout,
+] = createGetterSetter('renderAssociatedObjectsDetailsFlyout');
 
 export class ObservabilityPlugin
   implements
@@ -378,9 +387,16 @@ export class ObservabilityPlugin
       );
     setRenderAccelerationDetailsFlyout(renderAccelerationDetailsFlyout);
 
+    const renderAssociatedObjectsDetailsFlyout = (tableDetail: AssociatedObjectsFlyoutProps) =>
+      core.overlays.openFlyout(
+        toMountPoint(<AssociatedObjectsDetailsFlyout tableDetail={tableDetail} />)
+      );
+    setRenderAssociatedObjectsDetailsFlyout(renderAssociatedObjectsDetailsFlyout);
+
     // Export so other plugins can use this flyout
     return {
       renderAccelerationDetailsFlyout,
+      renderAssociatedObjectsDetailsFlyout,
     };
   }
 


### PR DESCRIPTION
### Description
Manual backport of #1496: Add flyout pages to associated objects table.

### Issues Resolved
* Backport #1496 

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
