### PR TITLE
Move create acceleration flyout from workbench to datasources

### DIFF
--- a/common/constants/data_sources.ts
+++ b/common/constants/data_sources.ts
@@ -24,3 +24,50 @@ export enum DATA_SOURCE_TYPES {
 export const ASYNC_POLLING_INTERVAL = 2000;
 
 export const CATALOG_CACHE_VERSION = '1.0';
+export const ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME = 'skipping';
+export const ACCELERATION_TIME_INTERVAL = [
+  { text: 'millisecond(s)', value: 'millisecond' },
+  { text: 'second(s)', value: 'second' },
+  { text: 'minutes(s)', value: 'minute' },
+  { text: 'hour(s)', value: 'hour' },
+  { text: 'day(s)', value: 'day' },
+  { text: 'week(s)', value: 'week' },
+];
+
+export const ACCELERATION_ADD_FIELDS_TEXT = '(add fields here)';
+export const ACCELERATION_INDEX_NAME_REGEX = /^[a-z][a-z_]*$/;
+export const ACCELERATION_S3_URL_REGEX = /^(s3|s3a):\/\/[a-zA-Z0-9.\-]+/;
+
+export const ACCELERATION_INDEX_TYPES = [
+  { label: 'Skipping Index', value: 'skipping' },
+  { label: 'Covering Index', value: 'covering' },
+  { label: 'Materialized View', value: 'materialized' },
+];
+
+export const ACCELERATION_INDEX_NAME_INFO = `All OpenSearch acceleration indices have a naming format of pattern: \`prefix_<index name>_suffix\`. They share a common prefix structure, which is \`flint_<data source name>_<database name>_<table name>_\`. Additionally, they may have a suffix that varies based on the index type. 
+##### Skipping Index
+- For 'Skipping' indices, a fixed index name 'skipping' is used, and this name cannot be modified by the user. The suffix added to this type is \`_index\`.
+  - An example of a 'Skipping' index name would be: \`flint_mydatasource_mydb_mytable_skipping_index\`.
+##### Covering Index
+- 'Covering' indices allow users to specify their index name. The suffix added to this type is \`_index\`.
+  - For instance, a 'Covering' index name could be: \`flint_mydatasource_mydb_mytable_myindexname_index\`.
+##### Materialized View Index
+- 'Materialized View' indices also enable users to define their index name, but they do not have a suffix.
+  - An example of a 'Materialized View' index name might look like: \`flint_mydatasource_mydb_mytable_myindexname\`.
+##### Note:
+- All user given index names must be in lowercase letters. Index name cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \, |, ?, #, >, or < are not allowed.  
+  `;
+
+export const SKIPPING_INDEX_ACCELERATION_METHODS = [
+  { value: 'PARTITION', text: 'Partition' },
+  { value: 'VALUE_SET', text: 'Value Set' },
+  { value: 'MIN_MAX', text: 'Min Max' },
+];
+
+export const ACCELERATION_AGGREGRATION_FUNCTIONS = [
+  { label: 'count' },
+  { label: 'sum' },
+  { label: 'avg' },
+  { label: 'max' },
+  { label: 'min' },
+];

--- a/common/constants/data_sources.ts
+++ b/common/constants/data_sources.ts
@@ -44,6 +44,9 @@ export const ACCELERATION_INDEX_TYPES = [
   { label: 'Materialized View', value: 'materialized' },
 ];
 
+export const ACC_INDEX_TYPE_DOCUMENTATION_URL =
+  'https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md';
+
 export const ACCELERATION_INDEX_NAME_INFO = `All OpenSearch acceleration indices have a naming format of pattern: \`prefix_<index name>_suffix\`. They share a common prefix structure, which is \`flint_<data source name>_<database name>_<table name>_\`. Additionally, they may have a suffix that varies based on the index type. 
 ##### Skipping Index
 - For 'Skipping' indices, a fixed index name 'skipping' is used, and this name cannot be modified by the user. The suffix added to this type is \`_index\`.

--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -128,3 +128,103 @@ export interface PollingSuccessResult {
 }
 
 export type AsyncPollingResult = PollingSuccessResult | null;
+
+export interface CreateAccelerationForm {
+  dataSource: string;
+  database: string;
+  dataTable: string;
+  dataTableFields: DataTableFieldsType[];
+  accelerationIndexType: AccelerationIndexType;
+  skippingIndexQueryData: SkippingIndexRowType[];
+  coveringIndexQueryData: string[];
+  materializedViewQueryData: MaterializedViewQueryType;
+  accelerationIndexName: string;
+  primaryShardsCount: number;
+  replicaShardsCount: number;
+  refreshType: AccelerationRefreshType;
+  checkpointLocation: string | undefined;
+  watermarkDelay: WatermarkDelayType;
+  refreshIntervalOptions: RefreshIntervalType;
+  formErrors: FormErrorsType;
+}
+
+export type AggregationFunctionType = 'count' | 'sum' | 'avg' | 'max' | 'min';
+
+export interface MaterializedViewColumn {
+  id: string;
+  functionName: AggregationFunctionType;
+  functionParam: string;
+  fieldAlias?: string;
+}
+
+export type SkippingIndexAccMethodType = 'PARTITION' | 'VALUE_SET' | 'MIN_MAX';
+
+export interface SkippingIndexRowType {
+  id: string;
+  fieldName: string;
+  dataType: string;
+  accelerationMethod: SkippingIndexAccMethodType;
+}
+
+export interface DataTableFieldsType {
+  id: string;
+  fieldName: string;
+  dataType: string;
+}
+
+export interface RefreshIntervalType {
+  refreshWindow: number;
+  refreshInterval: string;
+}
+
+export interface WatermarkDelayType {
+  delayWindow: number;
+  delayInterval: string;
+}
+
+export interface GroupByTumbleType {
+  timeField: string;
+  tumbleWindow: number;
+  tumbleInterval: string;
+}
+
+export interface MaterializedViewQueryType {
+  columnsValues: MaterializedViewColumn[];
+  groupByTumbleValue: GroupByTumbleType;
+}
+
+export interface FormErrorsType {
+  dataSourceError: string[];
+  databaseError: string[];
+  dataTableError: string[];
+  skippingIndexError: string[];
+  coveringIndexError: string[];
+  materializedViewError: string[];
+  indexNameError: string[];
+  primaryShardsError: string[];
+  replicaShardsError: string[];
+  refreshIntervalError: string[];
+  checkpointLocationError: string[];
+  watermarkDelayError: string[];
+}
+
+export type AccelerationRefreshType = 'auto' | 'interval' | 'manual';
+
+export interface CreateAccelerationForm {
+  dataSource: string;
+  database: string;
+  dataTable: string;
+  dataTableFields: DataTableFieldsType[];
+  accelerationIndexType: AccelerationIndexType;
+  skippingIndexQueryData: SkippingIndexRowType[];
+  coveringIndexQueryData: string[];
+  materializedViewQueryData: MaterializedViewQueryType;
+  accelerationIndexName: string;
+  primaryShardsCount: number;
+  replicaShardsCount: number;
+  refreshType: AccelerationRefreshType;
+  checkpointLocation: string | undefined;
+  watermarkDelay: WatermarkDelayType;
+  refreshIntervalOptions: RefreshIntervalType;
+  formErrors: FormErrorsType;
+}

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -76,7 +76,7 @@ Array [
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"
+                      href="https://opensearch.org/docs/latest/data-acceleration/index"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -148,7 +148,7 @@ Array [
                     />
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -156,7 +156,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Data source
                         </label>
@@ -165,7 +165,7 @@ Array [
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          aria-describedby="some_html_id-help-0"
+                          aria-describedby="random_html_id-help-0"
                           aria-expanded="false"
                           aria-haspopup="listbox"
                           class="euiComboBox"
@@ -194,7 +194,7 @@ Array [
                                   <input
                                     aria-controls=""
                                     data-test-subj="comboBoxSearchInput"
-                                    id="some_html_id"
+                                    id="random_html_id"
                                     role="textbox"
                                     style="box-sizing: content-box; width: 2px;"
                                     value=""
@@ -234,7 +234,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           A data source has to be configured and active to be able to select it and index data from.
                         </div>
@@ -242,7 +242,7 @@ Array [
                     </div>
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -250,7 +250,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Database
                         </label>
@@ -259,7 +259,7 @@ Array [
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          aria-describedby="some_html_id-help-0"
+                          aria-describedby="random_html_id-help-0"
                           aria-expanded="false"
                           aria-haspopup="listbox"
                           class="euiComboBox"
@@ -288,7 +288,7 @@ Array [
                                   <input
                                     aria-controls=""
                                     data-test-subj="comboBoxSearchInput"
-                                    id="some_html_id"
+                                    id="random_html_id"
                                     role="textbox"
                                     style="box-sizing: content-box; width: 2px;"
                                     value=""
@@ -328,7 +328,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Select the database that contains the tables you'd like to use.
                         </div>
@@ -336,7 +336,7 @@ Array [
                     </div>
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -344,7 +344,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Table
                         </label>
@@ -353,7 +353,7 @@ Array [
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          aria-describedby="some_html_id-help-0"
+                          aria-describedby="random_html_id-help-0"
                           aria-expanded="false"
                           aria-haspopup="listbox"
                           class="euiComboBox"
@@ -382,7 +382,7 @@ Array [
                                   <input
                                     aria-controls=""
                                     data-test-subj="comboBoxSearchInput"
-                                    id="some_html_id"
+                                    id="random_html_id"
                                     role="textbox"
                                     style="box-sizing: content-box; width: 2px;"
                                     value=""
@@ -422,7 +422,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Select the Spark table that has the data you would like to index.
                         </div>
@@ -444,14 +444,14 @@ Array [
                     />
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
                       >
                         <label
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Index type
                         </label>
@@ -493,7 +493,7 @@ Array [
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          aria-describedby="some_html_id-help-0"
+                          aria-describedby="random_html_id-help-0"
                           aria-expanded="false"
                           aria-haspopup="listbox"
                           class="euiComboBox"
@@ -523,7 +523,7 @@ Array [
                                   <input
                                     aria-controls=""
                                     data-test-subj="comboBoxSearchInput"
-                                    id="some_html_id"
+                                    id="random_html_id"
                                     role="textbox"
                                     style="box-sizing: content-box; width: 2px;"
                                     value=""
@@ -563,7 +563,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Select the type of index you want to create. Each index type has benefits and costs.
                         </div>
@@ -571,7 +571,7 @@ Array [
                     </div>
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -579,7 +579,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Number of primary shards
                         </label>
@@ -594,10 +594,10 @@ Array [
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
-                              aria-describedby="some_html_id-help-0"
+                              aria-describedby="random_html_id-help-0"
                               aria-label="Number of primary shards"
                               class="euiFieldNumber"
-                              id="some_html_id"
+                              id="random_html_id"
                               max="100"
                               min="1"
                               placeholder="Number of primary shards"
@@ -608,7 +608,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
                         </div>
@@ -616,7 +616,7 @@ Array [
                     </div>
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -624,7 +624,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Number of replicas
                         </label>
@@ -639,10 +639,10 @@ Array [
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
-                              aria-describedby="some_html_id-help-0"
+                              aria-describedby="random_html_id-help-0"
                               aria-label="Number of replicas"
                               class="euiFieldNumber"
-                              id="some_html_id"
+                              id="random_html_id"
                               max="100"
                               min="0"
                               placeholder="Number of replicas"
@@ -653,7 +653,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Specify the number of replicas each primary shard should have.
                         </div>
@@ -661,14 +661,14 @@ Array [
                     </div>
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
                       >
                         <label
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Refresh type
                         </label>
@@ -677,8 +677,8 @@ Array [
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          aria-describedby="some_html_id-help-0"
-                          id="some_html_id"
+                          aria-describedby="random_html_id-help-0"
+                          id="random_html_id"
                         >
                           <div
                             class="euiRadio euiRadioGroup__item"
@@ -744,7 +744,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
                         </div>
@@ -752,7 +752,7 @@ Array [
                     </div>
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -760,7 +760,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Checkpoint location
                         </label>
@@ -775,10 +775,10 @@ Array [
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
-                              aria-describedby="some_html_id-help-0"
+                              aria-describedby="random_html_id-help-0"
                               aria-label="Use aria labels when no actual label is in use"
                               class="euiFieldText"
-                              id="some_html_id"
+                              id="random_html_id"
                               placeholder="s3://checkpoint/location"
                               type="text"
                               value=""
@@ -787,7 +787,7 @@ Array [
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           The HDFS compatible file system location path for incremental refresh job checkpoint.
                         </div>
@@ -809,7 +809,7 @@ Array [
                     />
                     <div
                       class="euiFormRow"
-                      id="some_html_id-row"
+                      id="random_html_id-row"
                     >
                       <div
                         class="euiFormRow__labelWrapper"
@@ -817,7 +817,7 @@ Array [
                         <label
                           aria-invalid="false"
                           class="euiFormLabel euiFormRow__label"
-                          for="some_html_id"
+                          for="random_html_id"
                         >
                           Index name
                         </label>
@@ -841,7 +841,7 @@ Array [
                         >
                           <label
                             class="euiFormLabel euiFormControlLayout__prepend"
-                            for="some_html_id"
+                            for="random_html_id"
                           >
                             flint_{Datasource Name}_{Database Name}_{Table Name}_
                           </label>
@@ -869,11 +869,11 @@ Array [
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
-                              aria-describedby="some_html_id-help-0"
+                              aria-describedby="random_html_id-help-0"
                               aria-label="Enter Index Name"
                               class="euiFieldText euiFieldText--inGroup"
                               disabled=""
-                              id="some_html_id"
+                              id="random_html_id"
                               placeholder="Enter index name"
                               type="text"
                               value="skipping"
@@ -881,14 +881,14 @@ Array [
                           </div>
                           <label
                             class="euiFormLabel euiFormControlLayout__append"
-                            for="some_html_id"
+                            for="random_html_id"
                           >
                             _index
                           </label>
                         </div>
                         <div
                           class="euiFormHelpText euiFormRow__text"
-                          id="some_html_id-help-0"
+                          id="random_html_id-help-0"
                         >
                           Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
                         </div>
@@ -932,7 +932,7 @@ Array [
                         </div>
                         <table
                           class="euiTable euiTable--responsive"
-                          id="some_html_id"
+                          id="random_html_id"
                           tabindex="-1"
                         >
                           <caption
@@ -1241,7 +1241,7 @@ Array [
                      
                     <a
                       className="euiLink euiLink--primary"
-                      href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"
+                      href="https://opensearch.org/docs/latest/data-acceleration/index"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -1315,7 +1315,7 @@ Array [
                       />,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -1323,7 +1323,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Data source
                           </label>
@@ -1332,7 +1332,7 @@ Array [
                           className="euiFormRow__fieldWrapper"
                         >
                           <div
-                            aria-describedby="some_html_id-help-0"
+                            aria-describedby="random_html_id-help-0"
                             aria-expanded={false}
                             aria-haspopup="listbox"
                             className="euiComboBox"
@@ -1368,7 +1368,7 @@ Array [
                                     <input
                                       aria-controls=""
                                       data-test-subj="comboBoxSearchInput"
-                                      id="some_html_id"
+                                      id="random_html_id"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onFocus={[Function]}
@@ -1428,7 +1428,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             A data source has to be configured and active to be able to select it and index data from.
                           </div>
@@ -1436,7 +1436,7 @@ Array [
                       </div>,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -1444,7 +1444,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Database
                           </label>
@@ -1453,7 +1453,7 @@ Array [
                           className="euiFormRow__fieldWrapper"
                         >
                           <div
-                            aria-describedby="some_html_id-help-0"
+                            aria-describedby="random_html_id-help-0"
                             aria-expanded={false}
                             aria-haspopup="listbox"
                             className="euiComboBox"
@@ -1489,7 +1489,7 @@ Array [
                                     <input
                                       aria-controls=""
                                       data-test-subj="comboBoxSearchInput"
-                                      id="some_html_id"
+                                      id="random_html_id"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onFocus={[Function]}
@@ -1549,7 +1549,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Select the database that contains the tables you'd like to use.
                           </div>
@@ -1557,7 +1557,7 @@ Array [
                       </div>,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -1565,7 +1565,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Table
                           </label>
@@ -1574,7 +1574,7 @@ Array [
                           className="euiFormRow__fieldWrapper"
                         >
                           <div
-                            aria-describedby="some_html_id-help-0"
+                            aria-describedby="random_html_id-help-0"
                             aria-expanded={false}
                             aria-haspopup="listbox"
                             className="euiComboBox"
@@ -1610,7 +1610,7 @@ Array [
                                     <input
                                       aria-controls=""
                                       data-test-subj="comboBoxSearchInput"
-                                      id="some_html_id"
+                                      id="random_html_id"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onFocus={[Function]}
@@ -1670,7 +1670,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Select the Spark table that has the data you would like to index.
                           </div>
@@ -1694,14 +1694,14 @@ Array [
                       />,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
                         >
                           <label
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Index type
                           </label>
@@ -1744,7 +1744,7 @@ Array [
                           className="euiFormRow__fieldWrapper"
                         >
                           <div
-                            aria-describedby="some_html_id-help-0"
+                            aria-describedby="random_html_id-help-0"
                             aria-expanded={false}
                             aria-haspopup="listbox"
                             className="euiComboBox"
@@ -1781,7 +1781,7 @@ Array [
                                     <input
                                       aria-controls=""
                                       data-test-subj="comboBoxSearchInput"
-                                      id="some_html_id"
+                                      id="random_html_id"
                                       onBlur={[Function]}
                                       onChange={[Function]}
                                       onFocus={[Function]}
@@ -1841,7 +1841,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Select the type of index you want to create. Each index type has benefits and costs.
                           </div>
@@ -1849,7 +1849,7 @@ Array [
                       </div>,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -1857,7 +1857,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Number of primary shards
                           </label>
@@ -1872,10 +1872,10 @@ Array [
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                aria-describedby="some_html_id-help-0"
+                                aria-describedby="random_html_id-help-0"
                                 aria-label="Number of primary shards"
                                 className="euiFieldNumber"
-                                id="some_html_id"
+                                id="random_html_id"
                                 max={100}
                                 min={1}
                                 onBlur={[Function]}
@@ -1889,7 +1889,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
                           </div>
@@ -1897,7 +1897,7 @@ Array [
                       </div>,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -1905,7 +1905,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Number of replicas
                           </label>
@@ -1920,10 +1920,10 @@ Array [
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                aria-describedby="some_html_id-help-0"
+                                aria-describedby="random_html_id-help-0"
                                 aria-label="Number of replicas"
                                 className="euiFieldNumber"
-                                id="some_html_id"
+                                id="random_html_id"
                                 max={100}
                                 min={0}
                                 onBlur={[Function]}
@@ -1937,7 +1937,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Specify the number of replicas each primary shard should have.
                           </div>
@@ -1945,14 +1945,14 @@ Array [
                       </div>,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
                         >
                           <label
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Refresh type
                           </label>
@@ -1961,8 +1961,8 @@ Array [
                           className="euiFormRow__fieldWrapper"
                         >
                           <div
-                            aria-describedby="some_html_id-help-0"
-                            id="some_html_id"
+                            aria-describedby="random_html_id-help-0"
+                            id="random_html_id"
                             onBlur={[Function]}
                             onFocus={[Function]}
                           >
@@ -2032,7 +2032,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
                           </div>
@@ -2040,7 +2040,7 @@ Array [
                       </div>,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -2048,7 +2048,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Checkpoint location
                           </label>
@@ -2063,10 +2063,10 @@ Array [
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                aria-describedby="some_html_id-help-0"
+                                aria-describedby="random_html_id-help-0"
                                 aria-label="Use aria labels when no actual label is in use"
                                 className="euiFieldText"
-                                id="some_html_id"
+                                id="random_html_id"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onFocus={[Function]}
@@ -2078,7 +2078,7 @@ Array [
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             The HDFS compatible file system location path for incremental refresh job checkpoint.
                           </div>
@@ -2102,7 +2102,7 @@ Array [
                       />,
                       <div
                         className="euiFormRow"
-                        id="some_html_id-row"
+                        id="random_html_id-row"
                       >
                         <div
                           className="euiFormRow__labelWrapper"
@@ -2110,7 +2110,7 @@ Array [
                           <label
                             aria-invalid={false}
                             className="euiFormLabel euiFormRow__label"
-                            htmlFor="some_html_id"
+                            htmlFor="random_html_id"
                           >
                             Index name
                           </label>
@@ -2136,7 +2136,7 @@ Array [
                           >
                             <label
                               className="euiFormLabel euiFormControlLayout__prepend"
-                              htmlFor="some_html_id"
+                              htmlFor="random_html_id"
                             >
                               flint_{Datasource Name}_{Database Name}_{Table Name}_
                             </label>
@@ -2170,11 +2170,11 @@ Array [
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <input
-                                aria-describedby="some_html_id-help-0"
+                                aria-describedby="random_html_id-help-0"
                                 aria-label="Enter Index Name"
                                 className="euiFieldText euiFieldText--inGroup"
                                 disabled={true}
-                                id="some_html_id"
+                                id="random_html_id"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onFocus={[Function]}
@@ -2185,14 +2185,14 @@ Array [
                             </div>
                             <label
                               className="euiFormLabel euiFormControlLayout__append"
-                              htmlFor="some_html_id"
+                              htmlFor="random_html_id"
                             >
                               _index
                             </label>
                           </div>
                           <div
                             className="euiFormHelpText euiFormRow__text"
-                            id="some_html_id-help-0"
+                            id="random_html_id-help-0"
                           >
                             Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
                           </div>
@@ -2240,7 +2240,7 @@ Array [
                             </div>
                             <table
                               className="euiTable euiTable--responsive"
-                              id="some_html_id"
+                              id="random_html_id"
                               tabIndex={-1}
                             >
                               <caption

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -1,0 +1,2519 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Create acceleration flyout components renders acceleration flyout component with default options 1`] = `
+Array [
+  "",
+  <Portal
+    containerInfo={
+      <div
+        class="euiOverlayMask euiOverlayMask--belowHeader"
+      >
+        <div
+          aria-hidden="true"
+          data-aria-hidden="true"
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="0"
+        />
+        <div
+          data-focus-lock-disabled="false"
+        >
+          <div
+            aria-labelledby="flyoutTitle"
+            class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+            role="dialog"
+            tabindex="-1"
+          >
+            <button
+              aria-label="Close this dialog"
+              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+              data-test-subj="euiFlyoutCloseButton"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                />
+              </svg>
+            </button>
+            <div
+              class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
+            >
+              <div>
+                <header
+                  class="euiPageHeader euiPageHeader--responsive euiPageHeader--center"
+                >
+                  <div
+                    class="euiPageHeaderSection"
+                  >
+                    <h1
+                      class="euiTitle euiTitle--large"
+                      data-test-subj="acceleration-header"
+                    >
+                      Accelerate data
+                    </h1>
+                  </div>
+                </header>
+                <div
+                  class="euiSpacer euiSpacer--s"
+                />
+                <div
+                  class="euiText euiText--small"
+                >
+                  <div
+                    class="euiTextColor euiTextColor--subdued"
+                  >
+                    Create OpenSearch Indexes from external data connections for better performance.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more
+                      <svg
+                        aria-hidden="true"
+                        aria-label="External link"
+                        class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                      <span
+                        class="euiScreenReaderOnly"
+                      >
+                        (opens in a new tab or window)
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlyoutBody"
+            >
+              <div
+                class="euiFlyoutBody__overflow"
+                tabindex="0"
+              >
+                <div
+                  class="euiFlyoutBody__overflowContent"
+                >
+                  <div
+                    class="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    class="euiForm"
+                    id="acceleration-form"
+                  >
+                    <div
+                      class="euiText euiText--medium"
+                      data-test-subj="datasource-selector-header"
+                    >
+                      <h3>
+                        Select data source
+                      </h3>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiText euiText--small"
+                    >
+                      <div
+                        class="euiTextColor euiTextColor--subdued"
+                      >
+                        Select the data source to accelerate data from. External data sources may take time to load.
+                      </div>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Data source
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          aria-describedby="some_html_id-help-0"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          class="euiComboBox"
+                          role="combobox"
+                        >
+                          <div
+                            class="euiFormControlLayout"
+                          >
+                            <div
+                              class="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                data-test-subj="comboBoxInput"
+                                tabindex="-1"
+                              >
+                                <p
+                                  class="euiComboBoxPlaceholder"
+                                >
+                                  Select a data source
+                                </p>
+                                <div
+                                  class="euiComboBox__input"
+                                  style="font-size: 14px; display: inline-block;"
+                                >
+                                  <input
+                                    aria-controls=""
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="some_html_id"
+                                    role="textbox"
+                                    style="box-sizing: content-box; width: 2px;"
+                                    value=""
+                                  />
+                                  <div
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <button
+                                  aria-label="Open list of options"
+                                  class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                  data-test-subj="comboBoxToggleListButton"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          A data source has to be configured and active to be able to select it and index data from.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Database
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          aria-describedby="some_html_id-help-0"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          class="euiComboBox"
+                          role="combobox"
+                        >
+                          <div
+                            class="euiFormControlLayout"
+                          >
+                            <div
+                              class="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                data-test-subj="comboBoxInput"
+                                tabindex="-1"
+                              >
+                                <p
+                                  class="euiComboBoxPlaceholder"
+                                >
+                                  Select a database
+                                </p>
+                                <div
+                                  class="euiComboBox__input"
+                                  style="font-size: 14px; display: inline-block;"
+                                >
+                                  <input
+                                    aria-controls=""
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="some_html_id"
+                                    role="textbox"
+                                    style="box-sizing: content-box; width: 2px;"
+                                    value=""
+                                  />
+                                  <div
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <button
+                                  aria-label="Open list of options"
+                                  class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                  data-test-subj="comboBoxToggleListButton"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Select the database that contains the tables you'd like to use.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Table
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          aria-describedby="some_html_id-help-0"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          class="euiComboBox"
+                          role="combobox"
+                        >
+                          <div
+                            class="euiFormControlLayout"
+                          >
+                            <div
+                              class="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                data-test-subj="comboBoxInput"
+                                tabindex="-1"
+                              >
+                                <p
+                                  class="euiComboBoxPlaceholder"
+                                >
+                                  Select a table
+                                </p>
+                                <div
+                                  class="euiComboBox__input"
+                                  style="font-size: 14px; display: inline-block;"
+                                >
+                                  <input
+                                    aria-controls=""
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="some_html_id"
+                                    role="textbox"
+                                    style="box-sizing: content-box; width: 2px;"
+                                    value=""
+                                  />
+                                  <div
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <button
+                                  aria-label="Open list of options"
+                                  class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                  data-test-subj="comboBoxToggleListButton"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Select the Spark table that has the data you would like to index.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--xxl"
+                    />
+                    <div
+                      class="euiText euiText--medium"
+                      data-test-subj="index-settings-header"
+                    >
+                      <h3>
+                        Index settings
+                      </h3>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Index type
+                        </label>
+                         
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <a
+                            class="euiLink euiLink--primary"
+                            href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            Help
+                            <svg
+                              aria-hidden="true"
+                              aria-label="External link"
+                              class="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                            <span
+                              class="euiScreenReaderOnly"
+                            >
+                              (opens in a new tab or window)
+                            </span>
+                          </a>
+                        </div>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          aria-describedby="some_html_id-help-0"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          class="euiComboBox"
+                          role="combobox"
+                        >
+                          <div
+                            class="euiFormControlLayout"
+                          >
+                            <div
+                              class="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                data-test-subj="comboBoxInput"
+                                tabindex="-1"
+                              >
+                                <span
+                                  class="euiComboBoxPill euiComboBoxPill--plainText"
+                                  value="skipping"
+                                >
+                                  Skipping Index
+                                </span>
+                                <div
+                                  class="euiComboBox__input"
+                                  style="font-size: 14px; display: inline-block;"
+                                >
+                                  <input
+                                    aria-controls=""
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="some_html_id"
+                                    role="textbox"
+                                    style="box-sizing: content-box; width: 2px;"
+                                    value=""
+                                  />
+                                  <div
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <button
+                                  aria-label="Open list of options"
+                                  class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                  data-test-subj="comboBoxToggleListButton"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Select the type of index you want to create. Each index type has benefits and costs.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Number of primary shards
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-describedby="some_html_id-help-0"
+                              aria-label="Number of primary shards"
+                              class="euiFieldNumber"
+                              id="some_html_id"
+                              max="100"
+                              min="1"
+                              placeholder="Number of primary shards"
+                              type="number"
+                              value="5"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Number of replicas
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-describedby="some_html_id-help-0"
+                              aria-label="Number of replicas"
+                              class="euiFieldNumber"
+                              id="some_html_id"
+                              max="100"
+                              min="0"
+                              placeholder="Number of replicas"
+                              type="number"
+                              value="1"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Specify the number of replicas each primary shard should have.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Refresh type
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          aria-describedby="some_html_id-help-0"
+                          id="some_html_id"
+                        >
+                          <div
+                            class="euiRadio euiRadioGroup__item"
+                          >
+                            <input
+                              checked=""
+                              class="euiRadio__input"
+                              id="refresh-option-1"
+                              name="refresh type radio group"
+                              type="radio"
+                              value=""
+                            />
+                            <div
+                              class="euiRadio__circle"
+                            />
+                            <label
+                              class="euiRadio__label"
+                              for="refresh-option-1"
+                            >
+                              Auto refresh
+                            </label>
+                          </div>
+                          <div
+                            class="euiRadio euiRadioGroup__item"
+                          >
+                            <input
+                              class="euiRadio__input"
+                              id="refresh-option-2"
+                              name="refresh type radio group"
+                              type="radio"
+                              value=""
+                            />
+                            <div
+                              class="euiRadio__circle"
+                            />
+                            <label
+                              class="euiRadio__label"
+                              for="refresh-option-2"
+                            >
+                              Auto refresh by interval
+                            </label>
+                          </div>
+                          <div
+                            class="euiRadio euiRadioGroup__item"
+                          >
+                            <input
+                              class="euiRadio__input"
+                              id="refresh-option-3"
+                              name="refresh type radio group"
+                              type="radio"
+                              value=""
+                            />
+                            <div
+                              class="euiRadio__circle"
+                            />
+                            <label
+                              class="euiRadio__label"
+                              for="refresh-option-3"
+                            >
+                              Manual refresh
+                            </label>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Checkpoint location
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-describedby="some_html_id-help-0"
+                              aria-label="Use aria labels when no actual label is in use"
+                              class="euiFieldText"
+                              id="some_html_id"
+                              placeholder="s3://checkpoint/location"
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          The HDFS compatible file system location path for incremental refresh job checkpoint.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--xxl"
+                    />
+                    <div
+                      class="euiText euiText--medium"
+                      data-test-subj="define-index-header"
+                    >
+                      <h3>
+                        Index settings
+                      </h3>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiFormRow"
+                      id="some_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="some_html_id"
+                        >
+                          Index name
+                        </label>
+                         
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <button
+                            class="euiLink euiLink--primary"
+                            type="button"
+                          >
+                            Help
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout euiFormControlLayout--group"
+                        >
+                          <label
+                            class="euiFormLabel euiFormControlLayout__prepend"
+                            for="some_html_id"
+                          >
+                            flint_{Datasource Name}_{Database Name}_{Table Name}_
+                          </label>
+                          <span
+                            class="euiToolTipAnchor"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-label="Info"
+                              class="euiIcon euiIcon--medium euiIcon--subdued euiIcon-isLoading"
+                              focusable="true"
+                              height="16"
+                              role="img"
+                              tabindex="0"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                          </span>
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-describedby="some_html_id-help-0"
+                              aria-label="Enter Index Name"
+                              class="euiFieldText euiFieldText--inGroup"
+                              disabled=""
+                              id="some_html_id"
+                              placeholder="Enter index name"
+                              type="text"
+                              value="skipping"
+                            />
+                          </div>
+                          <label
+                            class="euiFormLabel euiFormControlLayout__append"
+                            for="some_html_id"
+                          >
+                            _index
+                          </label>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="some_html_id-help-0"
+                        >
+                          Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--m"
+                    />
+                    <div
+                      class="euiSpacer euiSpacer--l"
+                    />
+                    <div
+                      class="euiText euiText--medium"
+                      data-test-subj="skipping-index-builder"
+                    >
+                      <h3>
+                        Skipping index definition
+                      </h3>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiBasicTable"
+                      itemid="id"
+                    >
+                      <div>
+                        <div
+                          class="euiTableHeaderMobile"
+                        >
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                          </div>
+                        </div>
+                        <table
+                          class="euiTable euiTable--responsive"
+                          id="some_html_id"
+                          tabindex="-1"
+                        >
+                          <caption
+                            class="euiScreenReaderOnly euiTableCaption"
+                          />
+                          <thead>
+                            <tr>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_fieldName_0"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </th>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_dataType_1"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </th>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_Acceleration method_2"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Acceleration method"
+                                  >
+                                    Acceleration method
+                                  </span>
+                                </span>
+                              </th>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_Delete_3"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Delete"
+                                  >
+                                    Delete
+                                  </span>
+                                </span>
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              class="euiTableRow"
+                            >
+                              <td
+                                class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                                colspan="4"
+                              >
+                                <div
+                                  class="euiTableCellContent euiTableCellContent--alignCenter"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                  >
+                                    No items found
+                                  </span>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <button
+                          class="euiButton euiButton--primary euiButton--fill"
+                          type="button"
+                        >
+                          <span
+                            class="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              class="euiButton__text"
+                            >
+                              Add fields
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <button
+                          class="euiButton euiButton--danger"
+                          type="button"
+                        >
+                          <span
+                            class="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              class="euiButton__text"
+                            >
+                              Bulk delete
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlyoutFooter"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <button
+                    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButtonEmpty__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                      <span
+                        class="euiButtonEmpty__text"
+                      >
+                        Close
+                      </span>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <button
+                    class="euiButton euiButton--primary euiButton--fill"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButton__content"
+                    >
+                      <span
+                        class="euiButton__text"
+                      >
+                        Copy Query to Editor
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          data-aria-hidden="true"
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="0"
+        />
+      </div>
+    }
+  >
+    Array [
+      Array [
+        <div
+          data-focus-guard={true}
+          key="guard-first"
+          style={
+            Object {
+              "height": "0px",
+              "left": "1px",
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "fixed",
+              "top": "1px",
+              "width": "1px",
+            }
+          }
+          tabIndex={0}
+        />,
+        "",
+        <div
+          data-focus-lock-disabled={false}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onScrollCapture={[Function]}
+          onTouchMoveCapture={[Function]}
+          onTouchStart={[Function]}
+          onWheelCapture={[Function]}
+        >
+          <div
+            aria-labelledby="flyoutTitle"
+            className="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchStart={[Function]}
+            role="dialog"
+            tabIndex={-1}
+          >
+            <button
+              aria-label="Close this dialog"
+              className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+              data-test-subj="euiFlyoutCloseButton"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                />
+              </svg>
+            </button>
+            <div
+              className="euiFlyoutHeader euiFlyoutHeader--hasBorder"
+            >
+              <div>
+                <header
+                  className="euiPageHeader euiPageHeader--responsive euiPageHeader--center"
+                >
+                  <div
+                    className="euiPageHeaderSection"
+                  >
+                    <h1
+                      className="euiTitle euiTitle--large"
+                      data-test-subj="acceleration-header"
+                    >
+                      Accelerate data
+                    </h1>
+                  </div>
+                </header>
+                <div
+                  className="euiSpacer euiSpacer--s"
+                />
+                <div
+                  className="euiText euiText--small"
+                >
+                  <div
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    Create OpenSearch Indexes from external data connections for better performance.
+                     
+                    <a
+                      className="euiLink euiLink--primary"
+                      href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more
+                      <svg
+                        aria-hidden={true}
+                        aria-label="External link"
+                        className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                        focusable="false"
+                        height={16}
+                        role="img"
+                        style={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                      <span
+                        className="euiScreenReaderOnly"
+                      >
+                        (opens in a new tab or window)
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="euiFlyoutBody"
+            >
+              <div
+                className="euiFlyoutBody__overflow"
+                tabIndex={0}
+              >
+                <div
+                  className="euiFlyoutBody__overflowContent"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    className="euiForm"
+                    id="acceleration-form"
+                  >
+                    Array [
+                      <div
+                        className="euiText euiText--medium"
+                        data-test-subj="datasource-selector-header"
+                      >
+                        <h3>
+                          Select data source
+                        </h3>
+                      </div>,
+                      <div
+                        className="euiSpacer euiSpacer--s"
+                      />,
+                      <div
+                        className="euiText euiText--small"
+                      >
+                        <div
+                          className="euiTextColor euiTextColor--subdued"
+                        >
+                          Select the data source to accelerate data from. External data sources may take time to load.
+                        </div>
+                      </div>,
+                      <div
+                        className="euiSpacer euiSpacer--s"
+                      />,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Data source
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            aria-describedby="some_html_id-help-0"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
+                            className="euiComboBox"
+                            onKeyDown={[Function]}
+                            role="combobox"
+                          >
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <div
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
+                                >
+                                  <p
+                                    className="euiComboBoxPlaceholder"
+                                  >
+                                    Select a data source
+                                  </p>
+                                  <div
+                                    className="euiComboBox__input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-controls=""
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "2px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <button
+                                    aria-label="Open list of options"
+                                    className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                    data-test-subj="comboBoxToggleListButton"
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            A data source has to be configured and active to be able to select it and index data from.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Database
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            aria-describedby="some_html_id-help-0"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
+                            className="euiComboBox"
+                            onKeyDown={[Function]}
+                            role="combobox"
+                          >
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <div
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
+                                >
+                                  <p
+                                    className="euiComboBoxPlaceholder"
+                                  >
+                                    Select a database
+                                  </p>
+                                  <div
+                                    className="euiComboBox__input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-controls=""
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "2px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <button
+                                    aria-label="Open list of options"
+                                    className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                    data-test-subj="comboBoxToggleListButton"
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Select the database that contains the tables you'd like to use.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Table
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            aria-describedby="some_html_id-help-0"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
+                            className="euiComboBox"
+                            onKeyDown={[Function]}
+                            role="combobox"
+                          >
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <div
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
+                                >
+                                  <p
+                                    className="euiComboBoxPlaceholder"
+                                  >
+                                    Select a table
+                                  </p>
+                                  <div
+                                    className="euiComboBox__input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-controls=""
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "2px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <button
+                                    aria-label="Open list of options"
+                                    className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                    data-test-subj="comboBoxToggleListButton"
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Select the Spark table that has the data you would like to index.
+                          </div>
+                        </div>
+                      </div>,
+                    ]
+                    <div
+                      className="euiSpacer euiSpacer--xxl"
+                    />
+                    Array [
+                      <div
+                        className="euiText euiText--medium"
+                        data-test-subj="index-settings-header"
+                      >
+                        <h3>
+                          Index settings
+                        </h3>
+                      </div>,
+                      <div
+                        className="euiSpacer euiSpacer--s"
+                      />,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Index type
+                          </label>
+                           
+                          <div
+                            className="euiText euiText--extraSmall"
+                          >
+                            <a
+                              className="euiLink euiLink--primary"
+                              href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              Help
+                              <svg
+                                aria-hidden={true}
+                                aria-label="External link"
+                                className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                              <span
+                                className="euiScreenReaderOnly"
+                              >
+                                (opens in a new tab or window)
+                              </span>
+                            </a>
+                          </div>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            aria-describedby="some_html_id-help-0"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
+                            className="euiComboBox"
+                            onKeyDown={[Function]}
+                            role="combobox"
+                          >
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <div
+                                  className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                                  data-test-subj="comboBoxInput"
+                                  onClick={[Function]}
+                                  tabIndex={-1}
+                                >
+                                  <span
+                                    className="euiComboBoxPill euiComboBoxPill--plainText"
+                                    value="skipping"
+                                  >
+                                    Skipping Index
+                                  </span>
+                                  <div
+                                    className="euiComboBox__input"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "fontSize": 14,
+                                      }
+                                    }
+                                  >
+                                    <input
+                                      aria-controls=""
+                                      data-test-subj="comboBoxSearchInput"
+                                      id="some_html_id"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      role="textbox"
+                                      style={
+                                        Object {
+                                          "boxSizing": "content-box",
+                                          "width": "2px",
+                                        }
+                                      }
+                                      value=""
+                                    />
+                                    <div
+                                      style={
+                                        Object {
+                                          "height": 0,
+                                          "left": 0,
+                                          "overflow": "scroll",
+                                          "position": "absolute",
+                                          "top": 0,
+                                          "visibility": "hidden",
+                                          "whiteSpace": "pre",
+                                        }
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <button
+                                    aria-label="Open list of options"
+                                    className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                    data-test-subj="comboBoxToggleListButton"
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Select the type of index you want to create. Each index type has benefits and costs.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Number of primary shards
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                aria-label="Number of primary shards"
+                                className="euiFieldNumber"
+                                id="some_html_id"
+                                max={100}
+                                min={1}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Number of primary shards"
+                                type="number"
+                                value={5}
+                              />
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Number of replicas
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                aria-label="Number of replicas"
+                                className="euiFieldNumber"
+                                id="some_html_id"
+                                max={100}
+                                min={0}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Number of replicas"
+                                type="number"
+                                value={1}
+                              />
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Specify the number of replicas each primary shard should have.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Refresh type
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            aria-describedby="some_html_id-help-0"
+                            id="some_html_id"
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                          >
+                            <div
+                              className="euiRadio euiRadioGroup__item"
+                            >
+                              <input
+                                checked={true}
+                                className="euiRadio__input"
+                                id="refresh-option-1"
+                                name="refresh type radio group"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              <div
+                                className="euiRadio__circle"
+                              />
+                              <label
+                                className="euiRadio__label"
+                                htmlFor="refresh-option-1"
+                              >
+                                Auto refresh
+                              </label>
+                            </div>
+                            <div
+                              className="euiRadio euiRadioGroup__item"
+                            >
+                              <input
+                                checked={false}
+                                className="euiRadio__input"
+                                id="refresh-option-2"
+                                name="refresh type radio group"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              <div
+                                className="euiRadio__circle"
+                              />
+                              <label
+                                className="euiRadio__label"
+                                htmlFor="refresh-option-2"
+                              >
+                                Auto refresh by interval
+                              </label>
+                            </div>
+                            <div
+                              className="euiRadio euiRadioGroup__item"
+                            >
+                              <input
+                                checked={false}
+                                className="euiRadio__input"
+                                id="refresh-option-3"
+                                name="refresh type radio group"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              <div
+                                className="euiRadio__circle"
+                              />
+                              <label
+                                className="euiRadio__label"
+                                htmlFor="refresh-option-3"
+                              >
+                                Manual refresh
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Checkpoint location
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                aria-label="Use aria labels when no actual label is in use"
+                                className="euiFieldText"
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="s3://checkpoint/location"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            The HDFS compatible file system location path for incremental refresh job checkpoint.
+                          </div>
+                        </div>
+                      </div>,
+                    ]
+                    <div
+                      className="euiSpacer euiSpacer--xxl"
+                    />
+                    Array [
+                      <div
+                        className="euiText euiText--medium"
+                        data-test-subj="define-index-header"
+                      >
+                        <h3>
+                          Index settings
+                        </h3>
+                      </div>,
+                      <div
+                        className="euiSpacer euiSpacer--s"
+                      />,
+                      <div
+                        className="euiFormRow"
+                        id="some_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="some_html_id"
+                          >
+                            Index name
+                          </label>
+                           
+                          <div
+                            className="euiText euiText--extraSmall"
+                          >
+                            <button
+                              className="euiLink euiLink--primary"
+                              disabled={false}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              Help
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--group"
+                          >
+                            <label
+                              className="euiFormLabel euiFormControlLayout__prepend"
+                              htmlFor="some_html_id"
+                            >
+                              flint_{Datasource Name}_{Database Name}_{Table Name}_
+                            </label>
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-label="Info"
+                                className="euiIcon euiIcon--medium euiIcon--subdued euiIcon-isLoading"
+                                focusable="true"
+                                height={16}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                role="img"
+                                style={null}
+                                tabIndex={0}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <input
+                                aria-describedby="some_html_id-help-0"
+                                aria-label="Enter Index Name"
+                                className="euiFieldText euiFieldText--inGroup"
+                                disabled={true}
+                                id="some_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Enter index name"
+                                type="text"
+                                value="skipping"
+                              />
+                            </div>
+                            <label
+                              className="euiFormLabel euiFormControlLayout__append"
+                              htmlFor="some_html_id"
+                            >
+                              _index
+                            </label>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="some_html_id-help-0"
+                          >
+                            Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
+                          </div>
+                        </div>
+                      </div>,
+                      "",
+                    ]
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                    Array [
+                      <div
+                        className="euiSpacer euiSpacer--l"
+                      />,
+                      Array [
+                        <div
+                          className="euiText euiText--medium"
+                          data-test-subj="skipping-index-builder"
+                        >
+                          <h3>
+                            Skipping index definition
+                          </h3>
+                        </div>,
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />,
+                        <div
+                          className="euiBasicTable"
+                          itemID="id"
+                        >
+                          <div>
+                            <div
+                              className="euiTableHeaderMobile"
+                            >
+                              <div
+                                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                />
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                />
+                              </div>
+                            </div>
+                            <table
+                              className="euiTable euiTable--responsive"
+                              id="some_html_id"
+                              tabIndex={-1}
+                            >
+                              <caption
+                                className="euiScreenReaderOnly euiTableCaption"
+                              />
+                              <thead>
+                                <tr>
+                                  <th
+                                    className="euiTableHeaderCell"
+                                    data-test-subj="tableHeaderCell_fieldName_0"
+                                    role="columnheader"
+                                    scope="col"
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Field name"
+                                      >
+                                        Field name
+                                      </span>
+                                    </span>
+                                  </th>
+                                  <th
+                                    className="euiTableHeaderCell"
+                                    data-test-subj="tableHeaderCell_dataType_1"
+                                    role="columnheader"
+                                    scope="col"
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Datatype"
+                                      >
+                                        Datatype
+                                      </span>
+                                    </span>
+                                  </th>
+                                  <th
+                                    className="euiTableHeaderCell"
+                                    data-test-subj="tableHeaderCell_Acceleration method_2"
+                                    role="columnheader"
+                                    scope="col"
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Acceleration method"
+                                      >
+                                        Acceleration method
+                                      </span>
+                                    </span>
+                                  </th>
+                                  <th
+                                    className="euiTableHeaderCell"
+                                    data-test-subj="tableHeaderCell_Delete_3"
+                                    role="columnheader"
+                                    scope="col"
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Delete"
+                                      >
+                                        Delete
+                                      </span>
+                                    </span>
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                <tr
+                                  className="euiTableRow"
+                                >
+                                  <td
+                                    className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                                    colSpan={4}
+                                    style={
+                                      Object {
+                                        "width": undefined,
+                                      }
+                                    }
+                                  >
+                                    <div
+                                      className="euiTableCellContent euiTableCellContent--alignCenter"
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                      >
+                                        No items found
+                                      </span>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>,
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <button
+                              className="euiButton euiButton--primary euiButton--fill"
+                              disabled={false}
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                              type="button"
+                            >
+                              <span
+                                className="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  className="euiButton__text"
+                                >
+                                  Add fields
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <button
+                              className="euiButton euiButton--danger"
+                              disabled={false}
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                              type="button"
+                            >
+                              <span
+                                className="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  className="euiButton__text"
+                                >
+                                  Bulk delete
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                        </div>,
+                      ],
+                    ]
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="euiFlyoutFooter"
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <button
+                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--flushLeft"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                    type="button"
+                  >
+                    <span
+                      className="euiButtonContent euiButtonEmpty__content"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                        focusable="false"
+                        height={16}
+                        role="img"
+                        style={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                      <span
+                        className="euiButtonEmpty__text"
+                      >
+                        Close
+                      </span>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <button
+                    className="euiButton euiButton--primary euiButton--fill"
+                    disabled={false}
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "minWidth": undefined,
+                      }
+                    }
+                    type="button"
+                  >
+                    <span
+                      className="euiButtonContent euiButton__content"
+                    >
+                      <span
+                        className="euiButton__text"
+                      >
+                        Copy Query to Editor
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>,
+        <div
+          data-focus-guard={true}
+          style={
+            Object {
+              "height": "0px",
+              "left": "1px",
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "fixed",
+              "top": "1px",
+              "width": "1px",
+            }
+          }
+          tabIndex={0}
+        />,
+      ],
+      "",
+    ]
+  </Portal>,
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Acceleration header renders acceleration flyout header 1`] = `
+<div>
+  <header
+    className="euiPageHeader euiPageHeader--responsive euiPageHeader--center"
+  >
+    <div
+      className="euiPageHeaderSection"
+    >
+      <h1
+        className="euiTitle euiTitle--large"
+        data-test-subj="acceleration-header"
+      >
+        Accelerate data
+      </h1>
+    </div>
+  </header>
+  <div
+    className="euiSpacer euiSpacer--s"
+  />
+  <div
+    className="euiText euiText--small"
+  >
+    <div
+      className="euiTextColor euiTextColor--subdued"
+    >
+      Create OpenSearch Indexes from external data connections for better performance.
+       
+      <a
+        className="euiLink euiLink--primary"
+        href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Learn more
+        <svg
+          aria-hidden={true}
+          aria-label="External link"
+          className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+        <span
+          className="euiScreenReaderOnly"
+        >
+          (opens in a new tab or window)
+        </span>
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Acceleration header renders acceleration flyout header 1`] = `
        
       <a
         className="euiLink euiLink--primary"
-        href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"
+        href="https://opensearch.org/docs/latest/data-acceleration/index"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/create_acceleration.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/create_acceleration.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiComboBoxOptionOption } from '@elastic/eui';
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { coreMock } from '../../../../../../../../../../src/core/public/mocks';
+import { mockDatasourcesQuery } from '../../../../../../../../test/accelerations';
+import { CreateAcceleration } from '../create_acceleration';
+
+const coreStartMock = coreMock.createStart();
+
+describe('Create acceleration flyout components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders acceleration flyout component with default options', async () => {
+    const selectedDatasource: EuiComboBoxOptionOption[] = [];
+    const resetFlyout = jest.fn();
+    const updateQueries = jest.fn();
+    const client = coreStartMock.http;
+    client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
+
+    const wrapper = mount(
+      <CreateAcceleration
+        http={client}
+        selectedDatasource={selectedDatasource}
+        resetFlyout={resetFlyout}
+        updateQueries={updateQueries}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/create_acceleration_header.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/create_acceleration_header.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationHeader } from '../create_acceleration_header';
+
+describe('Acceleration header', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders acceleration flyout header', async () => {
+    const wrapper = mount(<CreateAccelerationHeader />);
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/create/__tests__/utils.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create/__tests__/utils.test.tsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ACCELERATION_INDEX_NAME_REGEX,
+  ACCELERATION_S3_URL_REGEX,
+} from '../../../../../../../../common/constants/data_sources';
+import {
+  coveringIndexDataMock,
+  materializedViewEmptyDataMock,
+  materializedViewEmptyTumbleDataMock,
+  materializedViewStaleDataMock,
+  materializedViewValidDataMock,
+  skippingIndexDataMock,
+} from '../../../../../../../../test/accelerations';
+import {
+  pluralizeTime,
+  validateCheckpointLocation,
+  validateCoveringIndexData,
+  validateDataSource,
+  validateDataTable,
+  validateDatabase,
+  validateIndexName,
+  validateMaterializedViewData,
+  validatePrimaryShardCount,
+  validateRefreshInterval,
+  validateReplicaCount,
+  validateSkippingIndexData,
+} from '../utils';
+
+describe('pluralizeTime', () => {
+  it('should return "s" for a time window greater than 1', () => {
+    expect(pluralizeTime(2)).toBe('s');
+    expect(pluralizeTime(10)).toBe('s');
+    expect(pluralizeTime(100)).toBe('s');
+  });
+
+  it('should return an empty string for a time window of 1/0', () => {
+    expect(pluralizeTime(1)).toBe('');
+    expect(pluralizeTime(0)).toBe(''); // form throws validation error, doesn't allow user to proceed
+  });
+});
+
+describe('validateDataSource', () => {
+  it('should return an array with an error message when the dataSource is empty', () => {
+    expect(validateDataSource('')).toEqual(['Select a valid data source']);
+    expect(validateDataSource('   ')).toEqual(['Select a valid data source']);
+  });
+
+  it('should return an empty array when the dataSource is not empty', () => {
+    expect(validateDataSource('Some_valid_data_source')).toEqual([]);
+    expect(validateDataSource('   Some_valid_data_source   ')).toEqual([]);
+  });
+});
+
+describe('validateDatabase', () => {
+  it('should return an array with an error message when the database is empty', () => {
+    expect(validateDatabase('')).toEqual(['Select a valid database']);
+    expect(validateDatabase('   ')).toEqual(['Select a valid database']);
+  });
+
+  it('should return an empty array when the database is not empty', () => {
+    expect(validateDatabase('Some_valid_database')).toEqual([]);
+    expect(validateDatabase('   Some_valid_database   ')).toEqual([]);
+  });
+});
+
+describe('validateDataTable', () => {
+  it('should return an array with an error message when the dataTable is empty', () => {
+    expect(validateDataTable('')).toEqual(['Select a valid table']);
+    expect(validateDataTable('   ')).toEqual(['Select a valid table']);
+  });
+
+  it('should return an empty array when the dataTable is not empty', () => {
+    expect(validateDataTable('Some_valid_table')).toEqual([]);
+    expect(validateDataTable('   Some_valid_table   ')).toEqual([]);
+  });
+});
+
+describe('validatePrimaryShardCount', () => {
+  it('should return an array with an error message when primaryShardCount is less than 1', () => {
+    expect(validatePrimaryShardCount(0)).toEqual(['Primary shards count should be greater than 0']);
+    expect(validatePrimaryShardCount(-1)).toEqual([
+      'Primary shards count should be greater than 0',
+    ]); // form throws validation error, doesn't allow user to proceed
+  });
+
+  it('should return an empty array when primaryShardCount is greater than or equal to 1', () => {
+    expect(validatePrimaryShardCount(1)).toEqual([]);
+    expect(validatePrimaryShardCount(5)).toEqual([]);
+    expect(validatePrimaryShardCount(100)).toEqual([]);
+  });
+});
+
+describe('validateReplicaCount', () => {
+  it('should return an array with an error message when replicaCount is less than 1', () => {
+    expect(validateReplicaCount(-1)).toEqual(['Replica count should be equal or greater than 0']); // form throws validation error, doesn't allow user to proceed
+  });
+
+  it('should return an empty array when replicaCount is greater than or equal to 1', () => {
+    expect(validateReplicaCount(0)).toEqual([]);
+    expect(validateReplicaCount(1)).toEqual([]);
+    expect(validateReplicaCount(5)).toEqual([]);
+    expect(validateReplicaCount(100)).toEqual([]);
+  });
+});
+
+describe('validateRefreshInterval', () => {
+  it('should return an array with an error message when refreshType is "interval" and refreshWindow is less than 1', () => {
+    expect(validateRefreshInterval('interval', 0)).toEqual([
+      'refresh window should be greater than 0',
+    ]);
+    expect(validateRefreshInterval('interval', -1)).toEqual([
+      'refresh window should be greater than 0',
+    ]);
+    expect(validateRefreshInterval('interval', -10)).toEqual([
+      'refresh window should be greater than 0',
+    ]);
+  });
+
+  it('should return an empty array when refreshType is not "interval" or when refreshWindow is greater than or equal to 1', () => {
+    expect(validateRefreshInterval('auto', 0)).toEqual([]);
+    expect(validateRefreshInterval('auto', 1)).toEqual([]);
+    expect(validateRefreshInterval('interval', 1)).toEqual([]);
+    expect(validateRefreshInterval('auto', 5)).toEqual([]);
+  });
+});
+
+describe('validateIndexName', () => {
+  it('should return an array with an error message when the index name is invalid', () => {
+    expect(validateIndexName('_invalid')).toEqual(['Enter a valid index name']);
+    expect(validateIndexName('-invalid')).toEqual(['Enter a valid index name']);
+    expect(validateIndexName('InVal1d')).toEqual(['Enter a valid index name']);
+    expect(validateIndexName('invalid_with spaces')).toEqual(['Enter a valid index name']);
+    expect(validateIndexName('another-valid-name')).toEqual(['Enter a valid index name']);
+  });
+
+  it('should return an empty array when the index name is valid', () => {
+    expect(validateIndexName('valid')).toEqual([]);
+    expect(validateIndexName('valid_name')).toEqual([]);
+    expect(validateIndexName('valid_name_index')).toEqual([]);
+  });
+
+  it('should use the ACCELERATION_INDEX_NAME_REGEX pattern to validate the index name', () => {
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('valid_name')).toBe(true);
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('invalid name')).toBe(false);
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('-invalid')).toBe(false);
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('_invalid')).toBe(false);
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('invalid.')).toBe(false);
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('invalid<')).toBe(false);
+    expect(ACCELERATION_INDEX_NAME_REGEX.test('invalid*')).toBe(false);
+  });
+});
+
+describe('validateCheckpointLocation', () => {
+  it('should return an array with an error message when using auto refresh without a checkpoint location', () => {
+    const materializedError = validateCheckpointLocation('auto', undefined);
+    expect(materializedError).toEqual(['Checkpoint location is mandatory for auto refresh']);
+  });
+
+  it('should return an array with an error message when using auto refresh with empty a checkpoint location', () => {
+    const materializedError = validateCheckpointLocation('auto', '');
+    expect(materializedError).toEqual(['Checkpoint location is mandatory for auto refresh']);
+  });
+
+  it('should return an array with an error message when the checkpoint location is not a valid S3 URL', () => {
+    const invalidCheckpoint = validateCheckpointLocation('auto', 'not_a_valid_s3_url');
+    expect(invalidCheckpoint).toEqual(['Enter a valid checkpoint location']);
+  });
+
+  it('should return an empty array when the checkpoint location is a valid S3 URL', () => {
+    const validCheckpoint = validateCheckpointLocation(
+      'interval',
+      's3://valid-s3-bucket/path/to/checkpoint'
+    );
+    expect(validCheckpoint).toEqual([]);
+  });
+
+  it('should return an empty array when the checkpoint location is a valid S3A URL', () => {
+    const validCheckpoint = validateCheckpointLocation(
+      'auto',
+      's3a://valid-s3-bucket/path/to/checkpoint'
+    );
+    expect(validCheckpoint).toEqual([]);
+  });
+
+  it('should return an empty array when the checkpoint location is a valid S3A URL with just bucket in checkpoint', () => {
+    const validCheckpoint = validateCheckpointLocation('auto', 's3a://valid-s3-bucket');
+    expect(validCheckpoint).toEqual([]);
+  });
+
+  it('should return an empty array when using manual refresh with no checkpoint location', () => {
+    const validMaterializedCheckpoint = validateCheckpointLocation('manual', '');
+    expect(validMaterializedCheckpoint).toEqual([]);
+  });
+
+  it('should use the ACCELERATION_S3_URL_REGEX pattern to validate the checkpoint location', () => {
+    expect(ACCELERATION_S3_URL_REGEX.test('s3://valid-s3-bucket/path/to/checkpoint')).toBe(true);
+    expect(ACCELERATION_S3_URL_REGEX.test('s3a://valid-s3-bucket/path/to/checkpoint')).toBe(true);
+    expect(ACCELERATION_S3_URL_REGEX.test('https://amazon.com')).toBe(false);
+    expect(ACCELERATION_S3_URL_REGEX.test('http://www.amazon.com')).toBe(false);
+  });
+});
+
+describe('validateSkippingIndexData', () => {
+  it('should return an array with an error message when accelerationIndexType is "skipping" and no skipping index data is provided', () => {
+    const error = validateSkippingIndexData('skipping', []);
+    expect(error).toEqual(['Add fields to the skipping index definition']);
+  });
+
+  it('should return an empty array when accelerationIndexType is not "skipping"', () => {
+    const noError = validateSkippingIndexData('covering', []);
+    expect(noError).toEqual([]);
+  });
+
+  it('should return an empty array when accelerationIndexType is "skipping" and skipping index data is provided', () => {
+    const noError = validateSkippingIndexData('skipping', skippingIndexDataMock);
+    expect(noError).toEqual([]);
+  });
+});
+
+describe('validateCoveringIndexData', () => {
+  it('should return an array with an error message when accelerationIndexType is "covering" and no covering index data is provided', () => {
+    const error = validateCoveringIndexData('covering', []);
+    expect(error).toEqual(['Add fields to covering index definition']);
+  });
+
+  it('should return an empty array when accelerationIndexType is not "covering"', () => {
+    const noError = validateCoveringIndexData('skipping', []);
+    expect(noError).toEqual([]);
+  });
+
+  it('should return an empty array when accelerationIndexType is "covering" and covering index data is provided', () => {
+    const noError = validateCoveringIndexData('covering', coveringIndexDataMock);
+    expect(noError).toEqual([]);
+  });
+});
+
+describe('validateMaterializedViewData', () => {
+  it('should return an array with an error message when accelerationIndexType is "materialized" and no materialized view data is provided', () => {
+    const error = validateMaterializedViewData('materialized', materializedViewEmptyDataMock);
+    expect(error).toEqual(['Add columns to materialized view definition']);
+  });
+
+  it('should return an array with an error message when accelerationIndexType is "materialized" and groupByTumbleValue is incomplete', () => {
+    const error = validateMaterializedViewData('materialized', materializedViewEmptyTumbleDataMock);
+    expect(error).toEqual(['Add a time field to tumble function in materialized view definition']);
+  });
+
+  it('should return an empty array when accelerationIndexType is not "materialized"', () => {
+    const noError = validateMaterializedViewData('covering', materializedViewStaleDataMock);
+    expect(noError).toEqual([]);
+  });
+
+  it('should return an empty array when accelerationIndexType is "materialized" and materialized view data is complete', () => {
+    const noError = validateMaterializedViewData('materialized', materializedViewValidDataMock);
+    expect(noError).toEqual([]);
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create/create_acceleration.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiComboBoxOptionOption,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiForm,
+  EuiSpacer,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { CoreStart } from '../../../../../../../../../src/core/public';
+import {
+  ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+  ACCELERATION_TIME_INTERVAL,
+} from '../../../../../../../common/constants/data_sources';
+import { CreateAccelerationForm } from '../../../../../../../common/types/data_connections';
+import { DefineIndexOptions } from '../selectors/define_index_options';
+import { IndexSettingOptions } from '../selectors/index_setting_options';
+import { AccelerationDataSourceSelector } from '../selectors/source_selector';
+import { accelerationQueryBuilder } from '../visual_editors/query_builder';
+import { QueryVisualEditor } from '../visual_editors/query_visual_editor';
+import { CreateAccelerationHeader } from './create_acceleration_header';
+import { formValidator, hasError } from './utils';
+
+export interface CreateAccelerationProps {
+  http: CoreStart['http'];
+  selectedDatasource: EuiComboBoxOptionOption[];
+  resetFlyout: () => void;
+  updateQueries: (query: string) => void;
+}
+
+export const CreateAcceleration = ({
+  http,
+  selectedDatasource,
+  resetFlyout,
+  updateQueries,
+}: CreateAccelerationProps) => {
+  const [accelerationFormData, setAccelerationFormData] = useState<CreateAccelerationForm>({
+    dataSource: selectedDatasource.length > 0 ? selectedDatasource[0].label : '',
+    dataTable: '',
+    database: '',
+    dataTableFields: [],
+    accelerationIndexType: 'skipping',
+    skippingIndexQueryData: [],
+    coveringIndexQueryData: [],
+    materializedViewQueryData: {
+      columnsValues: [],
+      groupByTumbleValue: {
+        timeField: '',
+        tumbleWindow: 0,
+        tumbleInterval: '',
+      },
+    },
+    accelerationIndexName: ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+    primaryShardsCount: 5,
+    replicaShardsCount: 1,
+    refreshType: 'auto',
+    checkpointLocation: undefined,
+    watermarkDelay: {
+      delayWindow: 1,
+      delayInterval: ACCELERATION_TIME_INTERVAL[1].value,
+    },
+    refreshIntervalOptions: {
+      refreshWindow: 1,
+      refreshInterval: ACCELERATION_TIME_INTERVAL[1].value,
+    },
+    formErrors: {
+      dataSourceError: [],
+      databaseError: [],
+      dataTableError: [],
+      skippingIndexError: [],
+      coveringIndexError: [],
+      materializedViewError: [],
+      indexNameError: [],
+      primaryShardsError: [],
+      replicaShardsError: [],
+      refreshIntervalError: [],
+      checkpointLocationError: [],
+      watermarkDelayError: [],
+    },
+  });
+
+  const copyToEditor = () => {
+    const errors = formValidator(accelerationFormData);
+    if (hasError(errors)) {
+      setAccelerationFormData({ ...accelerationFormData, formErrors: errors });
+      return;
+    }
+    updateQueries(accelerationQueryBuilder(accelerationFormData));
+    resetFlyout();
+  };
+
+  return (
+    <>
+      <EuiFlyout ownFocus onClose={resetFlyout} aria-labelledby="flyoutTitle" size="m">
+        <EuiFlyoutHeader hasBorder>
+          <CreateAccelerationHeader />
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiSpacer size="l" />
+          <EuiForm
+            isInvalid={hasError(accelerationFormData.formErrors)}
+            error={Object.values(accelerationFormData.formErrors).flat()}
+            component="div"
+            id="acceleration-form"
+          >
+            <AccelerationDataSourceSelector
+              http={http}
+              accelerationFormData={accelerationFormData}
+              setAccelerationFormData={setAccelerationFormData}
+              selectedDatasource={selectedDatasource}
+            />
+            <EuiSpacer size="xxl" />
+            <IndexSettingOptions
+              accelerationFormData={accelerationFormData}
+              setAccelerationFormData={setAccelerationFormData}
+            />
+            <EuiSpacer size="xxl" />
+            <DefineIndexOptions
+              accelerationFormData={accelerationFormData}
+              setAccelerationFormData={setAccelerationFormData}
+            />
+            <EuiSpacer size="m" />
+            <QueryVisualEditor
+              accelerationFormData={accelerationFormData}
+              setAccelerationFormData={setAccelerationFormData}
+            />
+          </EuiForm>
+        </EuiFlyoutBody>
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty iconType="cross" onClick={resetFlyout} flush="left">
+                Close
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton onClick={copyToEditor} fill>
+                Copy Query to Editor
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/create/create_acceleration_header.tsx
+++ b/public/components/datasources/components/manage/accelerations/create/create_acceleration_header.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiLink,
+  EuiPageHeader,
+  EuiPageHeaderSection,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import React from 'react';
+import { OPENSEARCH_ACC_DOCUMENTATION_URL } from '../../../../../../../common/constants/data_connections';
+
+export const CreateAccelerationHeader = () => {
+  return (
+    <div>
+      <EuiPageHeader>
+        <EuiPageHeaderSection>
+          <EuiTitle size="l" data-test-subj="acceleration-header">
+            <h1>Accelerate data</h1>
+          </EuiTitle>
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        Create OpenSearch Indexes from external data connections for better performance.{' '}
+        <EuiLink external={true} href={OPENSEARCH_ACC_DOCUMENTATION_URL} target="_blank">
+          Learn more
+        </EuiLink>
+      </EuiText>
+    </div>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/create/utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/create/utils.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ACCELERATION_INDEX_NAME_REGEX,
+  ACCELERATION_S3_URL_REGEX,
+} from '../../../../../../../common/constants/data_sources';
+import {
+  AccelerationIndexType,
+  AccelerationRefreshType,
+  CreateAccelerationForm,
+  FormErrorsType,
+  MaterializedViewQueryType,
+  SkippingIndexRowType,
+} from '../../../../../../../common/types/data_connections';
+
+export const pluralizeTime = (timeWindow: number) => {
+  return timeWindow > 1 ? 's' : '';
+};
+
+export const hasError = (formErrors: FormErrorsType, key?: keyof FormErrorsType) => {
+  if (!key) return Object.values(formErrors).some((e) => !!e.length);
+  return !!formErrors[key]?.length;
+};
+
+export const validateDataSource = (dataSource: string) => {
+  return dataSource.trim().length === 0 ? ['Select a valid data source'] : [];
+};
+
+export const validateDatabase = (database: string) => {
+  return database.trim().length === 0 ? ['Select a valid database'] : [];
+};
+
+export const validateDataTable = (dataTable: string) => {
+  return dataTable.trim().length === 0 ? ['Select a valid table'] : [];
+};
+
+export const validatePrimaryShardCount = (primaryShardCount: number) => {
+  return primaryShardCount < 1 ? ['Primary shards count should be greater than 0'] : [];
+};
+
+export const validateReplicaCount = (replicaCount: number) => {
+  return replicaCount < 0 ? ['Replica count should be equal or greater than 0'] : [];
+};
+
+export const validateRefreshInterval = (refreshType: string, refreshWindow: number) => {
+  return refreshType === 'interval' && refreshWindow < 1
+    ? ['refresh window should be greater than 0']
+    : [];
+};
+
+export const validateWatermarkDelay = (
+  accelerationIndexType: AccelerationIndexType,
+  delayWindow: number
+) => {
+  return accelerationIndexType === 'materialized' && delayWindow < 1
+    ? ['delay window should be greater than 0']
+    : [];
+};
+
+export const validateIndexName = (value: string) => {
+  // Check if the value does not begin with underscores or hyphens and all characters are lower case
+  return !ACCELERATION_INDEX_NAME_REGEX.test(value) ? ['Enter a valid index name'] : [];
+};
+
+export const validateCheckpointLocation = (
+  refreshType: AccelerationRefreshType,
+  checkpointLocation: string | undefined
+) => {
+  if (refreshType !== 'manual' && !checkpointLocation) {
+    return ['Checkpoint location is mandatory for auto refresh'];
+  }
+
+  if (checkpointLocation && !ACCELERATION_S3_URL_REGEX.test(checkpointLocation))
+    return ['Enter a valid checkpoint location'];
+
+  return [];
+};
+
+export const validateSkippingIndexData = (
+  accelerationIndexType: AccelerationIndexType,
+  skippingIndexQueryData: SkippingIndexRowType[]
+) => {
+  // TODO: Validate dataType match with supported acceleration method type
+  if (accelerationIndexType !== 'skipping') return [];
+
+  if (skippingIndexQueryData.length < 1) return ['Add fields to the skipping index definition'];
+
+  return [];
+};
+
+export const validateCoveringIndexData = (
+  accelerationIndexType: AccelerationIndexType,
+  coveringIndexQueryData: string[]
+) => {
+  if (accelerationIndexType !== 'covering') return [];
+
+  if (coveringIndexQueryData.length < 1) return ['Add fields to covering index definition'];
+  return [];
+};
+
+export const validateMaterializedViewData = (
+  accelerationIndexType: AccelerationIndexType,
+  materializedViewQueryData: MaterializedViewQueryType
+) => {
+  if (accelerationIndexType !== 'materialized') return [];
+
+  if (materializedViewQueryData.columnsValues.length < 1)
+    return ['Add columns to materialized view definition'];
+
+  if (materializedViewQueryData.groupByTumbleValue.timeField === '')
+    return ['Add a time field to tumble function in materialized view definition'];
+
+  if (materializedViewQueryData.groupByTumbleValue.tumbleWindow < 1)
+    return ['Add a valid time window to tumble function in materialized view definition'];
+  return [];
+};
+
+export const formValidator = (accelerationformData: CreateAccelerationForm) => {
+  const {
+    dataSource,
+    database,
+    dataTable,
+    accelerationIndexType,
+    skippingIndexQueryData,
+    coveringIndexQueryData,
+    materializedViewQueryData,
+    accelerationIndexName,
+    primaryShardsCount,
+    replicaShardsCount,
+    refreshType,
+    checkpointLocation,
+    watermarkDelay,
+    refreshIntervalOptions,
+  } = accelerationformData;
+
+  const accelerationFormErrors: FormErrorsType = {
+    dataSourceError: validateDataSource(dataSource),
+    databaseError: validateDatabase(database),
+    dataTableError: validateDataTable(dataTable),
+    primaryShardsError: validatePrimaryShardCount(primaryShardsCount),
+    replicaShardsError: validateReplicaCount(replicaShardsCount),
+    refreshIntervalError: validateRefreshInterval(
+      refreshType,
+      refreshIntervalOptions.refreshWindow
+    ),
+    checkpointLocationError: validateCheckpointLocation(refreshType, checkpointLocation),
+    watermarkDelayError: validateWatermarkDelay(accelerationIndexType, watermarkDelay.delayWindow),
+    indexNameError: validateIndexName(accelerationIndexName),
+    skippingIndexError: validateSkippingIndexData(accelerationIndexType, skippingIndexQueryData),
+    coveringIndexError: validateCoveringIndexData(accelerationIndexType, coveringIndexQueryData),
+    materializedViewError: validateMaterializedViewData(
+      accelerationIndexType,
+      materializedViewQueryData
+    ),
+  };
+
+  return accelerationFormErrors;
+};

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
@@ -15,7 +15,7 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -23,7 +23,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Index name
       </label>
@@ -49,7 +49,7 @@ Array [
       >
         <label
           className="euiFormLabel euiFormControlLayout__prepend"
-          htmlFor="some_html_id"
+          htmlFor="random_html_id"
         >
           flint_{Datasource Name}_{Database Name}_{Table Name}_
         </label>
@@ -83,11 +83,11 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Enter Index Name"
             className="euiFieldText euiFieldText--inGroup"
             disabled={false}
-            id="some_html_id"
+            id="random_html_id"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -98,14 +98,14 @@ Array [
         </div>
         <label
           className="euiFormLabel euiFormControlLayout__append"
-          htmlFor="some_html_id"
+          htmlFor="random_html_id"
         >
           _index
         </label>
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
       </div>
@@ -130,7 +130,7 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -138,7 +138,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Index name
       </label>
@@ -164,7 +164,7 @@ Array [
       >
         <label
           className="euiFormLabel euiFormControlLayout__prepend"
-          htmlFor="some_html_id"
+          htmlFor="random_html_id"
         >
           flint_{Datasource Name}_{Database Name}_{Table Name}_
         </label>
@@ -198,11 +198,11 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Enter Index Name"
             className="euiFieldText euiFieldText--inGroup"
             disabled={true}
-            id="some_html_id"
+            id="random_html_id"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -213,14 +213,14 @@ Array [
         </div>
         <label
           className="euiFormLabel euiFormControlLayout__append"
-          htmlFor="some_html_id"
+          htmlFor="random_html_id"
         >
           _index
         </label>
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
       </div>
@@ -245,7 +245,7 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -253,7 +253,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Index name
       </label>
@@ -279,7 +279,7 @@ Array [
       >
         <label
           className="euiFormLabel euiFormControlLayout__prepend"
-          htmlFor="some_html_id"
+          htmlFor="random_html_id"
         >
           flint_{Datasource Name}_{Database Name}_
         </label>
@@ -313,11 +313,11 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Enter Index Name"
             className="euiFieldText euiFieldText--inGroup"
             disabled={false}
-            id="some_html_id"
+            id="random_html_id"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -329,7 +329,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
       </div>

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Index options acceleration components renders acceleration index options with covering index options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="define-index-header"
+  >
+    <h3>
+      Index settings
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Index name
+      </label>
+       
+      <div
+        className="euiText euiText--extraSmall"
+      >
+        <button
+          className="euiLink euiLink--primary"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Help
+        </button>
+      </div>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <label
+          className="euiFormLabel euiFormControlLayout__prepend"
+          htmlFor="some_html_id"
+        >
+          flint_{Datasource Name}_{Database Name}_{Table Name}_
+        </label>
+        <span
+          className="euiToolTipAnchor"
+          onKeyUp={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+        >
+          <svg
+            aria-label="Info"
+            className="euiIcon euiIcon--medium euiIcon--subdued"
+            focusable="true"
+            height={16}
+            onBlur={[Function]}
+            onFocus={[Function]}
+            role="img"
+            style={null}
+            tabIndex={0}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.5 11.508 7.468 8H6.25V7h2.401l.03 3.508H9.8v1H7.5Zm-.25-6.202a.83.83 0 0 1 .207-.577c.137-.153.334-.229.59-.229.256 0 .454.076.594.23.14.152.209.345.209.576 0 .228-.07.417-.21.568-.14.15-.337.226-.593.226-.256 0-.453-.075-.59-.226a.81.81 0 0 1-.207-.568ZM8 13A5 5 0 1 0 8 3a5 5 0 0 0 0 10Zm0 1A6 6 0 1 1 8 2a6 6 0 0 1 0 12Z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </span>
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Enter Index Name"
+            className="euiFieldText euiFieldText--inGroup"
+            disabled={false}
+            id="some_html_id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Enter index name"
+            type="text"
+            value="covering-idx"
+          />
+        </div>
+        <label
+          className="euiFormLabel euiFormControlLayout__append"
+          htmlFor="some_html_id"
+        >
+          _index
+        </label>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
+      </div>
+    </div>
+  </div>,
+  "",
+]
+`;
+
+exports[`Index options acceleration components renders acceleration index options with default options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="define-index-header"
+  >
+    <h3>
+      Index settings
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Index name
+      </label>
+       
+      <div
+        className="euiText euiText--extraSmall"
+      >
+        <button
+          className="euiLink euiLink--primary"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Help
+        </button>
+      </div>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <label
+          className="euiFormLabel euiFormControlLayout__prepend"
+          htmlFor="some_html_id"
+        >
+          flint_{Datasource Name}_{Database Name}_{Table Name}_
+        </label>
+        <span
+          className="euiToolTipAnchor"
+          onKeyUp={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+        >
+          <svg
+            aria-hidden={true}
+            aria-label="Info"
+            className="euiIcon euiIcon--medium euiIcon--subdued euiIcon-isLoading"
+            focusable="true"
+            height={16}
+            onBlur={[Function]}
+            onFocus={[Function]}
+            role="img"
+            style={null}
+            tabIndex={0}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+            />
+          </svg>
+        </span>
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Enter Index Name"
+            className="euiFieldText euiFieldText--inGroup"
+            disabled={true}
+            id="some_html_id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Enter index name"
+            type="text"
+            value="skipping"
+          />
+        </div>
+        <label
+          className="euiFormLabel euiFormControlLayout__append"
+          htmlFor="some_html_id"
+        >
+          _index
+        </label>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
+      </div>
+    </div>
+  </div>,
+  "",
+]
+`;
+
+exports[`Index options acceleration components renders acceleration index options with materialized index options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="define-index-header"
+  >
+    <h3>
+      Index settings
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Index name
+      </label>
+       
+      <div
+        className="euiText euiText--extraSmall"
+      >
+        <button
+          className="euiLink euiLink--primary"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Help
+        </button>
+      </div>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <label
+          className="euiFormLabel euiFormControlLayout__prepend"
+          htmlFor="some_html_id"
+        >
+          flint_{Datasource Name}_{Database Name}_
+        </label>
+        <span
+          className="euiToolTipAnchor"
+          onKeyUp={[Function]}
+          onMouseOut={[Function]}
+          onMouseOver={[Function]}
+        >
+          <svg
+            aria-label="Info"
+            className="euiIcon euiIcon--medium euiIcon--subdued"
+            focusable="true"
+            height={16}
+            onBlur={[Function]}
+            onFocus={[Function]}
+            role="img"
+            style={null}
+            tabIndex={0}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.5 11.508 7.468 8H6.25V7h2.401l.03 3.508H9.8v1H7.5Zm-.25-6.202a.83.83 0 0 1 .207-.577c.137-.153.334-.229.59-.229.256 0 .454.076.594.23.14.152.209.345.209.576 0 .228-.07.417-.21.568-.14.15-.337.226-.593.226-.256 0-.453-.075-.59-.226a.81.81 0 0 1-.207-.568ZM8 13A5 5 0 1 0 8 3a5 5 0 0 0 0 10Zm0 1A6 6 0 1 1 8 2a6 6 0 0 1 0 12Z"
+              fillRule="evenodd"
+            />
+          </svg>
+        </span>
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Enter Index Name"
+            className="euiFieldText euiFieldText--inGroup"
+            disabled={false}
+            id="some_html_id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Enter index name"
+            type="text"
+            value="mv_metrics"
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \\, |, ?, #, &gt;, or &lt; are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.
+      </div>
+    </div>
+  </div>,
+  "",
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
@@ -1,0 +1,1225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Index settings acceleration components renders acceleration index settings with default options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="index-settings-header"
+  >
+    <h3>
+      Index settings
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Index type
+      </label>
+       
+      <div
+        className="euiText euiText--extraSmall"
+      >
+        <a
+          className="euiLink euiLink--primary"
+          href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Help
+          <svg
+            aria-hidden={true}
+            aria-label="External link"
+            className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+            focusable="false"
+            height={16}
+            role="img"
+            style={null}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+            />
+          </svg>
+          <span
+            className="euiScreenReaderOnly"
+          >
+            (opens in a new tab or window)
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <span
+                className="euiComboBoxPill euiComboBoxPill--plainText"
+                value="skipping"
+              >
+                Skipping Index
+              </span>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the type of index you want to create. Each index type has benefits and costs.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Number of primary shards
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Number of primary shards"
+            className="euiFieldNumber"
+            id="some_html_id"
+            max={100}
+            min={1}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Number of primary shards"
+            type="number"
+            value={5}
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Number of replicas
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Number of replicas"
+            className="euiFieldNumber"
+            id="some_html_id"
+            max={100}
+            min={0}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Number of replicas"
+            type="number"
+            value={1}
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify the number of replicas each primary shard should have.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Refresh type
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        id="some_html_id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={true}
+            className="euiRadio__input"
+            id="refresh-option-1"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-1"
+          >
+            Auto refresh
+          </label>
+        </div>
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={false}
+            className="euiRadio__input"
+            id="refresh-option-2"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-2"
+          >
+            Auto refresh by interval
+          </label>
+        </div>
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={false}
+            className="euiRadio__input"
+            id="refresh-option-3"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-3"
+          >
+            Manual refresh
+          </label>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Checkpoint location
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Use aria labels when no actual label is in use"
+            className="euiFieldText"
+            id="some_html_id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="s3://checkpoint/location"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        The HDFS compatible file system location path for incremental refresh job checkpoint.
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Index settings acceleration components renders acceleration index settings with different options1 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="index-settings-header"
+  >
+    <h3>
+      Index settings
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Index type
+      </label>
+       
+      <div
+        className="euiText euiText--extraSmall"
+      >
+        <a
+          className="euiLink euiLink--primary"
+          href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Help
+          <svg
+            aria-label="External link"
+            className="euiIcon euiIcon--small euiLink__externalIcon"
+            focusable="false"
+            height={16}
+            role="img"
+            style={null}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+            />
+          </svg>
+          <span
+            className="euiScreenReaderOnly"
+          >
+            (opens in a new tab or window)
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <span
+                className="euiComboBoxPill euiComboBoxPill--plainText"
+                value="skipping"
+              >
+                Skipping Index
+              </span>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the type of index you want to create. Each index type has benefits and costs.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Number of primary shards
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Number of primary shards"
+            className="euiFieldNumber"
+            id="some_html_id"
+            max={100}
+            min={1}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Number of primary shards"
+            type="number"
+            value={5}
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Number of replicas
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Number of replicas"
+            className="euiFieldNumber"
+            id="some_html_id"
+            max={100}
+            min={0}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Number of replicas"
+            type="number"
+            value={1}
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify the number of replicas each primary shard should have.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Refresh type
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        id="some_html_id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={true}
+            className="euiRadio__input"
+            id="refresh-option-1"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-1"
+          >
+            Auto refresh
+          </label>
+        </div>
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={false}
+            className="euiRadio__input"
+            id="refresh-option-2"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-2"
+          >
+            Auto refresh by interval
+          </label>
+        </div>
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={false}
+            className="euiRadio__input"
+            id="refresh-option-3"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-3"
+          >
+            Manual refresh
+          </label>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Checkpoint location
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Use aria labels when no actual label is in use"
+            className="euiFieldText"
+            id="some_html_id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="s3://checkpoint/location"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        The HDFS compatible file system location path for incremental refresh job checkpoint.
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Index settings acceleration components renders acceleration index settings with different options2 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="index-settings-header"
+  >
+    <h3>
+      Index settings
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Index type
+      </label>
+       
+      <div
+        className="euiText euiText--extraSmall"
+      >
+        <a
+          className="euiLink euiLink--primary"
+          href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Help
+          <svg
+            aria-label="External link"
+            className="euiIcon euiIcon--small euiLink__externalIcon"
+            focusable="false"
+            height={16}
+            role="img"
+            style={null}
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+            />
+          </svg>
+          <span
+            className="euiScreenReaderOnly"
+          >
+            (opens in a new tab or window)
+          </span>
+        </a>
+      </div>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <span
+                className="euiComboBoxPill euiComboBoxPill--plainText"
+                value="skipping"
+              >
+                Skipping Index
+              </span>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the type of index you want to create. Each index type has benefits and costs.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Number of primary shards
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Number of primary shards"
+            className="euiFieldNumber"
+            id="some_html_id"
+            max={100}
+            min={1}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Number of primary shards"
+            type="number"
+            value={5}
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Number of replicas
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Number of replicas"
+            className="euiFieldNumber"
+            id="some_html_id"
+            max={100}
+            min={0}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Number of replicas"
+            type="number"
+            value={1}
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify the number of replicas each primary shard should have.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Refresh type
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        id="some_html_id"
+        onBlur={[Function]}
+        onFocus={[Function]}
+      >
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={true}
+            className="euiRadio__input"
+            id="refresh-option-1"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-1"
+          >
+            Auto refresh
+          </label>
+        </div>
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={false}
+            className="euiRadio__input"
+            id="refresh-option-2"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-2"
+          >
+            Auto refresh by interval
+          </label>
+        </div>
+        <div
+          className="euiRadio euiRadioGroup__item"
+        >
+          <input
+            checked={false}
+            className="euiRadio__input"
+            id="refresh-option-3"
+            name="refresh type radio group"
+            onChange={[Function]}
+            type="radio"
+          />
+          <div
+            className="euiRadio__circle"
+          />
+          <label
+            className="euiRadio__label"
+            htmlFor="refresh-option-3"
+          >
+            Manual refresh
+          </label>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Checkpoint location
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="some_html_id-help-0"
+            aria-label="Use aria labels when no actual label is in use"
+            className="euiFieldText"
+            id="some_html_id"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="s3://checkpoint/location"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        The HDFS compatible file system location path for incremental refresh job checkpoint.
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
@@ -15,14 +15,14 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
     >
       <label
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Index type
       </label>
@@ -65,7 +65,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -102,7 +102,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -162,7 +162,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the type of index you want to create. Each index type has benefits and costs.
       </div>
@@ -170,7 +170,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -178,7 +178,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Number of primary shards
       </label>
@@ -193,10 +193,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Number of primary shards"
             className="euiFieldNumber"
-            id="some_html_id"
+            id="random_html_id"
             max={100}
             min={1}
             onBlur={[Function]}
@@ -210,7 +210,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
       </div>
@@ -218,7 +218,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -226,7 +226,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Number of replicas
       </label>
@@ -241,10 +241,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Number of replicas"
             className="euiFieldNumber"
-            id="some_html_id"
+            id="random_html_id"
             max={100}
             min={0}
             onBlur={[Function]}
@@ -258,7 +258,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify the number of replicas each primary shard should have.
       </div>
@@ -266,14 +266,14 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
     >
       <label
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Refresh type
       </label>
@@ -282,8 +282,8 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
-        id="some_html_id"
+        aria-describedby="random_html_id-help-0"
+        id="random_html_id"
         onBlur={[Function]}
         onFocus={[Function]}
       >
@@ -353,7 +353,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
       </div>
@@ -361,7 +361,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -369,7 +369,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Checkpoint location
       </label>
@@ -384,10 +384,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Use aria labels when no actual label is in use"
             className="euiFieldText"
-            id="some_html_id"
+            id="random_html_id"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -399,7 +399,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         The HDFS compatible file system location path for incremental refresh job checkpoint.
       </div>
@@ -423,14 +423,14 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
     >
       <label
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Index type
       </label>
@@ -472,7 +472,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -509,7 +509,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -570,7 +570,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the type of index you want to create. Each index type has benefits and costs.
       </div>
@@ -578,7 +578,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -586,7 +586,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Number of primary shards
       </label>
@@ -601,10 +601,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Number of primary shards"
             className="euiFieldNumber"
-            id="some_html_id"
+            id="random_html_id"
             max={100}
             min={1}
             onBlur={[Function]}
@@ -618,7 +618,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
       </div>
@@ -626,7 +626,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -634,7 +634,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Number of replicas
       </label>
@@ -649,10 +649,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Number of replicas"
             className="euiFieldNumber"
-            id="some_html_id"
+            id="random_html_id"
             max={100}
             min={0}
             onBlur={[Function]}
@@ -666,7 +666,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify the number of replicas each primary shard should have.
       </div>
@@ -674,14 +674,14 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
     >
       <label
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Refresh type
       </label>
@@ -690,8 +690,8 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
-        id="some_html_id"
+        aria-describedby="random_html_id-help-0"
+        id="random_html_id"
         onBlur={[Function]}
         onFocus={[Function]}
       >
@@ -761,7 +761,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
       </div>
@@ -769,7 +769,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -777,7 +777,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Checkpoint location
       </label>
@@ -792,10 +792,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Use aria labels when no actual label is in use"
             className="euiFieldText"
-            id="some_html_id"
+            id="random_html_id"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -807,7 +807,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         The HDFS compatible file system location path for incremental refresh job checkpoint.
       </div>
@@ -831,14 +831,14 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
     >
       <label
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Index type
       </label>
@@ -880,7 +880,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -917,7 +917,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -978,7 +978,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the type of index you want to create. Each index type has benefits and costs.
       </div>
@@ -986,7 +986,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -994,7 +994,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Number of primary shards
       </label>
@@ -1009,10 +1009,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Number of primary shards"
             className="euiFieldNumber"
-            id="some_html_id"
+            id="random_html_id"
             max={100}
             min={1}
             onBlur={[Function]}
@@ -1026,7 +1026,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created.
       </div>
@@ -1034,7 +1034,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -1042,7 +1042,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Number of replicas
       </label>
@@ -1057,10 +1057,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Number of replicas"
             className="euiFieldNumber"
-            id="some_html_id"
+            id="random_html_id"
             max={100}
             min={0}
             onBlur={[Function]}
@@ -1074,7 +1074,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify the number of replicas each primary shard should have.
       </div>
@@ -1082,14 +1082,14 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
     >
       <label
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Refresh type
       </label>
@@ -1098,8 +1098,8 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
-        id="some_html_id"
+        aria-describedby="random_html_id-help-0"
+        id="random_html_id"
         onBlur={[Function]}
         onFocus={[Function]}
       >
@@ -1169,7 +1169,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
       </div>
@@ -1177,7 +1177,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -1185,7 +1185,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Checkpoint location
       </label>
@@ -1200,10 +1200,10 @@ Array [
           className="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-describedby="some_html_id-help-0"
+            aria-describedby="random_html_id-help-0"
             aria-label="Use aria labels when no actual label is in use"
             className="euiFieldText"
-            id="some_html_id"
+            id="random_html_id"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -1215,7 +1215,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         The HDFS compatible file system location path for incremental refresh job checkpoint.
       </div>

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Index type selector components renders type selector with default options 1`] = `
 <div
   className="euiFormRow"
-  id="some_html_id-row"
+  id="random_html_id-row"
 >
   <div
     className="euiFormRow__labelWrapper"
   >
     <label
       className="euiFormLabel euiFormRow__label"
-      htmlFor="some_html_id"
+      htmlFor="random_html_id"
     >
       Index type
     </label>
@@ -53,7 +53,7 @@ exports[`Index type selector components renders type selector with default optio
     className="euiFormRow__fieldWrapper"
   >
     <div
-      aria-describedby="some_html_id-help-0"
+      aria-describedby="random_html_id-help-0"
       aria-expanded={false}
       aria-haspopup="listbox"
       className="euiComboBox"
@@ -90,7 +90,7 @@ exports[`Index type selector components renders type selector with default optio
               <input
                 aria-controls=""
                 data-test-subj="comboBoxSearchInput"
-                id="some_html_id"
+                id="random_html_id"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -150,7 +150,7 @@ exports[`Index type selector components renders type selector with default optio
     </div>
     <div
       className="euiFormHelpText euiFormRow__text"
-      id="some_html_id-help-0"
+      id="random_html_id-help-0"
     >
       Select the type of index you want to create. Each index type has benefits and costs.
     </div>
@@ -161,14 +161,14 @@ exports[`Index type selector components renders type selector with default optio
 exports[`Index type selector components renders type selector with different options 1`] = `
 <div
   className="euiFormRow"
-  id="some_html_id-row"
+  id="random_html_id-row"
 >
   <div
     className="euiFormRow__labelWrapper"
   >
     <label
       className="euiFormLabel euiFormRow__label"
-      htmlFor="some_html_id"
+      htmlFor="random_html_id"
     >
       Index type
     </label>
@@ -210,7 +210,7 @@ exports[`Index type selector components renders type selector with different opt
     className="euiFormRow__fieldWrapper"
   >
     <div
-      aria-describedby="some_html_id-help-0"
+      aria-describedby="random_html_id-help-0"
       aria-expanded={false}
       aria-haspopup="listbox"
       className="euiComboBox"
@@ -247,7 +247,7 @@ exports[`Index type selector components renders type selector with different opt
               <input
                 aria-controls=""
                 data-test-subj="comboBoxSearchInput"
-                id="some_html_id"
+                id="random_html_id"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -308,7 +308,7 @@ exports[`Index type selector components renders type selector with different opt
     </div>
     <div
       className="euiFormHelpText euiFormRow__text"
-      id="some_html_id-help-0"
+      id="random_html_id-help-0"
     >
       Select the type of index you want to create. Each index type has benefits and costs.
     </div>

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
@@ -1,0 +1,317 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Index type selector components renders type selector with default options 1`] = `
+<div
+  className="euiFormRow"
+  id="some_html_id-row"
+>
+  <div
+    className="euiFormRow__labelWrapper"
+  >
+    <label
+      className="euiFormLabel euiFormRow__label"
+      htmlFor="some_html_id"
+    >
+      Index type
+    </label>
+     
+    <div
+      className="euiText euiText--extraSmall"
+    >
+      <a
+        className="euiLink euiLink--primary"
+        href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Help
+        <svg
+          aria-hidden={true}
+          aria-label="External link"
+          className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+        <span
+          className="euiScreenReaderOnly"
+        >
+          (opens in a new tab or window)
+        </span>
+      </a>
+    </div>
+  </div>
+  <div
+    className="euiFormRow__fieldWrapper"
+  >
+    <div
+      aria-describedby="some_html_id-help-0"
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      className="euiComboBox"
+      onKeyDown={[Function]}
+      role="combobox"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+            data-test-subj="comboBoxInput"
+            onClick={[Function]}
+            tabIndex={-1}
+          >
+            <span
+              className="euiComboBoxPill euiComboBoxPill--plainText"
+              value="skipping"
+            >
+              Skipping Index
+            </span>
+            <div
+              className="euiComboBox__input"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "fontSize": 14,
+                }
+              }
+            >
+              <input
+                aria-controls=""
+                data-test-subj="comboBoxSearchInput"
+                id="some_html_id"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                role="textbox"
+                style={
+                  Object {
+                    "boxSizing": "content-box",
+                    "width": "2px",
+                  }
+                }
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "overflow": "scroll",
+                    "position": "absolute",
+                    "top": 0,
+                    "visibility": "hidden",
+                    "whiteSpace": "pre",
+                  }
+                }
+              />
+            </div>
+          </div>
+          <div
+            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <button
+              aria-label="Open list of options"
+              className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+              data-test-subj="comboBoxToggleListButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFormHelpText euiFormRow__text"
+      id="some_html_id-help-0"
+    >
+      Select the type of index you want to create. Each index type has benefits and costs.
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Index type selector components renders type selector with different options 1`] = `
+<div
+  className="euiFormRow"
+  id="some_html_id-row"
+>
+  <div
+    className="euiFormRow__labelWrapper"
+  >
+    <label
+      className="euiFormLabel euiFormRow__label"
+      htmlFor="some_html_id"
+    >
+      Index type
+    </label>
+     
+    <div
+      className="euiText euiText--extraSmall"
+    >
+      <a
+        className="euiLink euiLink--primary"
+        href="https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Help
+        <svg
+          aria-label="External link"
+          className="euiIcon euiIcon--small euiLink__externalIcon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+          />
+        </svg>
+        <span
+          className="euiScreenReaderOnly"
+        >
+          (opens in a new tab or window)
+        </span>
+      </a>
+    </div>
+  </div>
+  <div
+    className="euiFormRow__fieldWrapper"
+  >
+    <div
+      aria-describedby="some_html_id-help-0"
+      aria-expanded={false}
+      aria-haspopup="listbox"
+      className="euiComboBox"
+      onKeyDown={[Function]}
+      role="combobox"
+    >
+      <div
+        className="euiFormControlLayout"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+            data-test-subj="comboBoxInput"
+            onClick={[Function]}
+            tabIndex={-1}
+          >
+            <span
+              className="euiComboBoxPill euiComboBoxPill--plainText"
+              value="skipping"
+            >
+              Skipping Index
+            </span>
+            <div
+              className="euiComboBox__input"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "fontSize": 14,
+                }
+              }
+            >
+              <input
+                aria-controls=""
+                data-test-subj="comboBoxSearchInput"
+                id="some_html_id"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                role="textbox"
+                style={
+                  Object {
+                    "boxSizing": "content-box",
+                    "width": "2px",
+                  }
+                }
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "overflow": "scroll",
+                    "position": "absolute",
+                    "top": 0,
+                    "visibility": "hidden",
+                    "whiteSpace": "pre",
+                  }
+                }
+              />
+            </div>
+          </div>
+          <div
+            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+          >
+            <button
+              aria-label="Open list of options"
+              className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+              data-test-subj="comboBoxToggleListButton"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                  fillRule="non-zero"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFormHelpText euiFormRow__text"
+      id="some_html_id-help-0"
+    >
+      Select the type of index you want to create. Each index type has benefits and costs.
+    </div>
+  </div>
+</div>
+`;

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
@@ -1,0 +1,789 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Source selector components renders source selector with default options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="datasource-selector-header"
+  >
+    <h3>
+      Select data source
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiText euiText--small"
+  >
+    <div
+      className="euiTextColor euiTextColor--subdued"
+    >
+      Select the data source to accelerate data from. External data sources may take time to load.
+    </div>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Data source
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <p
+                className="euiComboBoxPlaceholder"
+              >
+                Select a data source
+              </p>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        A data source has to be configured and active to be able to select it and index data from.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Database
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <p
+                className="euiComboBoxPlaceholder"
+              >
+                Select a database
+              </p>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the database that contains the tables you'd like to use.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Table
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <p
+                className="euiComboBoxPlaceholder"
+              >
+                Select a table
+              </p>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the Spark table that has the data you would like to index.
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Source selector components renders source selector with different options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="datasource-selector-header"
+  >
+    <h3>
+      Select data source
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiText euiText--small"
+  >
+    <div
+      className="euiTextColor euiTextColor--subdued"
+    >
+      Select the data source to accelerate data from. External data sources may take time to load.
+    </div>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Data source
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <span
+                className="euiComboBoxPill euiComboBoxPill--plainText"
+              >
+                ds
+              </span>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        A data source has to be configured and active to be able to select it and index data from.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Database
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <p
+                className="euiComboBoxPlaceholder"
+              >
+                Select a database
+              </p>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the database that contains the tables you'd like to use.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="some_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="some_html_id"
+      >
+        Table
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        aria-describedby="some_html_id-help-0"
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        className="euiComboBox"
+        onKeyDown={[Function]}
+        role="combobox"
+      >
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <div
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
+              data-test-subj="comboBoxInput"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              <p
+                className="euiComboBoxPlaceholder"
+              >
+                Select a table
+              </p>
+              <div
+                className="euiComboBox__input"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "fontSize": 14,
+                  }
+                }
+              >
+                <input
+                  aria-controls=""
+                  data-test-subj="comboBoxSearchInput"
+                  id="some_html_id"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="textbox"
+                  style={
+                    Object {
+                      "boxSizing": "content-box",
+                      "width": "2px",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                className="euiLoadingSpinner euiLoadingSpinner--medium"
+              />
+              <button
+                aria-label="Open list of options"
+                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                data-test-subj="comboBoxToggleListButton"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="some_html_id-help-0"
+      >
+        Select the Spark table that has the data you would like to index.
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
@@ -27,7 +27,7 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -35,7 +35,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Data source
       </label>
@@ -44,7 +44,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -80,7 +80,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -140,7 +140,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         A data source has to be configured and active to be able to select it and index data from.
       </div>
@@ -148,7 +148,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -156,7 +156,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Database
       </label>
@@ -165,7 +165,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -201,7 +201,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -261,7 +261,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the database that contains the tables you'd like to use.
       </div>
@@ -269,7 +269,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -277,7 +277,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Table
       </label>
@@ -286,7 +286,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -322,7 +322,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -382,7 +382,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the Spark table that has the data you would like to index.
       </div>
@@ -418,7 +418,7 @@ Array [
   />,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -426,7 +426,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Data source
       </label>
@@ -435,7 +435,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -471,7 +471,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -532,7 +532,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         A data source has to be configured and active to be able to select it and index data from.
       </div>
@@ -540,7 +540,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -548,7 +548,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Database
       </label>
@@ -557,7 +557,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -593,7 +593,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -654,7 +654,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the database that contains the tables you'd like to use.
       </div>
@@ -662,7 +662,7 @@ Array [
   </div>,
   <div
     className="euiFormRow"
-    id="some_html_id-row"
+    id="random_html_id-row"
   >
     <div
       className="euiFormRow__labelWrapper"
@@ -670,7 +670,7 @@ Array [
       <label
         aria-invalid={false}
         className="euiFormLabel euiFormRow__label"
-        htmlFor="some_html_id"
+        htmlFor="random_html_id"
       >
         Table
       </label>
@@ -679,7 +679,7 @@ Array [
       className="euiFormRow__fieldWrapper"
     >
       <div
-        aria-describedby="some_html_id-help-0"
+        aria-describedby="random_html_id-help-0"
         aria-expanded={false}
         aria-haspopup="listbox"
         className="euiComboBox"
@@ -693,7 +693,7 @@ Array [
             className="euiFormControlLayout__childrenWrapper"
           >
             <div
-              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
+              className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
               data-test-subj="comboBoxInput"
               onClick={[Function]}
               tabIndex={-1}
@@ -715,7 +715,7 @@ Array [
                 <input
                   aria-controls=""
                   data-test-subj="comboBoxSearchInput"
-                  id="some_html_id"
+                  id="random_html_id"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -746,9 +746,6 @@ Array [
             <div
               className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
             >
-              <span
-                className="euiLoadingSpinner euiLoadingSpinner--medium"
-              />
               <button
                 aria-label="Open list of options"
                 className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
@@ -779,7 +776,7 @@ Array [
       </div>
       <div
         className="euiFormHelpText euiFormRow__text"
-        id="some_html_id-help-0"
+        id="random_html_id-help-0"
       >
         Select the Spark table that has the data you would like to index.
       </div>

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/define_index_options.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/define_index_options.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import { createAccelerationEmptyDataMock } from '../../../../../../../../test/accelerations';
+import { DefineIndexOptions } from '../define_index_options';
+
+describe('Index options acceleration components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders acceleration index options with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <DefineIndexOptions
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders acceleration index options with covering index options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'covering',
+      accelerationIndexName: 'covering-idx',
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <DefineIndexOptions
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders acceleration index options with materialized index options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      accelerationIndexName: 'mv_metrics',
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <DefineIndexOptions
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/index_setting_options.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/index_setting_options.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import { createAccelerationEmptyDataMock } from '../../../../../../../../test/accelerations';
+import { IndexSettingOptions } from '../index_setting_options';
+
+describe('Index settings acceleration components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders acceleration index settings with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <IndexSettingOptions
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders acceleration index settings with different options1', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      primaryShardsCount: 1,
+      replicaShardsCount: 5,
+      refreshType: 'auto',
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <IndexSettingOptions
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders acceleration index settings with different options2', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      primaryShardsCount: 5,
+      replicaShardsCount: 1,
+      refreshType: 'interval',
+      refreshIntervalOptions: { refreshWindow: 1, refreshInterval: 'second' },
+      checkpointLocation: 's3://test/url',
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <IndexSettingOptions
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/index_type_selector.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/index_type_selector.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import { createAccelerationEmptyDataMock } from '../../../../../../../../test/accelerations';
+import { IndexTypeSelector } from '../index_type_selector';
+
+describe('Index type selector components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders type selector with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <IndexTypeSelector
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders type selector with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'covering',
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <IndexTypeSelector
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/source_selector.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/source_selector.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiComboBoxOptionOption } from '@elastic/eui';
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { coreMock } from '../../../../../../../../../../src/core/public/mocks';
+import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  mockDatasourcesQuery,
+} from '../../../../../../../../test/accelerations';
+import { AccelerationDataSourceSelector } from '../source_selector';
+
+const coreStartMock = coreMock.createStart();
+
+describe('Source selector components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders source selector with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const selectedDatasource: EuiComboBoxOptionOption[] = [];
+    const setAccelerationFormData = jest.fn();
+    const client = coreStartMock.http;
+    client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
+
+    const wrapper = mount(
+      <AccelerationDataSourceSelector
+        http={client}
+        selectedDatasource={selectedDatasource}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders source selector with different options', async () => {
+    const selectedDatasource: EuiComboBoxOptionOption[] = [{ label: 'ds' }];
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      dataSource: 'ds',
+      database: 'db',
+      dataTable: 'tb',
+    };
+    const setAccelerationFormData = jest.fn();
+    const client = httpClientMock;
+    client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
+    client.post = jest.fn().mockResolvedValue([]);
+    const wrapper = mount(
+      <AccelerationDataSourceSelector
+        selectedDatasource={selectedDatasource}
+        http={client}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/selectors/__tests__/source_selector.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/__tests__/source_selector.test.tsx
@@ -57,7 +57,7 @@ describe('Source selector components', () => {
       dataTable: 'tb',
     };
     const setAccelerationFormData = jest.fn();
-    const client = httpClientMock;
+    const client = coreStartMock.http;
     client.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
     client.post = jest.fn().mockResolvedValue([]);
     const wrapper = mount(

--- a/public/components/datasources/components/manage/accelerations/selectors/define_index_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/define_index_options.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiIconTip,
+  EuiLink,
+  EuiMarkdownFormat,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import producer from 'immer';
+import React, { ChangeEvent, useState } from 'react';
+import { ACCELERATION_INDEX_NAME_INFO } from '../../../../../../../common/constants/data_sources';
+import { CreateAccelerationForm } from '../../../../../../../common/types/data_connections';
+import { hasError, validateIndexName } from '../create/utils';
+
+interface DefineIndexOptionsProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const DefineIndexOptions = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: DefineIndexOptionsProps) => {
+  const [modalComponent, setModalComponent] = useState(<></>);
+
+  const modalValue = (
+    <EuiModal maxWidth={850} onClose={() => setModalComponent(<></>)}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <h1>Acceleration index naming</h1>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <EuiMarkdownFormat>{ACCELERATION_INDEX_NAME_INFO}</EuiMarkdownFormat>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton onClick={() => setModalComponent(<></>)} fill>
+          Close
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+
+  const onChangeIndexName = (e: ChangeEvent<HTMLInputElement>) => {
+    setAccelerationFormData({ ...accelerationFormData, accelerationIndexName: e.target.value });
+  };
+
+  const getPreprend = () => {
+    const dataSource =
+      accelerationFormData.dataSource !== ''
+        ? accelerationFormData.dataSource
+        : '{Datasource Name}';
+    const database =
+      accelerationFormData.database !== '' ? accelerationFormData.database : '{Database Name}';
+    const dataTable =
+      accelerationFormData.dataTable !== '' ? accelerationFormData.dataTable : '{Table Name}';
+    const prependValue =
+      accelerationFormData.accelerationIndexType === 'materialized'
+        ? `flint_${dataSource}_${database}_`
+        : `flint_${dataSource}_${database}_${dataTable}_`;
+    return [
+      prependValue,
+      <EuiIconTip type="iInCircle" color="subdued" content={prependValue} position="top" />,
+    ];
+  };
+
+  const getAppend = () => {
+    const appendValue =
+      accelerationFormData.accelerationIndexType === 'materialized' ? '' : '_index';
+    return appendValue;
+  };
+
+  return (
+    <>
+      <EuiText data-test-subj="define-index-header">
+        <h3>Index settings</h3>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiFormRow
+        label="Index name"
+        helpText='Must be in lowercase letters. Cannot begin with underscores. Spaces, commas, and characters -, :, ", *, +, /, \, |, ?, #, >, or < are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.'
+        isInvalid={hasError(accelerationFormData.formErrors, 'indexNameError')}
+        error={accelerationFormData.formErrors.indexNameError}
+        labelAppend={
+          <EuiText size="xs">
+            <EuiLink onClick={() => setModalComponent(modalValue)}>Help</EuiLink>
+          </EuiText>
+        }
+      >
+        <EuiFieldText
+          placeholder="Enter index name"
+          value={accelerationFormData.accelerationIndexName}
+          onChange={onChangeIndexName}
+          aria-label="Enter Index Name"
+          prepend={getPreprend()}
+          append={getAppend()}
+          disabled={accelerationFormData.accelerationIndexType === 'skipping'}
+          isInvalid={hasError(accelerationFormData.formErrors, 'indexNameError')}
+          onBlur={(e) => {
+            setAccelerationFormData(
+              producer((accData) => {
+                accData.formErrors.indexNameError = validateIndexName(e.target.value);
+              })
+            );
+          }}
+        />
+      </EuiFormRow>
+      {modalComponent}
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/selectors/index_setting_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/index_setting_options.tsx
@@ -1,0 +1,313 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFormRow,
+  EuiRadioGroup,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import producer from 'immer';
+import React, { ChangeEvent, useState } from 'react';
+import { ACCELERATION_TIME_INTERVAL } from '../../../../../../../common/constants/data_sources';
+import {
+  AccelerationRefreshType,
+  CreateAccelerationForm,
+} from '../../../../../../../common/types/data_connections';
+import {
+  hasError,
+  validateCheckpointLocation,
+  validatePrimaryShardCount,
+  validateRefreshInterval,
+  validateReplicaCount,
+  validateWatermarkDelay,
+} from '../create/utils';
+import { IndexTypeSelector } from './index_type_selector';
+
+interface IndexSettingOptionsProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const IndexSettingOptions = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: IndexSettingOptionsProps) => {
+  const autoRefreshId = 'refresh-option-1';
+  const intervalRefreshId = 'refresh-option-2';
+  const manualRefreshId = 'refresh-option-3';
+  const refreshOptions = [
+    {
+      id: autoRefreshId,
+      label: 'Auto refresh',
+    },
+    {
+      id: intervalRefreshId,
+      label: 'Auto refresh by interval',
+    },
+    {
+      id: manualRefreshId,
+      label: 'Manual refresh',
+    },
+  ];
+
+  const [primaryShards, setPrimaryShards] = useState(5);
+  const [replicaCount, setReplicaCount] = useState(1);
+  const [refreshTypeSelected, setRefreshTypeSelected] = useState(autoRefreshId);
+  const [refreshWindow, setRefreshWindow] = useState(1);
+  const [refreshInterval, setRefreshInterval] = useState(ACCELERATION_TIME_INTERVAL[1].value);
+  const [delayWindow, setDelayWindow] = useState(1);
+  const [delayInterval, setDelayInterval] = useState(ACCELERATION_TIME_INTERVAL[1].value);
+  const [checkpoint, setCheckpoint] = useState('');
+
+  const onChangePrimaryShards = (e: ChangeEvent<HTMLInputElement>) => {
+    const countPrimaryShards = parseInt(e.target.value, 10);
+    setAccelerationFormData({ ...accelerationFormData, primaryShardsCount: countPrimaryShards });
+    setPrimaryShards(countPrimaryShards);
+  };
+
+  const onChangeReplicaCount = (e: ChangeEvent<HTMLInputElement>) => {
+    const parsedReplicaCount = parseInt(e.target.value, 10);
+    setAccelerationFormData({ ...accelerationFormData, replicaShardsCount: parsedReplicaCount });
+    setReplicaCount(parsedReplicaCount);
+  };
+
+  const onChangeRefreshType = (optionId: React.SetStateAction<string>) => {
+    let refreshOption: AccelerationRefreshType = 'auto';
+    switch (optionId) {
+      case autoRefreshId:
+        refreshOption = 'auto';
+        break;
+      case intervalRefreshId:
+        refreshOption = 'interval';
+        break;
+      case manualRefreshId:
+        refreshOption = 'manual';
+        break;
+    }
+    setAccelerationFormData({
+      ...accelerationFormData,
+      refreshType: refreshOption,
+    });
+    setRefreshTypeSelected(optionId);
+  };
+
+  const onChangeRefreshWindow = (e: ChangeEvent<HTMLInputElement>) => {
+    const windowCount = parseInt(e.target.value, 10);
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.refreshIntervalOptions.refreshWindow = windowCount;
+      })
+    );
+    setRefreshWindow(windowCount);
+  };
+
+  const onChangeDelayWindow = (e: ChangeEvent<HTMLInputElement>) => {
+    const windowCount = parseInt(e.target.value, 10);
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.watermarkDelay.delayWindow = windowCount;
+      })
+    );
+    setDelayWindow(windowCount);
+  };
+
+  const onChangeRefreshInterval = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const refreshIntervalValue = e.target.value;
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.refreshIntervalOptions.refreshInterval = refreshIntervalValue;
+      })
+    );
+    setRefreshInterval(refreshIntervalValue);
+  };
+
+  const onChangeDelayInterval = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const delayIntervalValue = e.target.value;
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.watermarkDelay.delayInterval = delayIntervalValue;
+      })
+    );
+    setDelayInterval(delayIntervalValue);
+  };
+
+  const onChangeCheckpoint = (e: ChangeEvent<HTMLInputElement>) => {
+    const checkpointLocation = e.target.value;
+    setAccelerationFormData({ ...accelerationFormData, checkpointLocation });
+    setCheckpoint(checkpointLocation);
+  };
+
+  return (
+    <>
+      <EuiText data-test-subj="index-settings-header">
+        <h3>Index settings</h3>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <IndexTypeSelector
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+      <EuiFormRow
+        label="Number of primary shards"
+        helpText="Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created."
+        isInvalid={hasError(accelerationFormData.formErrors, 'primaryShardsError')}
+        error={accelerationFormData.formErrors.primaryShardsError}
+      >
+        <EuiFieldNumber
+          placeholder="Number of primary shards"
+          value={primaryShards}
+          onChange={onChangePrimaryShards}
+          aria-label="Number of primary shards"
+          min={1}
+          max={100}
+          onBlur={(e) => {
+            setAccelerationFormData(
+              producer((accData) => {
+                accData.formErrors.primaryShardsError = validatePrimaryShardCount(
+                  parseInt(e.target.value, 10)
+                );
+              })
+            );
+          }}
+          isInvalid={hasError(accelerationFormData.formErrors, 'primaryShardsError')}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label="Number of replicas"
+        helpText="Specify the number of replicas each primary shard should have."
+        isInvalid={hasError(accelerationFormData.formErrors, 'replicaShardsError')}
+        error={accelerationFormData.formErrors.replicaShardsError}
+      >
+        <EuiFieldNumber
+          placeholder="Number of replicas"
+          value={replicaCount}
+          onChange={onChangeReplicaCount}
+          aria-label="Number of replicas"
+          min={0}
+          max={100}
+          onBlur={(e) => {
+            setAccelerationFormData(
+              producer((accData) => {
+                accData.formErrors.replicaShardsError = validateReplicaCount(
+                  parseInt(e.target.value, 10)
+                );
+              })
+            );
+          }}
+          isInvalid={hasError(accelerationFormData.formErrors, 'replicaShardsError')}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label="Refresh type"
+        helpText="Specify how often the index should refresh, which publishes the most recent changes and make them available for search."
+      >
+        <EuiRadioGroup
+          options={refreshOptions}
+          idSelected={refreshTypeSelected}
+          onChange={onChangeRefreshType}
+          name="refresh type radio group"
+        />
+      </EuiFormRow>
+      {refreshTypeSelected === intervalRefreshId && (
+        <EuiFormRow
+          label="Refresh interval"
+          helpText="Specify how often the index should refresh, which publishes the most recent changes and make them available for search"
+          isInvalid={hasError(accelerationFormData.formErrors, 'refreshIntervalError')}
+          error={accelerationFormData.formErrors.refreshIntervalError}
+        >
+          <EuiFieldNumber
+            placeholder="Refresh interval"
+            value={refreshWindow}
+            onChange={onChangeRefreshWindow}
+            aria-label="Refresh interval"
+            min={1}
+            isInvalid={hasError(accelerationFormData.formErrors, 'refreshIntervalError')}
+            onBlur={(e) => {
+              setAccelerationFormData(
+                producer((accData) => {
+                  accData.formErrors.refreshIntervalError = validateRefreshInterval(
+                    refreshTypeSelected,
+                    parseInt(e.target.value, 10)
+                  );
+                })
+              );
+            }}
+            append={
+              <EuiSelect
+                value={refreshInterval}
+                onChange={onChangeRefreshInterval}
+                options={ACCELERATION_TIME_INTERVAL}
+              />
+            }
+          />
+        </EuiFormRow>
+      )}
+      {refreshTypeSelected !== manualRefreshId && (
+        <EuiFormRow
+          label="Checkpoint location"
+          helpText="The HDFS compatible file system location path for incremental refresh job checkpoint."
+          isInvalid={hasError(accelerationFormData.formErrors, 'checkpointLocationError')}
+          error={accelerationFormData.formErrors.checkpointLocationError}
+        >
+          <EuiFieldText
+            placeholder="s3://checkpoint/location"
+            value={checkpoint}
+            onChange={onChangeCheckpoint}
+            aria-label="Use aria labels when no actual label is in use"
+            isInvalid={hasError(accelerationFormData.formErrors, 'checkpointLocationError')}
+            onBlur={(e) => {
+              setAccelerationFormData(
+                producer((accData) => {
+                  accData.formErrors.checkpointLocationError = validateCheckpointLocation(
+                    accData.refreshType,
+                    e.target.value
+                  );
+                })
+              );
+            }}
+          />
+        </EuiFormRow>
+      )}
+      {accelerationFormData.accelerationIndexType === 'materialized' && (
+        <EuiFormRow
+          label="Watermark Delay"
+          helpText="Data arrival delay for incremental refresh on a materialized view with aggregations"
+          isInvalid={hasError(accelerationFormData.formErrors, 'watermarkDelayError')}
+          error={accelerationFormData.formErrors.watermarkDelayError}
+        >
+          <EuiFieldNumber
+            placeholder="Watermark delay interval"
+            value={delayWindow}
+            onChange={onChangeDelayWindow}
+            aria-label="Watermark delay interval"
+            min={1}
+            isInvalid={hasError(accelerationFormData.formErrors, 'watermarkDelayError')}
+            onBlur={(e) => {
+              setAccelerationFormData(
+                producer((accData) => {
+                  accData.formErrors.watermarkDelayError = validateWatermarkDelay(
+                    accelerationFormData.accelerationIndexType,
+                    parseInt(e.target.value, 10)
+                  );
+                })
+              );
+            }}
+            append={
+              <EuiSelect
+                value={delayInterval}
+                onChange={onChangeDelayInterval}
+                options={ACCELERATION_TIME_INTERVAL}
+              />
+            }
+          />
+        </EuiFormRow>
+      )}
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/index_type_selector.tsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 import {
   ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
   ACCELERATION_INDEX_TYPES,
+  ACC_INDEX_TYPE_DOCUMENTATION_URL,
 } from '../../../../../../../common/constants/data_sources';
 import {
   AccelerationIndexType,
@@ -27,7 +28,7 @@ export const IndexTypeSelector = ({
   const [selectedIndexType, setSelectedIndexType] = useState<
     Array<EuiComboBoxOptionOption<string>>
   >([ACCELERATION_INDEX_TYPES[0]]);
-  // const [loading, setLoading] = useState(false);
+  const [loading, _setLoading] = useState(false);
 
   // useEffect(() => {
   //   if (accelerationFormData.dataTable !== '') {

--- a/public/components/datasources/components/manage/accelerations/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/index_type_selector.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow, EuiLink, EuiText } from '@elastic/eui';
+import React, { useState } from 'react';
+import {
+  ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+  ACCELERATION_INDEX_TYPES,
+} from '../../../../../../../common/constants/data_sources';
+import {
+  AccelerationIndexType,
+  CreateAccelerationForm,
+} from '../../../../../../../common/types/data_connections';
+// import { executeAsyncQuery } from '../../../../common/utils/async_query_helpers';
+
+interface IndexTypeSelectorProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const IndexTypeSelector = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: IndexTypeSelectorProps) => {
+  const [selectedIndexType, setSelectedIndexType] = useState<
+    Array<EuiComboBoxOptionOption<string>>
+  >([ACCELERATION_INDEX_TYPES[0]]);
+  // const [loading, setLoading] = useState(false);
+
+  // useEffect(() => {
+  //   if (accelerationFormData.dataTable !== '') {
+  //     setLoading(true);
+  //     const idPrefix = htmlIdGenerator()();
+  //     const query = {
+  //       lang: 'sql',
+  //       query: `DESC \`${accelerationFormData.dataSource}\`.\`${accelerationFormData.database}\`.\`${accelerationFormData.dataTable}\``,
+  //       datasource: accelerationFormData.dataSource,
+  //     };
+
+  //     executeAsyncQuery(
+  //       accelerationFormData.dataSource,
+  //       query,
+  //       (response: AsyncApiResponse) => {
+  //         const status = response.data.resp.status.toLowerCase();
+  //         if (status === AsyncQueryStatus.Success) {
+  //           const dataTableFields: DataTableFieldsType[] = response.data.resp.datarows
+  //             .filter((row) => !row[0].startsWith('#'))
+  //             .map((row, index) => ({
+  //               id: `${idPrefix}${index + 1}`,
+  //               fieldName: row[0],
+  //               dataType: row[1],
+  //             }));
+  //           setAccelerationFormData({
+  //             ...accelerationFormData,
+  //             dataTableFields,
+  //           });
+  //           setLoading(false);
+  //         }
+  //         if (status === AsyncQueryStatus.Failed || status === AsyncQueryStatus.Cancelled) {
+  //           setLoading(false);
+  //         }
+  //       },
+  //       () => setLoading(false)
+  //     );
+  //   }
+  // }, [accelerationFormData.dataTable]);
+
+  const onChangeIndexType = (indexTypeOption: Array<EuiComboBoxOptionOption<string>>) => {
+    const indexType = indexTypeOption[0].value as AccelerationIndexType;
+    setAccelerationFormData({
+      ...accelerationFormData,
+      accelerationIndexType: indexType,
+      accelerationIndexName:
+        indexType === 'skipping' ? ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME : '',
+    });
+    setSelectedIndexType(indexTypeOption);
+  };
+  return (
+    <>
+      <EuiFormRow
+        label="Index type"
+        helpText="Select the type of index you want to create. Each index type has benefits and costs."
+        labelAppend={
+          <EuiText size="xs">
+            <EuiLink href={ACC_INDEX_TYPE_DOCUMENTATION_URL} target="_blank">
+              Help
+            </EuiLink>
+          </EuiText>
+        }
+      >
+        <EuiComboBox
+          placeholder="Select an index type"
+          singleSelection={{ asPlainText: true }}
+          options={ACCELERATION_INDEX_TYPES}
+          selectedOptions={selectedIndexType}
+          onChange={onChangeIndexType}
+          isInvalid={selectedIndexType.length === 0}
+          isClearable={false}
+          isLoading={loading}
+        />
+      </EuiFormRow>
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/source_selector.tsx
@@ -32,11 +32,11 @@ export const AccelerationDataSourceSelector = ({
   const [selectedDataConnection, setSelectedDataConnection] = useState<
     Array<EuiComboBoxOptionOption<string>>
   >(selectedDatasource.length > 0 ? [{ label: selectedDatasource[0].label }] : []);
-  // const [databases, setDatabases] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
+  const [databases, _setDatabases] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const [selectedDatabase, setSelectedDatabase] = useState<Array<EuiComboBoxOptionOption<string>>>(
     []
   );
-  // const [tables, setTables] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
+  const [tables, _setTables] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const [selectedTable, setSelectedTable] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
   const [loadingComboBoxes, setLoadingComboBoxes] = useState({
     dataSource: false,

--- a/public/components/datasources/components/manage/accelerations/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/selectors/source_selector.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiComboBox, EuiComboBoxOptionOption, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
+import producer from 'immer';
+import React, { useEffect, useState } from 'react';
+// import { executeAsyncQuery } from '../../../../common/utils/async_query_helpers';
+import { CoreStart } from '../../../../../../../../../src/core/public';
+import { CreateAccelerationForm } from '../../../../../../../common/types/data_connections';
+import { useToast } from '../../../../../common/toast';
+import { hasError, validateDataSource } from '../create/utils';
+
+interface AccelerationDataSourceSelectorProps {
+  http: CoreStart['http'];
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+  selectedDatasource: EuiComboBoxOptionOption[];
+}
+
+export const AccelerationDataSourceSelector = ({
+  http,
+  accelerationFormData,
+  setAccelerationFormData,
+  selectedDatasource,
+}: AccelerationDataSourceSelectorProps) => {
+  const { setToast } = useToast();
+  const [dataConnections, setDataConnections] = useState<Array<EuiComboBoxOptionOption<string>>>(
+    []
+  );
+  const [selectedDataConnection, setSelectedDataConnection] = useState<
+    Array<EuiComboBoxOptionOption<string>>
+  >(selectedDatasource.length > 0 ? [{ label: selectedDatasource[0].label }] : []);
+  // const [databases, setDatabases] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
+  const [selectedDatabase, setSelectedDatabase] = useState<Array<EuiComboBoxOptionOption<string>>>(
+    []
+  );
+  // const [tables, setTables] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
+  const [selectedTable, setSelectedTable] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
+  const [loadingComboBoxes, setLoadingComboBoxes] = useState({
+    dataSource: false,
+    database: false,
+    dataTable: false,
+  });
+
+  const loadDataSource = () => {
+    setLoadingComboBoxes({ ...loadingComboBoxes, dataSource: true });
+    http
+      .get(`/api/get_datasources`)
+      .then((res) => {
+        const data = res.data.resp;
+        setDataConnections(
+          data
+            .filter((connection: any) => connection.connector.toUpperCase() === 'S3GLUE')
+            .map((connection: any) => ({ label: connection.name }))
+        );
+      })
+      .catch((err) => {
+        console.error(err);
+        setToast(`ERROR: failed to load datasources`, 'danger');
+      });
+    setLoadingComboBoxes({ ...loadingComboBoxes, dataSource: false });
+  };
+
+  const loadDatabases = () => {
+    // setLoadingComboBoxes({ ...loadingComboBoxes, database: true });
+    // const query = {
+    //   lang: 'sql',
+    //   query: `SHOW SCHEMAS IN \`${accelerationFormData.dataSource}\``,
+    //   datasource: accelerationFormData.dataSource,
+    // };
+    // executeAsyncQuery(
+    //   accelerationFormData.dataSource,
+    //   query,
+    //   (response: AsyncApiResponse) => {
+    //     const status = response.data.resp.status.toLowerCase();
+    //     if (status === AsyncQueryStatus.Success) {
+    //       let databaseOptions: Array<EuiComboBoxOptionOption<string>> = [];
+    //       if (response.data.resp.datarows.length > 0)
+    //         databaseOptions = response.data.resp.datarows.map((subArray: any[]) => ({
+    //           label: subArray[0],
+    //         }));
+    //       setDatabases(databaseOptions);
+    //       setLoadingComboBoxes({ ...loadingComboBoxes, database: false });
+    //     }
+    //     if (status === AsyncQueryStatus.Failed || status === AsyncQueryStatus.Cancelled) {
+    //       setLoadingComboBoxes({ ...loadingComboBoxes, database: false });
+    //     }
+    //   },
+    //   () => setLoadingComboBoxes({ ...loadingComboBoxes, database: false })
+    // );
+  };
+
+  const loadTables = () => {
+    // setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: true });
+    // const query = {
+    //   lang: 'sql',
+    //   query: `SHOW TABLES IN \`${accelerationFormData.dataSource}\`.\`${accelerationFormData.database}\``,
+    //   datasource: accelerationFormData.dataSource,
+    // };
+    // executeAsyncQuery(
+    //   accelerationFormData.dataSource,
+    //   query,
+    //   (response: AsyncApiResponse) => {
+    //     const status = response.data.resp.status.toLowerCase();
+    //     if (status === AsyncQueryStatus.Success) {
+    //       let dataTableOptions: Array<EuiComboBoxOptionOption<string>> = [];
+    //       if (response.data.resp.datarows.length > 0)
+    //         dataTableOptions = response.data.resp.datarows.map((subArray) => ({
+    //           label: subArray[1],
+    //         }));
+    //       setTables(dataTableOptions);
+    //       setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: false });
+    //     }
+    //     if (status === AsyncQueryStatus.Failed || status === AsyncQueryStatus.Cancelled) {
+    //       setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: false });
+    //     }
+    //   },
+    //   () => setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: false })
+    // );
+  };
+
+  useEffect(() => {
+    loadDataSource();
+  }, []);
+
+  useEffect(() => {
+    if (accelerationFormData.dataSource !== '') {
+      loadDatabases();
+    }
+  }, [accelerationFormData.dataSource]);
+
+  useEffect(() => {
+    if (accelerationFormData.database !== '') {
+      loadTables();
+    }
+  }, [accelerationFormData.database]);
+
+  return (
+    <>
+      <EuiText data-test-subj="datasource-selector-header">
+        <h3>Select data source</h3>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        Select the data source to accelerate data from. External data sources may take time to load.
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiFormRow
+        label="Data source"
+        helpText="A data source has to be configured and active to be able to select it and index data from."
+        isInvalid={hasError(accelerationFormData.formErrors, 'dataSourceError')}
+        error={accelerationFormData.formErrors.dataSourceError}
+      >
+        <EuiComboBox
+          placeholder="Select a data source"
+          singleSelection={{ asPlainText: true }}
+          options={dataConnections}
+          selectedOptions={selectedDataConnection}
+          onChange={(dataConnectionOptions) => {
+            if (dataConnectionOptions.length > 0) {
+              setAccelerationFormData(
+                producer((accData) => {
+                  accData.dataSource = dataConnectionOptions[0].label;
+                  accData.formErrors.dataSourceError = validateDataSource(
+                    dataConnectionOptions[0].label
+                  );
+                })
+              );
+              setSelectedDataConnection(dataConnectionOptions);
+            }
+          }}
+          isClearable={false}
+          isInvalid={hasError(accelerationFormData.formErrors, 'dataSourceError')}
+          isLoading={loadingComboBoxes.dataSource}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label="Database"
+        helpText="Select the database that contains the tables you'd like to use."
+        isInvalid={hasError(accelerationFormData.formErrors, 'databaseError')}
+        error={accelerationFormData.formErrors.databaseError}
+      >
+        <EuiComboBox
+          placeholder="Select a database"
+          singleSelection={{ asPlainText: true }}
+          options={databases}
+          selectedOptions={selectedDatabase}
+          onChange={(databaseOptions) => {
+            if (databaseOptions.length > 0) {
+              setAccelerationFormData(
+                producer((accData) => {
+                  accData.database = databaseOptions[0].label;
+                  accData.formErrors.databaseError = validateDataSource(databaseOptions[0].label);
+                })
+              );
+              setSelectedDatabase(databaseOptions);
+            }
+          }}
+          isClearable={false}
+          isInvalid={hasError(accelerationFormData.formErrors, 'databaseError')}
+          isLoading={loadingComboBoxes.database}
+        />
+      </EuiFormRow>
+      <EuiFormRow
+        label="Table"
+        helpText="Select the Spark table that has the data you would like to index."
+        isInvalid={hasError(accelerationFormData.formErrors, 'dataTableError')}
+        error={accelerationFormData.formErrors.dataTableError}
+      >
+        <EuiComboBox
+          placeholder="Select a table"
+          singleSelection={{ asPlainText: true }}
+          options={tables}
+          selectedOptions={selectedTable}
+          onChange={(tableOptions) => {
+            if (tableOptions.length > 0) {
+              setAccelerationFormData(
+                producer((accData) => {
+                  accData.dataTable = tableOptions[0].label;
+                  accData.formErrors.dataTableError = validateDataSource(tableOptions[0].label);
+                })
+              );
+              setSelectedTable(tableOptions);
+            }
+          }}
+          isClearable={false}
+          isInvalid={hasError(accelerationFormData.formErrors, 'dataTableError')}
+          isLoading={loadingComboBoxes.dataTable}
+        />
+      </EuiFormRow>
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
@@ -1,0 +1,1130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Visual builder components renders visual builder with covering index options 1`] = `
+Array [
+  <div
+    className="euiSpacer euiSpacer--l"
+  />,
+  Array [
+    <div
+      className="euiText euiText--medium"
+      data-test-subj="covering-index-builder"
+    >
+      <h3>
+        Covering index definition
+      </h3>
+    </div>,
+    <div
+      className="euiSpacer euiSpacer--s"
+    />,
+    <div
+      className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+    >
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <span
+          className="euiExpression euiExpression-isUppercase euiExpression--success"
+        >
+          <span
+            className="euiExpression__description"
+          >
+            CREATE INDEX
+          </span>
+           
+          <span
+            className="euiExpression__value"
+          >
+            cv-idx
+          </span>
+        </span>
+      </div>
+      <div
+        className="euiFlexItem"
+      >
+        <span
+          className="euiExpression euiExpression-isUppercase euiExpression--accent"
+        >
+          <span
+            className="euiExpression__description"
+          >
+            ON
+          </span>
+           
+          <span
+            className="euiExpression__value"
+          >
+            ..
+          </span>
+        </span>
+        <div
+          className="euiPopover euiPopover--anchorDownLeft"
+          id="coveringIndexFieldsPopOver"
+        >
+          <div
+            className="euiPopover__anchor"
+          >
+            <button
+              className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+              onClick={[Function]}
+            >
+              <span
+                className="euiExpression__description"
+              />
+               
+              <span
+                className="euiExpression__value"
+              >
+                (add fields here)
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+  ],
+]
+`;
+
+exports[`Visual builder components renders visual builder with default options 1`] = `
+Array [
+  <div
+    className="euiSpacer euiSpacer--l"
+  />,
+  Array [
+    <div
+      className="euiText euiText--medium"
+      data-test-subj="skipping-index-builder"
+    >
+      <h3>
+        Skipping index definition
+      </h3>
+    </div>,
+    <div
+      className="euiSpacer euiSpacer--s"
+    />,
+    <div
+      className="euiBasicTable"
+      itemID="id"
+    >
+      <div>
+        <div
+          className="euiTableHeaderMobile"
+        >
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            />
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            />
+          </div>
+        </div>
+        <table
+          className="euiTable euiTable--responsive"
+          id="some_html_id"
+          tabIndex={-1}
+        >
+          <caption
+            className="euiScreenReaderOnly euiTableCaption"
+          />
+          <thead>
+            <tr>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_fieldName_0"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Field name"
+                  >
+                    Field name
+                  </span>
+                </span>
+              </th>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_dataType_1"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Datatype"
+                  >
+                    Datatype
+                  </span>
+                </span>
+              </th>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_Acceleration method_2"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Acceleration method"
+                  >
+                    Acceleration method
+                  </span>
+                </span>
+              </th>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_Delete_3"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Delete"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              className="euiTableRow"
+            >
+              <td
+                className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                colSpan={4}
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                  >
+                    No items found
+                  </span>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>,
+    <div
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+    >
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          className="euiButton euiButton--primary euiButton--fill"
+          disabled={false}
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          type="button"
+        >
+          <span
+            className="euiButtonContent euiButton__content"
+          >
+            <span
+              className="euiButton__text"
+            >
+              Add fields
+            </span>
+          </span>
+        </button>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          className="euiButton euiButton--danger"
+          disabled={false}
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          type="button"
+        >
+          <span
+            className="euiButtonContent euiButton__content"
+          >
+            <span
+              className="euiButton__text"
+            >
+              Bulk delete
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>,
+  ],
+]
+`;
+
+exports[`Visual builder components renders visual builder with materialized view options 1`] = `
+Array [
+  <div
+    className="euiSpacer euiSpacer--l"
+  />,
+  Array [
+    <div
+      className="euiText euiText--medium"
+      data-test-subj="covering-index-builder"
+    >
+      <h3>
+        Materialized view definition
+      </h3>
+    </div>,
+    <div
+      className="euiSpacer euiSpacer--s"
+    />,
+    <span
+      className="euiExpression euiExpression-isUppercase euiExpression--success"
+    >
+      <span
+        className="euiExpression__description"
+      >
+        CREATE MATERIALIZED VIEW
+      </span>
+       
+      <span
+        className="euiExpression__value"
+      >
+        ..skipping
+      </span>
+    </span>,
+    <div
+      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <span
+          className="euiExpression euiExpression-isUppercase euiExpression--accent"
+        >
+          <span
+            className="euiExpression__description"
+          >
+            AS SELECT
+          </span>
+           
+        </span>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <div
+          className="euiPopover euiPopover--anchorDownCenter"
+        >
+          <div
+            className="euiPopover__anchor"
+          >
+            <button
+              aria-label="add column"
+              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="euiButtonContent euiButtonEmpty__content"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+                <span
+                  className="euiButtonEmpty__text"
+                >
+                  Add Column
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    <div
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+    />,
+    <div
+      className="euiSpacer euiSpacer--s"
+    />,
+    <span
+      className="euiExpression euiExpression-isUppercase euiExpression--success"
+    >
+      <span
+        className="euiExpression__description"
+      >
+        FROM
+      </span>
+       
+      <span
+        className="euiExpression__value"
+      >
+        ..
+      </span>
+    </span>,
+    <div
+      className="euiSpacer euiSpacer--s"
+    />,
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="groupByTumblePopOver"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            >
+              GROUP BY
+            </span>
+             
+            <span
+              className="euiExpression__value"
+            >
+              TUMBLE(, '1 millisecond')
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>,
+  ],
+]
+`;
+
+exports[`Visual builder components renders visual builder with skipping index options 1`] = `
+Array [
+  <div
+    className="euiSpacer euiSpacer--l"
+  />,
+  Array [
+    <div
+      className="euiText euiText--medium"
+      data-test-subj="skipping-index-builder"
+    >
+      <h3>
+        Skipping index definition
+      </h3>
+    </div>,
+    <div
+      className="euiSpacer euiSpacer--s"
+    />,
+    <div
+      className="euiBasicTable"
+      itemID="id"
+    >
+      <div>
+        <div
+          className="euiTableHeaderMobile"
+        >
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            />
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            />
+          </div>
+        </div>
+        <table
+          className="euiTable euiTable--responsive"
+          id="some_html_id"
+          tabIndex={-1}
+        >
+          <caption
+            className="euiScreenReaderOnly euiTableCaption"
+          />
+          <thead>
+            <tr>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_fieldName_0"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Field name"
+                  >
+                    Field name
+                  </span>
+                </span>
+              </th>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_dataType_1"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Datatype"
+                  >
+                    Datatype
+                  </span>
+                </span>
+              </th>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_Acceleration method_2"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Acceleration method"
+                  >
+                    Acceleration method
+                  </span>
+                </span>
+              </th>
+              <th
+                className="euiTableHeaderCell"
+                data-test-subj="tableHeaderCell_Delete_3"
+                role="columnheader"
+                scope="col"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <span
+                  className="euiTableCellContent"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                    title="Delete"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              className="euiTableRow euiTableRow-hasActions"
+            >
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Field name
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--truncateText"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                  >
+                    field1
+                  </span>
+                </div>
+              </td>
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Datatype
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--truncateText"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                  >
+                    string
+                  </span>
+                </div>
+              </td>
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Acceleration method
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                >
+                  <div
+                    className="euiFormControlLayout"
+                  >
+                    <div
+                      className="euiFormControlLayout__childrenWrapper"
+                    >
+                      <select
+                        aria-label="Use aria labels when no actual label is in use"
+                        className="euiSelect"
+                        id="selectDocExample"
+                        onChange={[Function]}
+                        onMouseUp={[Function]}
+                        value="PARTITION"
+                      >
+                        <option
+                          key="0"
+                          value="PARTITION"
+                        >
+                          Partition
+                        </option>
+                        <option
+                          key="1"
+                          value="VALUE_SET"
+                        >
+                          Value Set
+                        </option>
+                        <option
+                          key="2"
+                          value="MIN_MAX"
+                        >
+                          Min Max
+                        </option>
+                      </select>
+                      <div
+                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <span
+                          className="euiFormControlLayoutCustomIcon"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Delete
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                >
+                  <button
+                    className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                      focusable="false"
+                      height={16}
+                      role="img"
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              className="euiTableRow euiTableRow-hasActions"
+            >
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Field name
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--truncateText"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                  >
+                    field2
+                  </span>
+                </div>
+              </td>
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Datatype
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--truncateText"
+                >
+                  <span
+                    className="euiTableCellContent__text"
+                  >
+                    number
+                  </span>
+                </div>
+              </td>
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Acceleration method
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                >
+                  <div
+                    className="euiFormControlLayout"
+                  >
+                    <div
+                      className="euiFormControlLayout__childrenWrapper"
+                    >
+                      <select
+                        aria-label="Use aria labels when no actual label is in use"
+                        className="euiSelect"
+                        id="selectDocExample"
+                        onChange={[Function]}
+                        onMouseUp={[Function]}
+                        value="VALUE_SET"
+                      >
+                        <option
+                          key="0"
+                          value="PARTITION"
+                        >
+                          Partition
+                        </option>
+                        <option
+                          key="1"
+                          value="VALUE_SET"
+                        >
+                          Value Set
+                        </option>
+                        <option
+                          key="2"
+                          value="MIN_MAX"
+                        >
+                          Min Max
+                        </option>
+                      </select>
+                      <div
+                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <span
+                          className="euiFormControlLayoutCustomIcon"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td
+                className="euiTableRowCell"
+                style={
+                  Object {
+                    "width": undefined,
+                  }
+                }
+              >
+                <div
+                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Delete
+                </div>
+                <div
+                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                >
+                  <button
+                    className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                      focusable="false"
+                      height={16}
+                      role="img"
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              className="euiPopover euiPopover--anchorUpRight"
+            >
+              <div
+                className="euiPopover__anchor"
+              >
+                <button
+                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                  data-test-subj="tablePaginationPopoverButton"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                      focusable="false"
+                      height={16}
+                      role="img"
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                    <span
+                      className="euiButtonEmpty__text"
+                    >
+                      Rows per page
+                      : 
+                      20
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <nav
+              className="euiPagination"
+            >
+              <button
+                aria-label="Previous page"
+                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                data-test-subj="pagination-button-previous"
+                disabled={true}
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+              <ul
+                className="euiPagination__list"
+              >
+                <li
+                  className="euiPagination__item"
+                >
+                  <button
+                    aria-controls="some_html_id"
+                    aria-current={true}
+                    aria-label="Page 1 of 1"
+                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                    data-test-subj="pagination-button-0"
+                    disabled={true}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiButtonContent euiButtonEmpty__content"
+                    >
+                      <span
+                        className="euiButtonEmpty__text"
+                      >
+                        1
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              </ul>
+              <button
+                aria-label="Next page"
+                className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                data-test-subj="pagination-button-next"
+                disabled={true}
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>,
+    <div
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+    >
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          className="euiButton euiButton--primary euiButton--fill"
+          disabled={false}
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          type="button"
+        >
+          <span
+            className="euiButtonContent euiButton__content"
+          >
+            <span
+              className="euiButton__text"
+            >
+              Add fields
+            </span>
+          </span>
+        </button>
+      </div>
+      <div
+        className="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          className="euiButton euiButton--danger"
+          disabled={false}
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
+          }
+          type="button"
+        >
+          <span
+            className="euiButtonContent euiButton__content"
+          >
+            <span
+              className="euiButton__text"
+            >
+              Bulk delete
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>,
+  ],
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
@@ -124,7 +124,7 @@ Array [
         </div>
         <table
           className="euiTable euiTable--responsive"
-          id="some_html_id"
+          id="random_html_id"
           tabIndex={-1}
         >
           <caption
@@ -497,7 +497,7 @@ Array [
         </div>
         <table
           className="euiTable euiTable--responsive"
-          id="some_html_id"
+          id="random_html_id"
           tabIndex={-1}
         >
           <caption
@@ -1021,7 +1021,7 @@ Array [
                   className="euiPagination__item"
                 >
                   <button
-                    aria-controls="some_html_id"
+                    aria-controls="random_html_id"
                     aria-current={true}
                     aria-label="Page 1 of 1"
                     className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"

--- a/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/query_builder.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/query_builder.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  coveringIndexBuilderMock1,
+  coveringIndexBuilderMock2,
+  coveringIndexBuilderMockResult1,
+  coveringIndexBuilderMockResult2,
+  indexOptionsMock1,
+  indexOptionsMock2,
+  indexOptionsMock3,
+  indexOptionsMock4,
+  indexOptionsMock5,
+  indexOptionsMock6,
+  indexOptionsMockResult1,
+  indexOptionsMockResult2,
+  indexOptionsMockResult3,
+  indexOptionsMockResult4,
+  indexOptionsMockResult5,
+  indexOptionsMockResult6,
+  materializedViewBuilderMock1,
+  materializedViewBuilderMock2,
+  materializedViewBuilderMockResult1,
+  materializedViewBuilderMockResult2,
+  skippingIndexBuilderMock1,
+  skippingIndexBuilderMock2,
+  skippingIndexBuilderMockResult1,
+  skippingIndexBuilderMockResult2,
+} from '../../../../../../../../test/accelerations';
+import {
+  buildIndexOptions,
+  coveringIndexQueryBuilder,
+  materializedQueryViewBuilder,
+  skippingIndexQueryBuilder,
+} from '../query_builder';
+
+describe('buildIndexOptions', () => {
+  it('should build index options with auto refresh', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock1);
+    expect(indexOptions).toEqual(indexOptionsMockResult1);
+  });
+
+  it('should build index options with interval refresh', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock2);
+    expect(indexOptions).toEqual(indexOptionsMockResult2);
+  });
+
+  it('should build index options with checkpoint location', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock3);
+    expect(indexOptions).toEqual(indexOptionsMockResult3);
+  });
+
+  it('should build index options with manual refresh', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock4);
+    expect(indexOptions).toEqual(indexOptionsMockResult4);
+  });
+
+  it('should build index options with watermark delay', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock5);
+    expect(indexOptions).toEqual(indexOptionsMockResult5);
+  });
+
+  it('should build index options with manual refresh and checkpoint', () => {
+    const indexOptions = buildIndexOptions(indexOptionsMock6);
+    expect(indexOptions).toEqual(indexOptionsMockResult6);
+  });
+
+  describe('skippingIndexQueryBuilder', () => {
+    it('should build skipping index query as expected with interval refresh', () => {
+      const result = skippingIndexQueryBuilder(skippingIndexBuilderMock1);
+      expect(result).toEqual(skippingIndexBuilderMockResult1);
+    });
+
+    it('should build skipping index query as expected with auto refresh', () => {
+      const result = skippingIndexQueryBuilder(skippingIndexBuilderMock2);
+      expect(result).toEqual(skippingIndexBuilderMockResult2);
+    });
+  });
+
+  describe('coveringIndexQueryBuilder', () => {
+    it('should build covering index query as expected with interval refresh', () => {
+      const result = coveringIndexQueryBuilder(coveringIndexBuilderMock1);
+      expect(result).toEqual(coveringIndexBuilderMockResult1);
+    });
+
+    it('should build covering index query as expected with auto refresh', () => {
+      const result = coveringIndexQueryBuilder(coveringIndexBuilderMock2);
+      expect(result).toEqual(coveringIndexBuilderMockResult2);
+    });
+  });
+
+  describe('materializedQueryViewBuilder', () => {
+    it('should build materialized view query as expected with interval refresh', () => {
+      const result = materializedQueryViewBuilder(materializedViewBuilderMock1);
+      expect(result).toEqual(materializedViewBuilderMockResult1);
+    });
+
+    it('should build materialized view query as expected with auto refresh', () => {
+      const result = materializedQueryViewBuilder(materializedViewBuilderMock2);
+      expect(result).toEqual(materializedViewBuilderMockResult2);
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/query_visual_editor.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/__tests__/query_visual_editor.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import {
+  coveringIndexDataMock,
+  createAccelerationEmptyDataMock,
+  materializedViewValidDataMock,
+  skippingIndexDataMock,
+} from '../../../../../../../../test/accelerations';
+import { QueryVisualEditor } from '../query_visual_editor';
+
+describe('Visual builder components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders visual builder with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <QueryVisualEditor
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders visual builder with skipping index options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexName: 'skipping',
+      accelerationIndexType: 'skipping',
+      skippingIndexQueryData: skippingIndexDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <QueryVisualEditor
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders visual builder with covering index options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexName: 'cv-idx',
+      accelerationIndexType: 'covering',
+      coveringIndexQueryData: coveringIndexDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <QueryVisualEditor
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders visual builder with materialized view options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      materializedViewQueryData: materializedViewValidDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <QueryVisualEditor
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/covering_index/__tests__/__snapshots__/covering_index_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/covering_index/__tests__/__snapshots__/covering_index_builder.test.tsx.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Covering index builder components renders covering index builder  with different options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="covering-index-builder"
+  >
+    <h3>
+      Covering index definition
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <span
+        className="euiExpression euiExpression-isUppercase euiExpression--success"
+      >
+        <span
+          className="euiExpression__description"
+        >
+          CREATE INDEX
+        </span>
+         
+        <span
+          className="euiExpression__value"
+        >
+          skipping
+        </span>
+      </span>
+    </div>
+    <div
+      className="euiFlexItem"
+    >
+      <span
+        className="euiExpression euiExpression-isUppercase euiExpression--accent"
+      >
+        <span
+          className="euiExpression__description"
+        >
+          ON
+        </span>
+         
+        <span
+          className="euiExpression__value"
+        >
+          ..
+        </span>
+      </span>
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="coveringIndexFieldsPopOver"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            />
+             
+            <span
+              className="euiExpression__value"
+            >
+              (add fields here)
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Covering index builder components renders covering index builder with default options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="covering-index-builder"
+  >
+    <h3>
+      Covering index definition
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <span
+        className="euiExpression euiExpression-isUppercase euiExpression--success"
+      >
+        <span
+          className="euiExpression__description"
+        >
+          CREATE INDEX
+        </span>
+         
+        <span
+          className="euiExpression__value"
+        >
+          skipping
+        </span>
+      </span>
+    </div>
+    <div
+      className="euiFlexItem"
+    >
+      <span
+        className="euiExpression euiExpression-isUppercase euiExpression--accent"
+      >
+        <span
+          className="euiExpression__description"
+        >
+          ON
+        </span>
+         
+        <span
+          className="euiExpression__value"
+        >
+          ..
+        </span>
+      </span>
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="coveringIndexFieldsPopOver"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            />
+             
+            <span
+              className="euiExpression__value"
+            >
+              (add fields here)
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/covering_index/__tests__/covering_index_builder.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/covering_index/__tests__/covering_index_builder.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import { createAccelerationEmptyDataMock } from '../../../../../../../../../test/accelerations';
+import { CoveringIndexBuilder } from '../covering_index_builder';
+
+describe('Covering index builder components', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders covering index builder with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <CoveringIndexBuilder
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders covering index builder  with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      coveringIndexQueryData: ['field1', 'field2', 'field3'],
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <CoveringIndexBuilder
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/covering_index/covering_index_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/covering_index/covering_index_builder.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiExpression,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { ACCELERATION_ADD_FIELDS_TEXT } from '../../../../../../../../common/constants/data_sources';
+import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import { hasError } from '../../create/utils';
+
+interface CoveringIndexBuilderProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const CoveringIndexBuilder = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: CoveringIndexBuilderProps) => {
+  const [isPopOverOpen, setIsPopOverOpen] = useState(false);
+  const [columnsValue, setColumnsValue] = useState(ACCELERATION_ADD_FIELDS_TEXT);
+  const [selectedOptions, setSelectedOptions] = useState<EuiComboBoxOptionOption[]>([]);
+
+  const onChange = (_selectedOptions: EuiComboBoxOptionOption[]) => {
+    let expressionValue = ACCELERATION_ADD_FIELDS_TEXT;
+    if (_selectedOptions.length > 0) {
+      expressionValue = `(${_selectedOptions.map((option) => option.label).join(', ')})`;
+    }
+    setAccelerationFormData({
+      ...accelerationFormData,
+      coveringIndexQueryData: _selectedOptions.map((option) => option.label),
+    });
+    setColumnsValue(expressionValue);
+    setSelectedOptions(_selectedOptions);
+  };
+
+  return (
+    <>
+      <EuiText data-test-subj="covering-index-builder">
+        <h3>Covering index definition</h3>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup direction="column" gutterSize="xs">
+        <EuiFlexItem grow={false}>
+          <EuiExpression
+            description="CREATE INDEX"
+            value={accelerationFormData.accelerationIndexName}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiExpression
+            description="ON"
+            color="accent"
+            value={`${accelerationFormData.dataSource}.${accelerationFormData.database}.${accelerationFormData.dataTable}`}
+          />
+          <EuiPopover
+            id="coveringIndexFieldsPopOver"
+            button={
+              <EuiExpression
+                description=""
+                value={columnsValue}
+                isActive={isPopOverOpen}
+                onClick={() => setIsPopOverOpen(true)}
+                isInvalid={
+                  hasError(accelerationFormData.formErrors, 'coveringIndexError') &&
+                  columnsValue === ACCELERATION_ADD_FIELDS_TEXT
+                }
+              />
+            }
+            isOpen={isPopOverOpen}
+            closePopover={() => setIsPopOverOpen(false)}
+            panelPaddingSize="s"
+            anchorPosition="downLeft"
+          >
+            <>
+              <EuiPopoverTitle paddingSize="l">Columns</EuiPopoverTitle>
+              <EuiComboBox
+                placeholder="Select one or more options"
+                options={accelerationFormData.dataTableFields.map((x) => ({ label: x.fieldName }))}
+                selectedOptions={selectedOptions}
+                onChange={onChange}
+              />
+            </>
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/add_column_popover.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/add_column_popover.test.tsx.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Column popover components in materialized view renders column popover components in materialized view with default options 1`] = `
+<div
+  className="euiPopover euiPopover--anchorDownCenter"
+>
+  <div
+    className="euiPopover__anchor"
+  >
+    <button
+      aria-label="add column"
+      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="euiButtonContent euiButtonEmpty__content"
+      >
+        <svg
+          aria-hidden={true}
+          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+        <span
+          className="euiButtonEmpty__text"
+        >
+          Add Column
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Column popover components in materialized view renders column popover components in materialized view with different options 1`] = `
+<div
+  className="euiPopover euiPopover--anchorDownCenter"
+>
+  <div
+    className="euiPopover__anchor"
+  >
+    <button
+      aria-label="add column"
+      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <span
+        className="euiButtonContent euiButtonEmpty__content"
+      >
+        <svg
+          aria-hidden={true}
+          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 7h3.5a.5.5 0 1 1 0 1H8v3.5a.5.5 0 1 1-1 0V8H3.5a.5.5 0 0 1 0-1H7V3.5a.5.5 0 0 1 1 0V7Zm-.5-7C11.636 0 15 3.364 15 7.5S11.636 15 7.5 15 0 11.636 0 7.5 3.364 0 7.5 0Zm0 .882a6.618 6.618 0 1 0 0 13.236A6.618 6.618 0 0 0 7.5.882Z"
+            fillRule="evenodd"
+          />
+        </svg>
+        <span
+          className="euiButtonEmpty__text"
+        >
+          Add Column
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/column_expression.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/column_expression.test.tsx.snap
@@ -1,0 +1,179 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Column expression components in materialized view renders column expression components in materialized view with default options 1`] = `
+<div
+  className="euiFlexItem euiFlexItem--flexGrowZero"
+>
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="columnFunctionExpression-1"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            />
+             
+            <span
+              className="euiExpression__value"
+            >
+              count(field1)
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="columnFunctionExpressionAlias-1"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--accent"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            >
+              AS
+            </span>
+             
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <button
+        aria-label="delete-column-expression"
+        className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Column expression components in materialized view renders column expression components in materialized view with different options 1`] = `
+<div
+  className="euiFlexItem euiFlexItem--flexGrowZero"
+>
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="columnFunctionExpression-2"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            />
+             
+            <span
+              className="euiExpression__value"
+            >
+              sum(field2)
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownLeft"
+        id="columnFunctionExpressionAlias-2"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--accent"
+            onClick={[Function]}
+          >
+            <span
+              className="euiExpression__description"
+            >
+              AS
+            </span>
+             
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <button
+        aria-label="delete-column-expression"
+        className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+          focusable="false"
+          height={16}
+          role="img"
+          style={null}
+          viewBox="0 0 16 16"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/group_by_tumble_expression.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/group_by_tumble_expression.test.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Group by components in materialized view renders group by components in materialized view with default options 1`] = `
+<div
+  className="euiFlexItem euiFlexItem--flexGrowZero"
+>
+  <div
+    className="euiPopover euiPopover--anchorDownLeft"
+    id="groupByTumblePopOver"
+  >
+    <div
+      className="euiPopover__anchor"
+    >
+      <button
+        className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+        onClick={[Function]}
+      >
+        <span
+          className="euiExpression__description"
+        >
+          GROUP BY
+        </span>
+         
+        <span
+          className="euiExpression__value"
+        >
+          TUMBLE(, '1 millisecond')
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Group by components in materialized view renders group by components in materialized view with different options 1`] = `
+<div
+  className="euiFlexItem euiFlexItem--flexGrowZero"
+>
+  <div
+    className="euiPopover euiPopover--anchorDownLeft"
+    id="groupByTumblePopOver"
+  >
+    <div
+      className="euiPopover__anchor"
+    >
+      <button
+        className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+        onClick={[Function]}
+      >
+        <span
+          className="euiExpression__description"
+        >
+          GROUP BY
+        </span>
+         
+        <span
+          className="euiExpression__value"
+        >
+          TUMBLE(, '1 millisecond')
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/materialized_view_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/__snapshots__/materialized_view_builder.test.tsx.snap
@@ -1,0 +1,294 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Builder components in materialized view renders builder components in materialized view with default options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="covering-index-builder"
+  >
+    <h3>
+      Materialized view definition
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <span
+    className="euiExpression euiExpression-isUppercase euiExpression--success"
+  >
+    <span
+      className="euiExpression__description"
+    >
+      CREATE MATERIALIZED VIEW
+    </span>
+     
+    <span
+      className="euiExpression__value"
+    >
+      ..skipping
+    </span>
+  </span>,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <span
+        className="euiExpression euiExpression-isUppercase euiExpression--accent"
+      >
+        <span
+          className="euiExpression__description"
+        >
+          AS SELECT
+        </span>
+         
+      </span>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownCenter"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            aria-label="add column"
+            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="euiButtonContent euiButtonEmpty__content"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                />
+              </svg>
+              <span
+                className="euiButtonEmpty__text"
+              >
+                Add Column
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+  />,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <span
+    className="euiExpression euiExpression-isUppercase euiExpression--success"
+  >
+    <span
+      className="euiExpression__description"
+    >
+      FROM
+    </span>
+     
+    <span
+      className="euiExpression__value"
+    >
+      ..
+    </span>
+  </span>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      className="euiPopover euiPopover--anchorDownLeft"
+      id="groupByTumblePopOver"
+    >
+      <div
+        className="euiPopover__anchor"
+      >
+        <button
+          className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+          onClick={[Function]}
+        >
+          <span
+            className="euiExpression__description"
+          >
+            GROUP BY
+          </span>
+           
+          <span
+            className="euiExpression__value"
+          >
+            TUMBLE(, '1 millisecond')
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Builder components in materialized view renders builder components in materialized view with different options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="covering-index-builder"
+  >
+    <h3>
+      Materialized view definition
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <span
+    className="euiExpression euiExpression-isUppercase euiExpression--success"
+  >
+    <span
+      className="euiExpression__description"
+    >
+      CREATE MATERIALIZED VIEW
+    </span>
+     
+    <span
+      className="euiExpression__value"
+    >
+      ..skipping
+    </span>
+  </span>,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <span
+        className="euiExpression euiExpression-isUppercase euiExpression--accent"
+      >
+        <span
+          className="euiExpression__description"
+        >
+          AS SELECT
+        </span>
+         
+      </span>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
+        className="euiPopover euiPopover--anchorDownCenter"
+      >
+        <div
+          className="euiPopover__anchor"
+        >
+          <button
+            aria-label="add column"
+            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span
+              className="euiButtonContent euiButtonEmpty__content"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 7h3.5a.5.5 0 1 1 0 1H8v3.5a.5.5 0 1 1-1 0V8H3.5a.5.5 0 0 1 0-1H7V3.5a.5.5 0 0 1 1 0V7Zm-.5-7C11.636 0 15 3.364 15 7.5S11.636 15 7.5 15 0 11.636 0 7.5 3.364 0 7.5 0Zm0 .882a6.618 6.618 0 1 0 0 13.236A6.618 6.618 0 0 0 7.5.882Z"
+                  fillRule="evenodd"
+                />
+              </svg>
+              <span
+                className="euiButtonEmpty__text"
+              >
+                Add Column
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionColumn euiFlexGroup--responsive"
+  />,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <span
+    className="euiExpression euiExpression-isUppercase euiExpression--success"
+  >
+    <span
+      className="euiExpression__description"
+    >
+      FROM
+    </span>
+     
+    <span
+      className="euiExpression__value"
+    >
+      ..
+    </span>
+  </span>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiFlexItem euiFlexItem--flexGrowZero"
+  >
+    <div
+      className="euiPopover euiPopover--anchorDownLeft"
+      id="groupByTumblePopOver"
+    >
+      <div
+        className="euiPopover__anchor"
+      >
+        <button
+          className="euiExpression euiExpression-isClickable euiExpression-isUppercase euiExpression--success"
+          onClick={[Function]}
+        >
+          <span
+            className="euiExpression__description"
+          >
+            GROUP BY
+          </span>
+           
+          <span
+            className="euiExpression__value"
+          >
+            TUMBLE(, '1 millisecond')
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/add_column_popover.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/add_column_popover.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  materializedViewValidDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { AddColumnPopOver } from '../add_column_popover';
+
+describe('Column popover components in materialized view', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders column popover components in materialized view with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const setIsColumnPopOverOpen = jest.fn();
+    const setColumnExpressionValues = jest.fn();
+    const wrapper = mount(
+      <AddColumnPopOver
+        isColumnPopOverOpen={false}
+        setIsColumnPopOverOpen={setIsColumnPopOverOpen}
+        columnExpressionValues={[]}
+        setColumnExpressionValues={setColumnExpressionValues}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders column popover components in materialized view with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      materializedViewQueryData: materializedViewValidDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const setIsColumnPopOverOpen = jest.fn();
+    const setColumnExpressionValues = jest.fn();
+    const wrapper = mount(
+      <AddColumnPopOver
+        isColumnPopOverOpen={false}
+        setIsColumnPopOverOpen={setIsColumnPopOverOpen}
+        columnExpressionValues={materializedViewValidDataMock.columnsValues}
+        setColumnExpressionValues={setColumnExpressionValues}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/column_expression.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/column_expression.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  materializedViewValidDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { ColumnExpression } from '../column_expression';
+
+describe('Column expression components in materialized view', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders column expression components in materialized view with default options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      materializedViewQueryData: materializedViewValidDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const setColumnExpressionValues = jest.fn();
+    const wrapper = mount(
+      <ColumnExpression
+        index={0}
+        currentColumnExpressionValue={materializedViewValidDataMock.columnsValues[0]}
+        columnExpressionValues={materializedViewValidDataMock.columnsValues}
+        setColumnExpressionValues={setColumnExpressionValues}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders column expression components in materialized view with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      materializedViewQueryData: materializedViewValidDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const setColumnExpressionValues = jest.fn();
+    const wrapper = mount(
+      <ColumnExpression
+        index={1}
+        currentColumnExpressionValue={materializedViewValidDataMock.columnsValues[1]}
+        columnExpressionValues={materializedViewValidDataMock.columnsValues}
+        setColumnExpressionValues={setColumnExpressionValues}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/group_by_tumble_expression.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/group_by_tumble_expression.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  materializedViewValidDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { GroupByTumbleExpression } from '../group_by_tumble_expression';
+
+describe('Group by components in materialized view', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders group by components in materialized view with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <GroupByTumbleExpression
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders group by components in materialized view with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      materializedViewQueryData: materializedViewValidDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <GroupByTumbleExpression
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/materialized_view_builder.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/__tests__/materialized_view_builder.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  materializedViewValidDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { MaterializedViewBuilder } from '../materialized_view_builder';
+
+describe('Builder components in materialized view', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders builder components in materialized view with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <MaterializedViewBuilder
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders builder components in materialized view with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'materialized',
+      materializedViewQueryData: materializedViewValidDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <MaterializedViewBuilder
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/add_column_popover.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/add_column_popover.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPopover,
+  EuiPopoverFooter,
+  EuiPopoverTitle,
+  EuiSpacer,
+  htmlIdGenerator,
+} from '@elastic/eui';
+import producer from 'immer';
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { ACCELERATION_AGGREGRATION_FUNCTIONS } from '../../../../../../../../common/constants/data_sources';
+import {
+  AggregationFunctionType,
+  CreateAccelerationForm,
+  MaterializedViewColumn,
+} from '../../../../../../../../common/types/data_connections';
+
+interface AddColumnPopOverProps {
+  isColumnPopOverOpen: boolean;
+  setIsColumnPopOverOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  columnExpressionValues: MaterializedViewColumn[];
+  setColumnExpressionValues: React.Dispatch<React.SetStateAction<MaterializedViewColumn[]>>;
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const AddColumnPopOver = ({
+  isColumnPopOverOpen,
+  setIsColumnPopOverOpen,
+  columnExpressionValues,
+  setColumnExpressionValues,
+  accelerationFormData,
+  setAccelerationFormData,
+}: AddColumnPopOverProps) => {
+  const [selectedFunction, setSelectedFunction] = useState([
+    ACCELERATION_AGGREGRATION_FUNCTIONS[0],
+  ]);
+  const [selectedField, setSelectedField] = useState<EuiComboBoxOptionOption[]>([]);
+  const [selectedAlias, setSeletedAlias] = useState('');
+
+  const resetSelectedField = () => {
+    if (accelerationFormData.dataTableFields.length > 0) {
+      const defaultFieldName = accelerationFormData.dataTableFields[0].fieldName;
+      setSelectedField([{ label: defaultFieldName }]);
+    }
+  };
+
+  const resetValues = () => {
+    setSelectedFunction([ACCELERATION_AGGREGRATION_FUNCTIONS[0]]);
+    resetSelectedField();
+    setSeletedAlias('');
+  };
+
+  const onChangeAlias = (e: ChangeEvent<HTMLInputElement>) => {
+    setSeletedAlias(e.target.value);
+  };
+
+  const onAddExpression = () => {
+    const newColumnExpresionValue = [
+      ...columnExpressionValues,
+      {
+        id: htmlIdGenerator()(),
+        functionName: selectedFunction[0].label as AggregationFunctionType,
+        functionParam: selectedField[0].label,
+        fieldAlias: selectedAlias,
+      },
+    ];
+
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.materializedViewQueryData.columnsValues = newColumnExpresionValue;
+      })
+    );
+
+    setColumnExpressionValues(newColumnExpresionValue);
+    setIsColumnPopOverOpen(false);
+  };
+
+  useEffect(() => {
+    resetSelectedField();
+  }, []);
+
+  return (
+    <EuiPopover
+      panelPaddingSize="s"
+      button={
+        <EuiButtonEmpty
+          iconType="plusInCircle"
+          aria-label="add column"
+          onClick={() => {
+            resetValues();
+            setIsColumnPopOverOpen(!isColumnPopOverOpen);
+          }}
+          size="xs"
+        >
+          Add Column
+        </EuiButtonEmpty>
+      }
+      isOpen={isColumnPopOverOpen}
+      closePopover={() => setIsColumnPopOverOpen(false)}
+    >
+      <EuiPopoverTitle>Add Column</EuiPopoverTitle>
+      <>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiFormRow label="Aggregate function">
+              <EuiComboBox
+                singleSelection={{ asPlainText: true }}
+                options={ACCELERATION_AGGREGRATION_FUNCTIONS}
+                selectedOptions={selectedFunction}
+                onChange={setSelectedFunction}
+                isClearable={false}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow label="Aggregation field">
+              <EuiComboBox
+                singleSelection={{ asPlainText: true }}
+                options={[
+                  { label: '*', disabled: selectedFunction[0].label !== 'count' },
+                  ...accelerationFormData.dataTableFields.map((x) => ({ label: x.fieldName })),
+                ]}
+                selectedOptions={selectedField}
+                onChange={setSelectedField}
+                isClearable={false}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="m" />
+        <EuiFormRow label="Column alias - optional">
+          <EuiFieldText name="aliasField" onChange={onChangeAlias} />
+        </EuiFormRow>
+      </>
+      <EuiPopoverFooter>
+        <EuiButton size="s" fill onClick={onAddExpression}>
+          Add
+        </EuiButton>
+      </EuiPopoverFooter>
+    </EuiPopover>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/column_expression.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButtonIcon,
+  EuiComboBox,
+  EuiExpression,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPopover,
+} from '@elastic/eui';
+import producer from 'immer';
+import _ from 'lodash';
+import React, { useState } from 'react';
+import { ACCELERATION_AGGREGRATION_FUNCTIONS } from '../../../../../../../../common/constants/data_sources';
+import {
+  AggregationFunctionType,
+  CreateAccelerationForm,
+  MaterializedViewColumn,
+} from '../../../../../../../../common/types/data_connections';
+
+interface ColumnExpressionProps {
+  index: number;
+  currentColumnExpressionValue: MaterializedViewColumn;
+  columnExpressionValues: MaterializedViewColumn[];
+  setColumnExpressionValues: React.Dispatch<React.SetStateAction<MaterializedViewColumn[]>>;
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const ColumnExpression = ({
+  index,
+  currentColumnExpressionValue,
+  columnExpressionValues,
+  setColumnExpressionValues,
+  accelerationFormData,
+  setAccelerationFormData,
+}: ColumnExpressionProps) => {
+  const [isFunctionPopOverOpen, setIsFunctionPopOverOpen] = useState(false);
+  const [isAliasPopOverOpen, setIsAliasPopOverOpen] = useState(false);
+
+  const updateColumnExpressionValue = (newValue: MaterializedViewColumn, columnIndex: number) => {
+    const updatedArray = [...columnExpressionValues];
+    updatedArray[columnIndex] = newValue;
+    setColumnExpressionValues(updatedArray);
+  };
+
+  const onDeleteColumnExpression = () => {
+    const newColumnExpresionValue = [
+      ..._.filter(columnExpressionValues, (o) => o.id !== currentColumnExpressionValue.id),
+    ];
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.materializedViewQueryData.columnsValues = newColumnExpresionValue;
+      })
+    );
+    setColumnExpressionValues(newColumnExpresionValue);
+  };
+
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id={'columnFunctionExpression-' + currentColumnExpressionValue.id}
+            button={
+              <EuiExpression
+                description=""
+                value={`${currentColumnExpressionValue.functionName}(${currentColumnExpressionValue.functionParam})`}
+                isActive={isFunctionPopOverOpen}
+                onClick={() => {
+                  setIsAliasPopOverOpen(false);
+                  setIsFunctionPopOverOpen(true);
+                }}
+              />
+            }
+            isOpen={isFunctionPopOverOpen}
+            closePopover={() => setIsFunctionPopOverOpen(false)}
+            panelPaddingSize="s"
+            anchorPosition="downLeft"
+          >
+            <>
+              <EuiFlexGroup>
+                <EuiFlexItem grow={false}>
+                  <EuiFormRow label="Aggregate function">
+                    <EuiComboBox
+                      singleSelection={{ asPlainText: true }}
+                      options={ACCELERATION_AGGREGRATION_FUNCTIONS}
+                      selectedOptions={[
+                        {
+                          label: currentColumnExpressionValue.functionName,
+                        },
+                      ]}
+                      onChange={(functionOption) =>
+                        updateColumnExpressionValue(
+                          {
+                            ...currentColumnExpressionValue,
+                            functionName: functionOption[0].label as AggregationFunctionType,
+                          },
+                          index
+                        )
+                      }
+                      isClearable={false}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiFormRow label="Aggregation field">
+                    <EuiComboBox
+                      singleSelection={{ asPlainText: true }}
+                      options={[
+                        {
+                          label: '*',
+                          disabled: currentColumnExpressionValue.functionName !== 'count',
+                        },
+                        ...accelerationFormData.dataTableFields.map((x) => ({
+                          label: x.fieldName,
+                        })),
+                      ]}
+                      selectedOptions={[
+                        {
+                          label: currentColumnExpressionValue.functionParam,
+                        },
+                      ]}
+                      onChange={(fieldOption) =>
+                        updateColumnExpressionValue(
+                          { ...currentColumnExpressionValue, functionParam: fieldOption[0].label },
+                          index
+                        )
+                      }
+                      isClearable={false}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </>
+          </EuiPopover>
+        </EuiFlexItem>
+        {currentColumnExpressionValue.fieldAlias !== '' && (
+          <EuiFlexItem grow={false}>
+            <EuiPopover
+              id={'columnFunctionExpressionAlias-' + currentColumnExpressionValue.id}
+              button={
+                <EuiExpression
+                  description="AS"
+                  color="accent"
+                  value={currentColumnExpressionValue.fieldAlias}
+                  isActive={isAliasPopOverOpen}
+                  onClick={() => {
+                    setIsFunctionPopOverOpen(false);
+                    setIsAliasPopOverOpen(true);
+                  }}
+                />
+              }
+              isOpen={isAliasPopOverOpen}
+              closePopover={() => setIsAliasPopOverOpen(false)}
+              panelPaddingSize="s"
+              anchorPosition="downLeft"
+            >
+              <EuiFormRow label="Column alias">
+                <EuiFieldText
+                  name="aliasField"
+                  value={currentColumnExpressionValue.fieldAlias}
+                  onChange={(e) =>
+                    updateColumnExpressionValue(
+                      { ...currentColumnExpressionValue, fieldAlias: e.target.value },
+                      index
+                    )
+                  }
+                />
+              </EuiFormRow>
+            </EuiPopover>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            color="danger"
+            onClick={onDeleteColumnExpression}
+            iconType="trash"
+            aria-label="delete-column-expression"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/group_by_tumble_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/group_by_tumble_expression.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiExpression,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPopover,
+  EuiSelect,
+} from '@elastic/eui';
+import producer from 'immer';
+import React, { useState } from 'react';
+import { ACCELERATION_TIME_INTERVAL } from '../../../../../../../../common/constants/data_sources';
+import {
+  CreateAccelerationForm,
+  GroupByTumbleType,
+} from '../../../../../../../../common/types/data_connections';
+import { hasError, pluralizeTime } from '../../create/utils';
+
+interface GroupByTumbleExpressionProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const GroupByTumbleExpression = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: GroupByTumbleExpressionProps) => {
+  const [IsGroupPopOverOpen, setIsGroupPopOverOpen] = useState(false);
+  const [groupbyValues, setGroupByValues] = useState<GroupByTumbleType>({
+    timeField: '',
+    tumbleWindow: 1,
+    tumbleInterval: ACCELERATION_TIME_INTERVAL[0].value,
+  });
+
+  const updateGroupByStates = (newGroupByValue: GroupByTumbleType) => {
+    setGroupByValues(newGroupByValue);
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.materializedViewQueryData.groupByTumbleValue = newGroupByValue;
+      })
+    );
+  };
+
+  const onChangeTumbleWindow = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newGroupByValue = { ...groupbyValues, tumbleWindow: parseInt(e.target.value, 10) };
+    updateGroupByStates(newGroupByValue);
+  };
+
+  const onChangeTumbleInterval = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newGroupByValue = { ...groupbyValues, tumbleInterval: e.target.value };
+    updateGroupByStates(newGroupByValue);
+  };
+
+  const onChangeTimeField = (selectedOptions: EuiComboBoxOptionOption[]) => {
+    if (selectedOptions.length > 0) {
+      const newGroupByValue = { ...groupbyValues, timeField: selectedOptions[0].label };
+      updateGroupByStates(newGroupByValue);
+    }
+  };
+
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiPopover
+        id="groupByTumblePopOver"
+        button={
+          <EuiExpression
+            description="GROUP BY"
+            value={`TUMBLE(${groupbyValues.timeField}, '${groupbyValues.tumbleWindow} ${
+              groupbyValues.tumbleInterval
+            }${pluralizeTime(groupbyValues.tumbleWindow)}')`}
+            isActive={IsGroupPopOverOpen}
+            onClick={() => setIsGroupPopOverOpen(true)}
+            isInvalid={
+              hasError(accelerationFormData.formErrors, 'materializedViewError') &&
+              groupbyValues.timeField === ''
+            }
+          />
+        }
+        isOpen={IsGroupPopOverOpen}
+        closePopover={() => setIsGroupPopOverOpen(false)}
+        panelPaddingSize="s"
+        anchorPosition="downLeft"
+      >
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiFormRow label="Time Field">
+              <EuiComboBox
+                style={{ minWidth: '200px' }}
+                placeholder="Select one or more options"
+                singleSelection={{ asPlainText: true }}
+                options={accelerationFormData.dataTableFields
+                  .filter((value) => value.dataType.includes(TIMESTAMP_DATATYPE))
+                  .map((value) => ({ label: value.fieldName }))}
+                selectedOptions={[{ label: groupbyValues.timeField }]}
+                onChange={onChangeTimeField}
+                isClearable={false}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow label="Tumble Window">
+              <EuiFieldNumber
+                value={groupbyValues.tumbleWindow}
+                onChange={onChangeTumbleWindow}
+                min={1}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFormRow label="Tumble Interval">
+              <EuiSelect
+                value={groupbyValues.tumbleInterval}
+                onChange={onChangeTumbleInterval}
+                options={ACCELERATION_TIME_INTERVAL}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPopover>
+    </EuiFlexItem>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/materialized_view_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/materialized_view/materialized_view_builder.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiExpression,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+  htmlIdGenerator,
+} from '@elastic/eui';
+import producer from 'immer';
+import { map } from 'lodash';
+import React, { useEffect, useState } from 'react';
+import {
+  AggregationFunctionType,
+  CreateAccelerationForm,
+  MaterializedViewColumn,
+} from '../../../../../../../../common/types/data_connections';
+import { hasError } from '../../create/utils';
+import { AddColumnPopOver } from './add_column_popover';
+import { ColumnExpression } from './column_expression';
+import { GroupByTumbleExpression } from './group_by_tumble_expression';
+
+interface MaterializedViewBuilderProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+const newColumnExpressionId = htmlIdGenerator()();
+
+export const MaterializedViewBuilder = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: MaterializedViewBuilderProps) => {
+  const [isColumnPopOverOpen, setIsColumnPopOverOpen] = useState(false);
+  const [columnExpressionValues, setColumnExpressionValues] = useState<MaterializedViewColumn[]>(
+    []
+  );
+
+  useEffect(() => {
+    if (accelerationFormData.dataTableFields.length > 0) {
+      const newColumnExpresionValue = [
+        {
+          id: newColumnExpressionId,
+          functionName: 'count' as AggregationFunctionType,
+          functionParam: accelerationFormData.dataTableFields[0].fieldName,
+          fieldAlias: 'counter1',
+        },
+      ];
+      setAccelerationFormData(
+        producer((accData) => {
+          accData.materializedViewQueryData.columnsValues = newColumnExpresionValue;
+        })
+      );
+      setColumnExpressionValues(newColumnExpresionValue);
+    }
+  }, [accelerationFormData.dataTableFields]);
+
+  return (
+    <>
+      <EuiText data-test-subj="covering-index-builder">
+        <h3>Materialized view definition</h3>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiExpression
+        description="CREATE MATERIALIZED VIEW"
+        value={`${accelerationFormData.dataSource}.${accelerationFormData.database}.${accelerationFormData.accelerationIndexName}`}
+      />
+
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiExpression
+            color="accent"
+            description="AS SELECT"
+            value=""
+            isInvalid={
+              hasError(accelerationFormData.formErrors, 'materializedViewError') &&
+              columnExpressionValues.length < 1
+            }
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <AddColumnPopOver
+            isColumnPopOverOpen={isColumnPopOverOpen}
+            setIsColumnPopOverOpen={setIsColumnPopOverOpen}
+            columnExpressionValues={columnExpressionValues}
+            setColumnExpressionValues={setColumnExpressionValues}
+            accelerationFormData={accelerationFormData}
+            setAccelerationFormData={setAccelerationFormData}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiFlexGroup direction="column" gutterSize="s">
+        {map(columnExpressionValues, (_, i) => {
+          return (
+            <ColumnExpression
+              index={i}
+              currentColumnExpressionValue={columnExpressionValues[i]}
+              columnExpressionValues={columnExpressionValues}
+              setColumnExpressionValues={setColumnExpressionValues}
+              accelerationFormData={accelerationFormData}
+              setAccelerationFormData={setAccelerationFormData}
+            />
+          );
+        })}
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      <EuiExpression
+        description="FROM"
+        value={`${accelerationFormData.dataSource}.${accelerationFormData.database}.${accelerationFormData.dataTable}`}
+      />
+      <EuiSpacer size="s" />
+      <GroupByTumbleExpression
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/query_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/query_builder.tsx
@@ -1,0 +1,203 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CreateAccelerationForm,
+  GroupByTumbleType,
+  MaterializedViewColumn,
+  SkippingIndexRowType,
+} from '../../../../../../../common/types/data_connections';
+import { pluralizeTime } from '../create/utils';
+
+/* Add index options to query */
+export const buildIndexOptions = (accelerationformData: CreateAccelerationForm) => {
+  const {
+    primaryShardsCount,
+    replicaShardsCount,
+    refreshType,
+    checkpointLocation,
+    accelerationIndexType,
+  } = accelerationformData;
+  const indexOptions: string[] = [];
+
+  // Add index settings option
+  indexOptions.push(
+    `index_settings = '{"number_of_shards":${primaryShardsCount},"number_of_replicas":${replicaShardsCount}}'`
+  );
+
+  // Add auto refresh option
+  indexOptions.push(`auto_refresh = ${['auto', 'interval'].includes(refreshType)}`);
+
+  // Add refresh interval option
+  if (refreshType === 'interval') {
+    const { refreshWindow, refreshInterval } = accelerationformData.refreshIntervalOptions;
+    indexOptions.push(
+      `refresh_interval = '${refreshWindow} ${refreshInterval}${pluralizeTime(refreshWindow)}'`
+    );
+  }
+
+  // Add watermark delay option with materialized view
+  if (accelerationIndexType === 'materialized') {
+    const { delayWindow, delayInterval } = accelerationformData.watermarkDelay;
+    indexOptions.push(
+      `watermark_delay = '${delayWindow} ${delayInterval}${pluralizeTime(delayWindow)}'`
+    );
+  }
+
+  if (refreshType !== 'manual' && checkpointLocation) {
+    // Add checkpoint location option
+    indexOptions.push(`checkpoint_location = '${checkpointLocation}'`);
+  }
+
+  // Combine all options with commas and return as a single string
+  return `WITH (\n${indexOptions.join(',\n')}\n)`;
+};
+
+/* Add skipping index columns to query */
+const buildSkippingIndexColumns = (skippingIndexQueryData: SkippingIndexRowType[]) => {
+  return skippingIndexQueryData
+    .map((n) => `   \`${n.fieldName}\` ${n.accelerationMethod}`)
+    .join(', \n');
+};
+
+/*
+ * Builds create skipping index query
+ * Skipping Index create query example:
+ *
+ * CREATE SKIPPING INDEX
+ * ON datasource.database.table (
+ *    `field1` VALUE_SET,
+ *    `field2` PARTITION,
+ *    `field3` MIN_MAX,
+ * ) WITH (
+ * auto_refresh = true,
+ * refresh_interval = '1 minute',
+ * checkpoint_location = 's3://test/',
+ * index_settings = '{"number_of_shards":9,"number_of_replicas":2}'
+ * )
+ */
+export const skippingIndexQueryBuilder = (accelerationformData: CreateAccelerationForm) => {
+  const { dataSource, database, dataTable, skippingIndexQueryData } = accelerationformData;
+
+  const codeQuery = `CREATE SKIPPING INDEX
+ON ${dataSource}.${database}.${dataTable} (
+${buildSkippingIndexColumns(skippingIndexQueryData)}
+  ) ${buildIndexOptions(accelerationformData)}`;
+
+  return codeQuery;
+};
+
+/* Add covering index columns to query */
+const buildCoveringIndexColumns = (coveringIndexQueryData: string[]) => {
+  return coveringIndexQueryData.map((field) => `   \`${field}\``).join(', \n');
+};
+
+/*
+ * Builds create covering index query
+ * Covering Index create query example:
+ *
+ * CREATE INDEX index_name
+ * ON datasource.database.table (
+ *    `field1`,
+ *    `field2`,
+ *    `field3`,
+ * ) WITH (
+ * auto_refresh = true,
+ * refresh_interval = '1 minute',
+ * checkpoint_location = 's3://test/',
+ * index_settings = '{"number_of_shards":9,"number_of_replicas":2}'
+ * )
+ */
+export const coveringIndexQueryBuilder = (accelerationformData: CreateAccelerationForm) => {
+  const {
+    dataSource,
+    database,
+    dataTable,
+    accelerationIndexName,
+    coveringIndexQueryData,
+  } = accelerationformData;
+
+  const codeQuery = `CREATE INDEX ${accelerationIndexName}
+ON ${dataSource}.${database}.${dataTable} (
+${buildCoveringIndexColumns(coveringIndexQueryData)}
+  ) ${buildIndexOptions(accelerationformData)}`;
+
+  return codeQuery;
+};
+
+const buildMaterializedViewColumnName = (columnName: string) => {
+  return columnName === '*' ? columnName : `\`${columnName}\``;
+};
+
+const buildMaterializedViewColumns = (columnsValues: MaterializedViewColumn[]) => {
+  return columnsValues
+    .map(
+      (column) =>
+        `   ${column.functionName}(${buildMaterializedViewColumnName(column.functionParam)})${
+          column.fieldAlias ? ` AS \`${column.fieldAlias}\`` : ``
+        }`
+    )
+    .join(', \n');
+};
+
+/* Build group by tumble values */
+const buildTumbleValue = (GroupByTumbleValue: GroupByTumbleType) => {
+  const { timeField, tumbleWindow, tumbleInterval } = GroupByTumbleValue;
+  return `(\`${timeField}\`, '${tumbleWindow} ${tumbleInterval}${pluralizeTime(tumbleWindow)}')`;
+};
+
+/*
+ * Builds create materialized view query
+ * Materialized View create query example:
+ *
+ * CREATE MATERIALIZED VIEW datasource.database.index_name
+ * AS SELECT
+ * count(`field`) as `counter`,
+ * count(*) as `counter1`,
+ * sum(`field2`),
+ * avg(`field3`) as `average`
+ *  WITH (
+ * auto_refresh = true,
+ * refresh_interval = '1 minute',
+ * checkpoint_location = 's3://test/',
+ * index_settings = '{"number_of_shards":9,"number_of_replicas":2}'
+ * )
+ */
+export const materializedQueryViewBuilder = (accelerationformData: CreateAccelerationForm) => {
+  const {
+    dataSource,
+    database,
+    dataTable,
+    accelerationIndexName,
+    materializedViewQueryData,
+  } = accelerationformData;
+
+  const codeQuery = `CREATE MATERIALIZED VIEW ${dataSource}.${database}.${accelerationIndexName}
+AS SELECT
+${buildMaterializedViewColumns(materializedViewQueryData.columnsValues)}
+FROM ${dataSource}.${database}.${dataTable}
+GROUP BY TUMBLE ${buildTumbleValue(materializedViewQueryData.groupByTumbleValue)}
+ ${buildIndexOptions(accelerationformData)}`;
+
+  return codeQuery;
+};
+
+/* Builds create acceleration index query */
+export const accelerationQueryBuilder = (accelerationformData: CreateAccelerationForm) => {
+  switch (accelerationformData.accelerationIndexType) {
+    case 'skipping': {
+      return skippingIndexQueryBuilder(accelerationformData);
+    }
+    case 'covering': {
+      return coveringIndexQueryBuilder(accelerationformData);
+    }
+    case 'materialized': {
+      return materializedQueryViewBuilder(accelerationformData);
+    }
+    default: {
+      return '';
+    }
+  }
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/query_visual_editor.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/query_visual_editor.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiSpacer } from '@elastic/eui';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../common/types/data_connections';
+import { CoveringIndexBuilder } from './covering_index/covering_index_builder';
+import { MaterializedViewBuilder } from './materialized_view/materialized_view_builder';
+import { SkippingIndexBuilder } from './skipping_index/skipping_index_builder';
+
+interface QueryVisualEditorProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const QueryVisualEditor = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: QueryVisualEditorProps) => {
+  return (
+    <>
+      <EuiSpacer size="l" />
+      {accelerationFormData.accelerationIndexType === 'skipping' && (
+        <SkippingIndexBuilder
+          accelerationFormData={accelerationFormData}
+          setAccelerationFormData={setAccelerationFormData}
+        />
+      )}
+      {accelerationFormData.accelerationIndexType === 'covering' && (
+        <CoveringIndexBuilder
+          accelerationFormData={accelerationFormData}
+          setAccelerationFormData={setAccelerationFormData}
+        />
+      )}
+      {accelerationFormData.accelerationIndexType === 'materialized' && (
+        <MaterializedViewBuilder
+          accelerationFormData={accelerationFormData}
+          setAccelerationFormData={setAccelerationFormData}
+        />
+      )}
+    </>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
@@ -1,0 +1,1533 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Add fields modal in skipping index renders add fields modal in skipping index with default options 1`] = `
+<Portal
+  containerInfo={
+    <div
+      class="euiOverlayMask euiOverlayMask--aboveHeader"
+    >
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+      <div
+        data-focus-lock-disabled="false"
+      >
+        <div
+          class="euiModal euiModal--maxWidth-default"
+          tabindex="0"
+        >
+          <button
+            aria-label="Closes this modal window"
+            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+              />
+            </svg>
+          </button>
+          <div
+            class="euiModal__flex"
+          >
+            <div
+              class="euiModalHeader"
+            >
+              <div
+                class="euiModalHeader__title"
+              >
+                <h1>
+                  Add fields
+                </h1>
+              </div>
+            </div>
+            <div
+              class="euiModalBody"
+            >
+              <div
+                class="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      class="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            class="euiFieldSearch euiFieldSearch--fullWidth"
+                            placeholder="Search..."
+                            type="search"
+                            value=""
+                          />
+                          <div
+                            class="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    class="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        class="euiTableHeaderMobile"
+                      >
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                class="euiCheckbox__input"
+                                disabled=""
+                                id="_selection_column-checkbox_some_html_id"
+                                type="checkbox"
+                              />
+                              <div
+                                class="euiCheckbox__square"
+                              />
+                              <label
+                                class="euiCheckbox__label"
+                                for="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiTableSortMobile"
+                            >
+                              <div
+                                class="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  class="euiPopover__anchor"
+                                >
+                                  <button
+                                    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                      <span
+                                        class="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        class="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabindex="-1"
+                      >
+                        <caption
+                          class="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              class="euiTableHeaderCellCheckbox"
+                              scope="col"
+                            >
+                              <div
+                                class="euiTableCellContent"
+                              >
+                                <div
+                                  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    class="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled=""
+                                    id="_selection_column-checkbox_some_html_id"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    class="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            class="euiTableRow"
+                          >
+                            <td
+                              class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                              colspan="3"
+                            >
+                              <div
+                                class="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  No items found
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiModalFooter"
+            >
+              <button
+                class="euiButton euiButton--primary"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                class="euiButton euiButton--primary euiButton--fill"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Add
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+    </div>
+  }
+>
+  Array [
+    Array [
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+      "",
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onScrollCapture={[Function]}
+        onTouchMoveCapture={[Function]}
+        onTouchStart={[Function]}
+        onWheelCapture={[Function]}
+      >
+        <div
+          className="euiModal euiModal--maxWidth-default"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <button
+            aria-label="Closes this modal window"
+            className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+              focusable="false"
+              height={16}
+              role="img"
+              style={null}
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+              />
+            </svg>
+          </button>
+          <div
+            className="euiModal__flex"
+          >
+            <div
+              className="euiModalHeader"
+            >
+              <div
+                className="euiModalHeader__title"
+              >
+                <h1>
+                  Add fields
+                </h1>
+              </div>
+            </div>
+            <div
+              className="euiModalBody"
+            >
+              <div
+                className="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      className="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            className="euiFieldSearch euiFieldSearch--fullWidth"
+                            defaultValue=""
+                            onKeyUp={[Function]}
+                            placeholder="Search..."
+                            type="search"
+                          />
+                          <div
+                            className="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              className="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    className="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        className="euiTableHeaderMobile"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                checked={false}
+                                className="euiCheckbox__input"
+                                disabled={true}
+                                id="_selection_column-checkbox_some_html_id"
+                                onChange={[Function]}
+                                type="checkbox"
+                              />
+                              <div
+                                className="euiCheckbox__square"
+                              />
+                              <label
+                                className="euiCheckbox__label"
+                                htmlFor="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiTableSortMobile"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        className="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabIndex={-1}
+                      >
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <div
+                                  className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_some_html_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <td
+                              className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                              colSpan={3}
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  No items found
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="euiModalFooter"
+            >
+              <button
+                className="euiButton euiButton--primary"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                className="euiButton euiButton--primary euiButton--fill"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Add
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>,
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+    ],
+    "",
+  ]
+</Portal>
+`;
+
+exports[`Add fields modal in skipping index renders add fields modal in skipping index with different options 1`] = `
+<Portal
+  containerInfo={
+    <div
+      class="euiOverlayMask euiOverlayMask--aboveHeader"
+    >
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+      <div
+        data-focus-lock-disabled="false"
+      >
+        <div
+          class="euiModal euiModal--maxWidth-default"
+          tabindex="0"
+        >
+          <button
+            aria-label="Closes this modal window"
+            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+              />
+            </svg>
+          </button>
+          <div
+            class="euiModal__flex"
+          >
+            <div
+              class="euiModalHeader"
+            >
+              <div
+                class="euiModalHeader__title"
+              >
+                <h1>
+                  Add fields
+                </h1>
+              </div>
+            </div>
+            <div
+              class="euiModalBody"
+            >
+              <div
+                class="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      class="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            class="euiFieldSearch euiFieldSearch--fullWidth"
+                            placeholder="Search..."
+                            type="search"
+                            value=""
+                          />
+                          <div
+                            class="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    class="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        class="euiTableHeaderMobile"
+                      >
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                class="euiCheckbox__input"
+                                disabled=""
+                                id="_selection_column-checkbox_some_html_id"
+                                type="checkbox"
+                              />
+                              <div
+                                class="euiCheckbox__square"
+                              />
+                              <label
+                                class="euiCheckbox__label"
+                                for="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiTableSortMobile"
+                            >
+                              <div
+                                class="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  class="euiPopover__anchor"
+                                >
+                                  <button
+                                    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                          fill-rule="non-zero"
+                                        />
+                                      </svg>
+                                      <span
+                                        class="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        class="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabindex="-1"
+                      >
+                        <caption
+                          class="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              class="euiTableHeaderCellCheckbox"
+                              scope="col"
+                            >
+                              <div
+                                class="euiTableCellContent"
+                              >
+                                <div
+                                  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    class="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled=""
+                                    id="_selection_column-checkbox_some_html_id"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    class="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            class="euiTableRow"
+                          >
+                            <td
+                              class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                              colspan="3"
+                            >
+                              <div
+                                class="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  No items found
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiModalFooter"
+            >
+              <button
+                class="euiButton euiButton--primary"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                class="euiButton euiButton--primary euiButton--fill"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Add
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+    </div>
+  }
+>
+  Array [
+    Array [
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+      "",
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onScrollCapture={[Function]}
+        onTouchMoveCapture={[Function]}
+        onTouchStart={[Function]}
+        onWheelCapture={[Function]}
+      >
+        <div
+          className="euiModal euiModal--maxWidth-default"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <button
+            aria-label="Closes this modal window"
+            className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+              focusable="false"
+              height={16}
+              role="img"
+              style={null}
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+              />
+            </svg>
+          </button>
+          <div
+            className="euiModal__flex"
+          >
+            <div
+              className="euiModalHeader"
+            >
+              <div
+                className="euiModalHeader__title"
+              >
+                <h1>
+                  Add fields
+                </h1>
+              </div>
+            </div>
+            <div
+              className="euiModalBody"
+            >
+              <div
+                className="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      className="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            className="euiFieldSearch euiFieldSearch--fullWidth"
+                            defaultValue=""
+                            onKeyUp={[Function]}
+                            placeholder="Search..."
+                            type="search"
+                          />
+                          <div
+                            className="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              className="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    className="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        className="euiTableHeaderMobile"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                checked={false}
+                                className="euiCheckbox__input"
+                                disabled={true}
+                                id="_selection_column-checkbox_some_html_id"
+                                onChange={[Function]}
+                                type="checkbox"
+                              />
+                              <div
+                                className="euiCheckbox__square"
+                              />
+                              <label
+                                className="euiCheckbox__label"
+                                htmlFor="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiTableSortMobile"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                          fillRule="non-zero"
+                                        />
+                                      </svg>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        className="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabIndex={-1}
+                      >
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <div
+                                  className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_some_html_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <td
+                              className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                              colSpan={3}
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  No items found
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="euiModalFooter"
+            >
+              <button
+                className="euiButton euiButton--primary"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                className="euiButton euiButton--primary euiButton--fill"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Add
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>,
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+    ],
+    "",
+  ]
+</Portal>
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                 aria-label="Select all rows"
                                 class="euiCheckbox__input"
                                 disabled=""
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 type="checkbox"
                               />
                               <div
@@ -137,7 +137,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                               />
                               <label
                                 class="euiCheckbox__label"
-                                for="_selection_column-checkbox_some_html_id"
+                                for="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -191,7 +191,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                       </div>
                       <table
                         class="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabindex="-1"
                       >
                         <caption
@@ -214,7 +214,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                     class="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled=""
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     type="checkbox"
                                   />
                                   <div
@@ -495,7 +495,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                 checked={false}
                                 className="euiCheckbox__input"
                                 disabled={true}
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -504,7 +504,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                               />
                               <label
                                 className="euiCheckbox__label"
-                                htmlFor="_selection_column-checkbox_some_html_id"
+                                htmlFor="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -561,7 +561,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                       </div>
                       <table
                         className="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabIndex={-1}
                       >
                         <caption
@@ -590,7 +590,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                     className="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled={true}
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     onChange={[Function]}
                                     type="checkbox"
                                   />
@@ -894,7 +894,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                 aria-label="Select all rows"
                                 class="euiCheckbox__input"
                                 disabled=""
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 type="checkbox"
                               />
                               <div
@@ -902,7 +902,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                               />
                               <label
                                 class="euiCheckbox__label"
-                                for="_selection_column-checkbox_some_html_id"
+                                for="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -957,7 +957,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                       </div>
                       <table
                         class="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabindex="-1"
                       >
                         <caption
@@ -980,7 +980,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                     class="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled=""
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     type="checkbox"
                                   />
                                   <div
@@ -1261,7 +1261,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                 checked={false}
                                 className="euiCheckbox__input"
                                 disabled={true}
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -1270,7 +1270,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                               />
                               <label
                                 className="euiCheckbox__label"
-                                htmlFor="_selection_column-checkbox_some_html_id"
+                                htmlFor="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -1328,7 +1328,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                       </div>
                       <table
                         className="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabIndex={-1}
                       >
                         <caption
@@ -1357,7 +1357,7 @@ exports[`Add fields modal in skipping index renders add fields modal in skipping
                                     className="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled={true}
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     onChange={[Function]}
                                     type="checkbox"
                                   />

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                 aria-label="Select all rows"
                                 class="euiCheckbox__input"
                                 disabled=""
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 type="checkbox"
                               />
                               <div
@@ -137,7 +137,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                               />
                               <label
                                 class="euiCheckbox__label"
-                                for="_selection_column-checkbox_some_html_id"
+                                for="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -191,7 +191,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                       </div>
                       <table
                         class="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabindex="-1"
                       >
                         <caption
@@ -214,7 +214,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                     class="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled=""
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     type="checkbox"
                                   />
                                   <div
@@ -520,7 +520,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                 checked={false}
                                 className="euiCheckbox__input"
                                 disabled={true}
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -529,7 +529,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                               />
                               <label
                                 className="euiCheckbox__label"
-                                htmlFor="_selection_column-checkbox_some_html_id"
+                                htmlFor="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -586,7 +586,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                       </div>
                       <table
                         className="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabIndex={-1}
                       >
                         <caption
@@ -615,7 +615,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                     className="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled={true}
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     onChange={[Function]}
                                     type="checkbox"
                                   />
@@ -949,7 +949,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                               <input
                                 aria-label="Select all rows"
                                 class="euiCheckbox__input"
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 type="checkbox"
                               />
                               <div
@@ -957,7 +957,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                               />
                               <label
                                 class="euiCheckbox__label"
-                                for="_selection_column-checkbox_some_html_id"
+                                for="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -1012,7 +1012,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                       </div>
                       <table
                         class="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabindex="-1"
                       >
                         <caption
@@ -1034,7 +1034,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                     aria-label="Select all rows"
                                     class="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     type="checkbox"
                                   />
                                   <div
@@ -1372,7 +1372,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                 class="euiPagination__item"
                               >
                                 <button
-                                  aria-controls="some_html_id"
+                                  aria-controls="random_html_id"
                                   aria-current="true"
                                   aria-label="Page 1 of 1"
                                   class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
@@ -1616,7 +1616,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                 checked={false}
                                 className="euiCheckbox__input"
                                 disabled={false}
-                                id="_selection_column-checkbox_some_html_id"
+                                id="_selection_column-checkbox_random_html_id"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -1625,7 +1625,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                               />
                               <label
                                 className="euiCheckbox__label"
-                                htmlFor="_selection_column-checkbox_some_html_id"
+                                htmlFor="_selection_column-checkbox_random_html_id"
                               >
                                 Select all rows
                               </label>
@@ -1683,7 +1683,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                       </div>
                       <table
                         className="euiTable euiTable--responsive"
-                        id="some_html_id"
+                        id="random_html_id"
                         tabIndex={-1}
                       >
                         <caption
@@ -1712,7 +1712,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                     className="euiCheckbox__input"
                                     data-test-subj="checkboxSelectAll"
                                     disabled={false}
-                                    id="_selection_column-checkbox_some_html_id"
+                                    id="_selection_column-checkbox_random_html_id"
                                     onChange={[Function]}
                                     type="checkbox"
                                   />
@@ -2110,7 +2110,7 @@ exports[`Delete fields modal in skipping index renders delete fields modal in sk
                                 className="euiPagination__item"
                               >
                                 <button
-                                  aria-controls="some_html_id"
+                                  aria-controls="random_html_id"
                                   aria-current={true}
                                   aria-label="Page 1 of 1"
                                   className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
@@ -1,0 +1,2234 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Delete fields modal in skipping index renders delete fields modal in skipping index with default options 1`] = `
+<Portal
+  containerInfo={
+    <div
+      class="euiOverlayMask euiOverlayMask--aboveHeader"
+    >
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+      <div
+        data-focus-lock-disabled="false"
+      >
+        <div
+          class="euiModal euiModal--maxWidth-default"
+          tabindex="0"
+        >
+          <button
+            aria-label="Closes this modal window"
+            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+              />
+            </svg>
+          </button>
+          <div
+            class="euiModal__flex"
+          >
+            <div
+              class="euiModalHeader"
+            >
+              <div
+                class="euiModalHeader__title"
+              >
+                <h1>
+                  Bulk delete
+                </h1>
+              </div>
+            </div>
+            <div
+              class="euiModalBody"
+            >
+              <div
+                class="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      class="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            class="euiFieldSearch euiFieldSearch--fullWidth"
+                            placeholder="Search..."
+                            type="search"
+                            value=""
+                          />
+                          <div
+                            class="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    class="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        class="euiTableHeaderMobile"
+                      >
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                class="euiCheckbox__input"
+                                disabled=""
+                                id="_selection_column-checkbox_some_html_id"
+                                type="checkbox"
+                              />
+                              <div
+                                class="euiCheckbox__square"
+                              />
+                              <label
+                                class="euiCheckbox__label"
+                                for="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiTableSortMobile"
+                            >
+                              <div
+                                class="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  class="euiPopover__anchor"
+                                >
+                                  <button
+                                    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                      <span
+                                        class="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        class="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabindex="-1"
+                      >
+                        <caption
+                          class="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              class="euiTableHeaderCellCheckbox"
+                              scope="col"
+                            >
+                              <div
+                                class="euiTableCellContent"
+                              >
+                                <div
+                                  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    class="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled=""
+                                    id="_selection_column-checkbox_some_html_id"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    class="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_accelerationMethod_2"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Acceleration method"
+                                  >
+                                    Acceleration method
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            class="euiTableRow"
+                          >
+                            <td
+                              class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                              colspan="4"
+                            >
+                              <div
+                                class="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  No items found
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiModalFooter"
+            >
+              <button
+                class="euiButton euiButton--primary"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                class="euiButton euiButton--danger euiButton--fill"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+    </div>
+  }
+>
+  Array [
+    Array [
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+      "",
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onScrollCapture={[Function]}
+        onTouchMoveCapture={[Function]}
+        onTouchStart={[Function]}
+        onWheelCapture={[Function]}
+      >
+        <div
+          className="euiModal euiModal--maxWidth-default"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <button
+            aria-label="Closes this modal window"
+            className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+              focusable="false"
+              height={16}
+              role="img"
+              style={null}
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+              />
+            </svg>
+          </button>
+          <div
+            className="euiModal__flex"
+          >
+            <div
+              className="euiModalHeader"
+            >
+              <div
+                className="euiModalHeader__title"
+              >
+                <h1>
+                  Bulk delete
+                </h1>
+              </div>
+            </div>
+            <div
+              className="euiModalBody"
+            >
+              <div
+                className="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      className="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            className="euiFieldSearch euiFieldSearch--fullWidth"
+                            defaultValue=""
+                            onKeyUp={[Function]}
+                            placeholder="Search..."
+                            type="search"
+                          />
+                          <div
+                            className="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              className="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    className="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        className="euiTableHeaderMobile"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                checked={false}
+                                className="euiCheckbox__input"
+                                disabled={true}
+                                id="_selection_column-checkbox_some_html_id"
+                                onChange={[Function]}
+                                type="checkbox"
+                              />
+                              <div
+                                className="euiCheckbox__square"
+                              />
+                              <label
+                                className="euiCheckbox__label"
+                                htmlFor="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiTableSortMobile"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        className="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabIndex={-1}
+                      >
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <div
+                                  className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={true}
+                                    id="_selection_column-checkbox_some_html_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_accelerationMethod_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Acceleration method"
+                                  >
+                                    Acceleration method
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <td
+                              className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                              colSpan={4}
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  No items found
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="euiModalFooter"
+            >
+              <button
+                className="euiButton euiButton--primary"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                className="euiButton euiButton--danger euiButton--fill"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>,
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+    ],
+    "",
+  ]
+</Portal>
+`;
+
+exports[`Delete fields modal in skipping index renders delete fields modal in skipping index with different options 1`] = `
+<Portal
+  containerInfo={
+    <div
+      class="euiOverlayMask euiOverlayMask--aboveHeader"
+    >
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+      <div
+        data-focus-lock-disabled="false"
+      >
+        <div
+          class="euiModal euiModal--maxWidth-default"
+          tabindex="0"
+        >
+          <button
+            aria-label="Closes this modal window"
+            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+              />
+            </svg>
+          </button>
+          <div
+            class="euiModal__flex"
+          >
+            <div
+              class="euiModalHeader"
+            >
+              <div
+                class="euiModalHeader__title"
+              >
+                <h1>
+                  Bulk delete
+                </h1>
+              </div>
+            </div>
+            <div
+              class="euiModalBody"
+            >
+              <div
+                class="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      class="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            class="euiFieldSearch euiFieldSearch--fullWidth"
+                            placeholder="Search..."
+                            type="search"
+                            value=""
+                          />
+                          <div
+                            class="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    class="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        class="euiTableHeaderMobile"
+                      >
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                class="euiCheckbox__input"
+                                id="_selection_column-checkbox_some_html_id"
+                                type="checkbox"
+                              />
+                              <div
+                                class="euiCheckbox__square"
+                              />
+                              <label
+                                class="euiCheckbox__label"
+                                for="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiTableSortMobile"
+                            >
+                              <div
+                                class="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  class="euiPopover__anchor"
+                                >
+                                  <button
+                                    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                          fill-rule="non-zero"
+                                        />
+                                      </svg>
+                                      <span
+                                        class="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        class="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabindex="-1"
+                      >
+                        <caption
+                          class="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              class="euiTableHeaderCellCheckbox"
+                              scope="col"
+                            >
+                              <div
+                                class="euiTableCellContent"
+                              >
+                                <div
+                                  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    class="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    id="_selection_column-checkbox_some_html_id"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    class="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              class="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_accelerationMethod_2"
+                              role="columnheader"
+                              scope="col"
+                            >
+                              <button
+                                class="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Acceleration method"
+                                  >
+                                    Acceleration method
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            class="euiTableRow euiTableRow-isSelectable"
+                          >
+                            <td
+                              class="euiTableRowCellCheckbox"
+                            >
+                              <div
+                                class="euiTableCellContent"
+                              >
+                                <div
+                                  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select this row"
+                                    class="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectRow-1"
+                                    id="_selection_column_1-checkbox"
+                                    title="Select this row"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    class="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              class="euiTableRowCell"
+                            >
+                              <div
+                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Field name
+                              </div>
+                              <div
+                                class="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  field1
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              class="euiTableRowCell"
+                            >
+                              <div
+                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Datatype
+                              </div>
+                              <div
+                                class="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  string
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              class="euiTableRowCell"
+                            >
+                              <div
+                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Acceleration method
+                              </div>
+                              <div
+                                class="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  PARTITION
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                          <tr
+                            class="euiTableRow euiTableRow-isSelectable"
+                          >
+                            <td
+                              class="euiTableRowCellCheckbox"
+                            >
+                              <div
+                                class="euiTableCellContent"
+                              >
+                                <div
+                                  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select this row"
+                                    class="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectRow-2"
+                                    id="_selection_column_2-checkbox"
+                                    title="Select this row"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    class="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              class="euiTableRowCell"
+                            >
+                              <div
+                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Field name
+                              </div>
+                              <div
+                                class="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  field2
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              class="euiTableRowCell"
+                            >
+                              <div
+                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Datatype
+                              </div>
+                              <div
+                                class="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  number
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              class="euiTableRowCell"
+                            >
+                              <div
+                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Acceleration method
+                              </div>
+                              <div
+                                class="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  class="euiTableCellContent__text"
+                                >
+                                  VALUE_SET
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <div>
+                      <div
+                        class="euiSpacer euiSpacer--m"
+                      />
+                      <div
+                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <div
+                          class="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <div
+                            class="euiPopover euiPopover--anchorUpRight"
+                          >
+                            <div
+                              class="euiPopover__anchor"
+                            >
+                              <button
+                                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                data-test-subj="tablePaginationPopoverButton"
+                                type="button"
+                              >
+                                <span
+                                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fill-rule="non-zero"
+                                    />
+                                  </svg>
+                                  <span
+                                    class="euiButtonEmpty__text"
+                                  >
+                                    Rows per page
+                                    : 
+                                    20
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <nav
+                            class="euiPagination"
+                          >
+                            <button
+                              aria-label="Previous page"
+                              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                              data-test-subj="pagination-button-previous"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </button>
+                            <ul
+                              class="euiPagination__list"
+                            >
+                              <li
+                                class="euiPagination__item"
+                              >
+                                <button
+                                  aria-controls="some_html_id"
+                                  aria-current="true"
+                                  aria-label="Page 1 of 1"
+                                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                  data-test-subj="pagination-button-0"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButtonEmpty__content"
+                                  >
+                                    <span
+                                      class="euiButtonEmpty__text"
+                                    >
+                                      1
+                                    </span>
+                                  </span>
+                                </button>
+                              </li>
+                            </ul>
+                            <button
+                              aria-label="Next page"
+                              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                              data-test-subj="pagination-button-next"
+                              disabled=""
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </button>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiModalFooter"
+            >
+              <button
+                class="euiButton euiButton--primary"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                class="euiButton euiButton--danger euiButton--fill"
+                type="button"
+              >
+                <span
+                  class="euiButtonContent euiButton__content"
+                >
+                  <span
+                    class="euiButton__text"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        data-aria-hidden="true"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
+    </div>
+  }
+>
+  Array [
+    Array [
+      <div
+        data-focus-guard={true}
+        key="guard-first"
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+      "",
+      <div
+        data-focus-lock-disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onScrollCapture={[Function]}
+        onTouchMoveCapture={[Function]}
+        onTouchStart={[Function]}
+        onWheelCapture={[Function]}
+      >
+        <div
+          className="euiModal euiModal--maxWidth-default"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <button
+            aria-label="Closes this modal window"
+            className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiModal__closeIcon"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+              focusable="false"
+              height={16}
+              role="img"
+              style={null}
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+              />
+            </svg>
+          </button>
+          <div
+            className="euiModal__flex"
+          >
+            <div
+              className="euiModalHeader"
+            >
+              <div
+                className="euiModalHeader__title"
+              >
+                <h1>
+                  Bulk delete
+                </h1>
+              </div>
+            </div>
+            <div
+              className="euiModalBody"
+            >
+              <div
+                className="euiModalBody__overflow"
+              >
+                <div>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                  >
+                    <div
+                      className="euiFlexItem euiSearchBar__searchHolder"
+                    >
+                      <div
+                        className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                      >
+                        <div
+                          className="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+                            className="euiFieldSearch euiFieldSearch--fullWidth"
+                            defaultValue=""
+                            onKeyUp={[Function]}
+                            placeholder="Search..."
+                            type="search"
+                          />
+                          <div
+                            className="euiFormControlLayoutIcons"
+                          >
+                            <span
+                              className="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                  <div
+                    className="euiBasicTable"
+                  >
+                    <div>
+                      <div
+                        className="euiTableHeaderMobile"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiCheckbox"
+                            >
+                              <input
+                                aria-label="Select all rows"
+                                checked={false}
+                                className="euiCheckbox__input"
+                                disabled={false}
+                                id="_selection_column-checkbox_some_html_id"
+                                onChange={[Function]}
+                                type="checkbox"
+                              />
+                              <div
+                                className="euiCheckbox__square"
+                              />
+                              <label
+                                className="euiCheckbox__label"
+                                htmlFor="_selection_column-checkbox_some_html_id"
+                              >
+                                Select all rows
+                              </label>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              className="euiTableSortMobile"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorDownRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                          fillRule="non-zero"
+                                        />
+                                      </svg>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Sorting
+                                      </span>
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <table
+                        className="euiTable euiTable--responsive"
+                        id="some_html_id"
+                        tabIndex={-1}
+                      >
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        />
+                        <thead>
+                          <tr>
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <div
+                                  className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectAll"
+                                    disabled={false}
+                                    id="_selection_column-checkbox_some_html_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_fieldName_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Field name"
+                                  >
+                                    Field name
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_dataType_1"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Datatype"
+                                  >
+                                    Datatype
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_accelerationMethod_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                    title="Acceleration method"
+                                  >
+                                    Acceleration method
+                                  </span>
+                                </span>
+                              </button>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <tr
+                            className="euiTableRow euiTableRow-isSelectable"
+                          >
+                            <td
+                              className="euiTableRowCellCheckbox"
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <div
+                                  className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select this row"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectRow-1"
+                                    disabled={false}
+                                    id="_selection_column_1-checkbox"
+                                    onChange={[Function]}
+                                    title="Select this row"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Field name
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  field1
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Datatype
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  string
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Acceleration method
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  PARTITION
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                          <tr
+                            className="euiTableRow euiTableRow-isSelectable"
+                          >
+                            <td
+                              className="euiTableRowCellCheckbox"
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <div
+                                  className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                >
+                                  <input
+                                    aria-label="Select this row"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    data-test-subj="checkboxSelectRow-2"
+                                    disabled={false}
+                                    id="_selection_column_2-checkbox"
+                                    onChange={[Function]}
+                                    title="Select this row"
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                </div>
+                              </div>
+                            </td>
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Field name
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  field2
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Datatype
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  number
+                                </span>
+                              </div>
+                            </td>
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Acceleration method
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  VALUE_SET
+                                </span>
+                              </div>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <div>
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <div
+                            className="euiPopover euiPopover--anchorUpRight"
+                          >
+                            <div
+                              className="euiPopover__anchor"
+                            >
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                data-test-subj="tablePaginationPopoverButton"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fillRule="non-zero"
+                                    />
+                                  </svg>
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    Rows per page
+                                    : 
+                                    20
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <nav
+                            className="euiPagination"
+                          >
+                            <button
+                              aria-label="Previous page"
+                              className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                              data-test-subj="pagination-button-previous"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </button>
+                            <ul
+                              className="euiPagination__list"
+                            >
+                              <li
+                                className="euiPagination__item"
+                              >
+                                <button
+                                  aria-controls="some_html_id"
+                                  aria-current={true}
+                                  aria-label="Page 1 of 1"
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                  data-test-subj="pagination-button-0"
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="euiButtonContent euiButtonEmpty__content"
+                                  >
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      1
+                                    </span>
+                                  </span>
+                                </button>
+                              </li>
+                            </ul>
+                            <button
+                              aria-label="Next page"
+                              className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                              data-test-subj="pagination-button-next"
+                              disabled={true}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </button>
+                          </nav>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="euiModalFooter"
+            >
+              <button
+                className="euiButton euiButton--primary"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Cancel
+                  </span>
+                </span>
+              </button>
+              <button
+                className="euiButton euiButton--danger euiButton--fill"
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  Object {
+                    "minWidth": undefined,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButton__content"
+                >
+                  <span
+                    className="euiButton__text"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>,
+      <div
+        data-focus-guard={true}
+        style={
+          Object {
+            "height": "0px",
+            "left": "1px",
+            "overflow": "hidden",
+            "padding": 0,
+            "position": "fixed",
+            "top": "1px",
+            "width": "1px",
+          }
+        }
+        tabIndex={0}
+      />,
+    ],
+    "",
+  ]
+</Portal>
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
@@ -1,0 +1,883 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Builder components in materialized view renders builder components in materialized view with default options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="skipping-index-builder"
+  >
+    <h3>
+      Skipping index definition
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiBasicTable"
+    itemID="id"
+  >
+    <div>
+      <div
+        className="euiTableHeaderMobile"
+      >
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          />
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          />
+        </div>
+      </div>
+      <table
+        className="euiTable euiTable--responsive"
+        id="some_html_id"
+        tabIndex={-1}
+      >
+        <caption
+          className="euiScreenReaderOnly euiTableCaption"
+        />
+        <thead>
+          <tr>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_fieldName_0"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Field name"
+                >
+                  Field name
+                </span>
+              </span>
+            </th>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_dataType_1"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Datatype"
+                >
+                  Datatype
+                </span>
+              </span>
+            </th>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_Acceleration method_2"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Acceleration method"
+                >
+                  Acceleration method
+                </span>
+              </span>
+            </th>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_Delete_3"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Delete"
+                >
+                  Delete
+                </span>
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            className="euiTableRow"
+          >
+            <td
+              className="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+              colSpan={4}
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableCellContent euiTableCellContent--alignCenter"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                >
+                  No items found
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <button
+        className="euiButton euiButton--primary euiButton--fill"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "minWidth": undefined,
+          }
+        }
+        type="button"
+      >
+        <span
+          className="euiButtonContent euiButton__content"
+        >
+          <span
+            className="euiButton__text"
+          >
+            Add fields
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <button
+        className="euiButton euiButton--danger"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "minWidth": undefined,
+          }
+        }
+        type="button"
+      >
+        <span
+          className="euiButtonContent euiButton__content"
+        >
+          <span
+            className="euiButton__text"
+          >
+            Bulk delete
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Builder components in materialized view renders builder components in materialized view with different options 1`] = `
+Array [
+  <div
+    className="euiText euiText--medium"
+    data-test-subj="skipping-index-builder"
+  >
+    <h3>
+      Skipping index definition
+    </h3>
+  </div>,
+  <div
+    className="euiSpacer euiSpacer--s"
+  />,
+  <div
+    className="euiBasicTable"
+    itemID="id"
+  >
+    <div>
+      <div
+        className="euiTableHeaderMobile"
+      >
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          />
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          />
+        </div>
+      </div>
+      <table
+        className="euiTable euiTable--responsive"
+        id="some_html_id"
+        tabIndex={-1}
+      >
+        <caption
+          className="euiScreenReaderOnly euiTableCaption"
+        />
+        <thead>
+          <tr>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_fieldName_0"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Field name"
+                >
+                  Field name
+                </span>
+              </span>
+            </th>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_dataType_1"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Datatype"
+                >
+                  Datatype
+                </span>
+              </span>
+            </th>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_Acceleration method_2"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Acceleration method"
+                >
+                  Acceleration method
+                </span>
+              </span>
+            </th>
+            <th
+              className="euiTableHeaderCell"
+              data-test-subj="tableHeaderCell_Delete_3"
+              role="columnheader"
+              scope="col"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <span
+                className="euiTableCellContent"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                  title="Delete"
+                >
+                  Delete
+                </span>
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            className="euiTableRow euiTableRow-hasActions"
+          >
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Field name
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--truncateText"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                >
+                  field1
+                </span>
+              </div>
+            </td>
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Datatype
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--truncateText"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                >
+                  string
+                </span>
+              </div>
+            </td>
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Acceleration method
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--overflowingContent"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <select
+                      aria-label="Use aria labels when no actual label is in use"
+                      className="euiSelect"
+                      id="selectDocExample"
+                      onChange={[Function]}
+                      onMouseUp={[Function]}
+                      value="PARTITION"
+                    >
+                      <option
+                        key="0"
+                        value="PARTITION"
+                      >
+                        Partition
+                      </option>
+                      <option
+                        key="1"
+                        value="VALUE_SET"
+                      >
+                        Value Set
+                      </option>
+                      <option
+                        key="2"
+                        value="MIN_MAX"
+                      >
+                        Min Max
+                      </option>
+                    </select>
+                    <div
+                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <span
+                        className="euiFormControlLayoutCustomIcon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Delete
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--overflowingContent"
+              >
+                <button
+                  className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                    focusable="false"
+                    height={16}
+                    role="img"
+                    style={null}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </td>
+          </tr>
+          <tr
+            className="euiTableRow euiTableRow-hasActions"
+          >
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Field name
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--truncateText"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                >
+                  field2
+                </span>
+              </div>
+            </td>
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Datatype
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--truncateText"
+              >
+                <span
+                  className="euiTableCellContent__text"
+                >
+                  number
+                </span>
+              </div>
+            </td>
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Acceleration method
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--overflowingContent"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <select
+                      aria-label="Use aria labels when no actual label is in use"
+                      className="euiSelect"
+                      id="selectDocExample"
+                      onChange={[Function]}
+                      onMouseUp={[Function]}
+                      value="VALUE_SET"
+                    >
+                      <option
+                        key="0"
+                        value="PARTITION"
+                      >
+                        Partition
+                      </option>
+                      <option
+                        key="1"
+                        value="VALUE_SET"
+                      >
+                        Value Set
+                      </option>
+                      <option
+                        key="2"
+                        value="MIN_MAX"
+                      >
+                        Min Max
+                      </option>
+                    </select>
+                    <div
+                      className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <span
+                        className="euiFormControlLayoutCustomIcon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                          />
+                        </svg>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              className="euiTableRowCell"
+              style={
+                Object {
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+              >
+                Delete
+              </div>
+              <div
+                className="euiTableCellContent euiTableCellContent--overflowingContent"
+              >
+                <button
+                  className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                    focusable="false"
+                    height={16}
+                    role="img"
+                    style={null}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <div
+        className="euiSpacer euiSpacer--m"
+      />
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+      >
+        <div
+          className="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            className="euiPopover euiPopover--anchorUpRight"
+          >
+            <div
+              className="euiPopover__anchor"
+            >
+              <button
+                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                data-test-subj="tablePaginationPopoverButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span
+                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                    focusable="false"
+                    height={16}
+                    role="img"
+                    style={null}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                  <span
+                    className="euiButtonEmpty__text"
+                  >
+                    Rows per page
+                    : 
+                    20
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <nav
+            className="euiPagination"
+          >
+            <button
+              aria-label="Previous page"
+              className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+              data-test-subj="pagination-button-previous"
+              disabled={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                />
+              </svg>
+            </button>
+            <ul
+              className="euiPagination__list"
+            >
+              <li
+                className="euiPagination__item"
+              >
+                <button
+                  aria-controls="some_html_id"
+                  aria-current={true}
+                  aria-label="Page 1 of 1"
+                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                  data-test-subj="pagination-button-0"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="euiButtonContent euiButtonEmpty__content"
+                  >
+                    <span
+                      className="euiButtonEmpty__text"
+                    >
+                      1
+                    </span>
+                  </span>
+                </button>
+              </li>
+            </ul>
+            <button
+              aria-label="Next page"
+              className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+              data-test-subj="pagination-button-next"
+              disabled={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                focusable="false"
+                height={16}
+                role="img"
+                style={null}
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                />
+              </svg>
+            </button>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+  >
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <button
+        className="euiButton euiButton--primary euiButton--fill"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "minWidth": undefined,
+          }
+        }
+        type="button"
+      >
+        <span
+          className="euiButtonContent euiButton__content"
+        >
+          <span
+            className="euiButton__text"
+          >
+            Add fields
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      className="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <button
+        className="euiButton euiButton--danger"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "minWidth": undefined,
+          }
+        }
+        type="button"
+      >
+        <span
+          className="euiButtonContent euiButton__content"
+        >
+          <span
+            className="euiButton__text"
+          >
+            Bulk delete
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
@@ -34,7 +34,7 @@ Array [
       </div>
       <table
         className="euiTable euiTable--responsive"
-        id="some_html_id"
+        id="random_html_id"
         tabIndex={-1}
       >
         <caption
@@ -251,7 +251,7 @@ Array [
       </div>
       <table
         className="euiTable euiTable--responsive"
-        id="some_html_id"
+        id="random_html_id"
         tabIndex={-1}
       >
         <caption
@@ -775,7 +775,7 @@ Array [
                 className="euiPagination__item"
               >
                 <button
-                  aria-controls="some_html_id"
+                  aria-controls="random_html_id"
                   aria-current={true}
                   aria-label="Page 1 of 1"
                   className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/add_fields_modal.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/add_fields_modal.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  skippingIndexDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { AddFieldsModal } from '../add_fields_modal';
+
+describe('Add fields modal in skipping index', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders add fields modal in skipping index with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const setIsAddModalVisible = jest.fn();
+    const wrapper = mount(
+      <AddFieldsModal
+        setIsAddModalVisible={setIsAddModalVisible}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders add fields modal in skipping index with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'skipping',
+      skippingIndexQueryData: skippingIndexDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const setIsAddModalVisible = jest.fn();
+    const wrapper = mount(
+      <AddFieldsModal
+        setIsAddModalVisible={setIsAddModalVisible}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/delete_fields_modal.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/delete_fields_modal.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  skippingIndexDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { DeleteFieldsModal } from '../delete_fields_modal';
+
+describe('Delete fields modal in skipping index', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders delete fields modal in skipping index with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const setIsDeleteModalVisible = jest.fn();
+    const wrapper = mount(
+      <DeleteFieldsModal
+        setIsDeleteModalVisible={setIsDeleteModalVisible}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders delete fields modal in skipping index with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'skipping',
+      skippingIndexQueryData: skippingIndexDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const setIsDeleteModalVisible = jest.fn();
+    const wrapper = mount(
+      <DeleteFieldsModal
+        setIsDeleteModalVisible={setIsDeleteModalVisible}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/skipping_index_builder.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/__tests__/skipping_index_builder.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
+import {
+  createAccelerationEmptyDataMock,
+  skippingIndexDataMock,
+} from '../../../../../../../../../test/accelerations';
+import { SkippingIndexBuilder } from '../skipping_index_builder';
+
+describe('Builder components in materialized view', () => {
+  configure({ adapter: new Adapter() });
+
+  it('renders builder components in materialized view with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <SkippingIndexBuilder
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+
+  it('renders builder components in materialized view with different options', async () => {
+    const accelerationFormData: CreateAccelerationForm = {
+      ...createAccelerationEmptyDataMock,
+      accelerationIndexType: 'skipping',
+      skippingIndexQueryData: skippingIndexDataMock,
+    };
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <SkippingIndexBuilder
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/add_fields_modal.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/add_fields_modal.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiInMemoryTable,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiTableFieldDataColumnType,
+} from '@elastic/eui';
+import producer from 'immer';
+import _ from 'lodash';
+import React, { useState } from 'react';
+import {
+  CreateAccelerationForm,
+  DataTableFieldsType,
+  SkippingIndexRowType,
+} from '../../../../../../../../common/types/data_connections';
+import { validateSkippingIndexData } from '../../create/utils';
+
+interface AddFieldsModalProps {
+  setIsAddModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const AddFieldsModal = ({
+  setIsAddModalVisible,
+  accelerationFormData,
+  setAccelerationFormData,
+}: AddFieldsModalProps) => {
+  const [selectedFields, setSelectedFields] = useState<DataTableFieldsType[]>([]);
+
+  const tableColumns: Array<EuiTableFieldDataColumnType<DataTableFieldsType>> = [
+    {
+      field: 'fieldName',
+      name: 'Field name',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'dataType',
+      name: 'Datatype',
+      sortable: true,
+      truncateText: true,
+    },
+  ];
+
+  const pagination = {
+    initialPageSize: 20,
+    pageSizeOptions: [10, 20, 50],
+  };
+
+  return (
+    <EuiModal onClose={() => setIsAddModalVisible(false)}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <h1>Add fields</h1>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiInMemoryTable
+          items={_.differenceBy(
+            accelerationFormData.dataTableFields,
+            accelerationFormData.skippingIndexQueryData,
+            'id'
+          )}
+          itemId="id"
+          columns={tableColumns}
+          search={true}
+          pagination={pagination}
+          sorting={true}
+          isSelectable={true}
+          selection={{
+            onSelectionChange: (items) => setSelectedFields(items),
+          }}
+        />
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButton onClick={() => setIsAddModalVisible(false)}>Cancel</EuiButton>
+        <EuiButton
+          onClick={() => {
+            setAccelerationFormData(
+              producer((accData) => {
+                accData.skippingIndexQueryData.push(
+                  ...selectedFields.map((x) => {
+                    return { ...x, accelerationMethod: 'PARTITION' } as SkippingIndexRowType;
+                  })
+                );
+                accData.formErrors.skippingIndexError = validateSkippingIndexData(
+                  accData.accelerationIndexType,
+                  accData.skippingIndexQueryData
+                );
+              })
+            );
+            setIsAddModalVisible(false);
+          }}
+          fill
+        >
+          Add
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/delete_fields_modal.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/delete_fields_modal.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButton,
+  EuiInMemoryTable,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiTableFieldDataColumnType,
+} from '@elastic/eui';
+import _ from 'lodash';
+import React, { useState } from 'react';
+import {
+  CreateAccelerationForm,
+  SkippingIndexRowType,
+} from '../../../../../../../../common/types/data_connections';
+
+interface AddFieldsModalProps {
+  setIsDeleteModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const DeleteFieldsModal = ({
+  setIsDeleteModalVisible,
+  accelerationFormData,
+  setAccelerationFormData,
+}: AddFieldsModalProps) => {
+  const [selectedFields, setSelectedFields] = useState<SkippingIndexRowType[]>([]);
+
+  const tableColumns: Array<EuiTableFieldDataColumnType<SkippingIndexRowType>> = [
+    {
+      field: 'fieldName',
+      name: 'Field name',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'dataType',
+      name: 'Datatype',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'accelerationMethod',
+      name: 'Acceleration method',
+      sortable: true,
+      truncateText: true,
+    },
+  ];
+
+  const pagination = {
+    initialPageSize: 20,
+    pageSizeOptions: [10, 20, 50],
+  };
+
+  return (
+    <EuiModal onClose={() => setIsDeleteModalVisible(false)}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <h1>Bulk delete</h1>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        <EuiInMemoryTable
+          items={accelerationFormData.skippingIndexQueryData}
+          itemId="id"
+          columns={tableColumns}
+          search={true}
+          pagination={pagination}
+          sorting={true}
+          isSelectable={true}
+          selection={{
+            onSelectionChange: (items) => setSelectedFields(items),
+          }}
+        />
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButton onClick={() => setIsDeleteModalVisible(false)}>Cancel</EuiButton>
+        <EuiButton
+          onClick={() => {
+            setAccelerationFormData({
+              ...accelerationFormData,
+              skippingIndexQueryData: _.differenceBy(
+                accelerationFormData.skippingIndexQueryData,
+                selectedFields,
+                'id'
+              ),
+            });
+            setIsDeleteModalVisible(false);
+          }}
+          color="danger"
+          fill
+        >
+          Delete
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/skipping_index_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/visual_editors/skipping_index/skipping_index_builder.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiBasicTable,
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import producer from 'immer';
+import React, { useEffect, useState } from 'react';
+import { SKIPPING_INDEX_ACCELERATION_METHODS } from '../../../../../../../../common/constants/data_sources';
+import {
+  CreateAccelerationForm,
+  SkippingIndexAccMethodType,
+  SkippingIndexRowType,
+} from '../../../../../../../../common/types/data_connections';
+import { validateSkippingIndexData } from '../../create/utils';
+import { AddFieldsModal } from './add_fields_modal';
+import { DeleteFieldsModal } from './delete_fields_modal';
+
+interface SkippingIndexBuilderProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+}
+
+export const SkippingIndexBuilder = ({
+  accelerationFormData,
+  setAccelerationFormData,
+}: SkippingIndexBuilderProps) => {
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+  const [totalItemCount, setTotalItemCount] = useState(0);
+
+  const [isAddModalVisible, setIsAddModalVisible] = useState(false);
+  const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
+
+  let modal;
+
+  if (isAddModalVisible)
+    modal = (
+      <AddFieldsModal
+        setIsAddModalVisible={setIsAddModalVisible}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+
+  if (isDeleteModalVisible)
+    modal = (
+      <DeleteFieldsModal
+        setIsDeleteModalVisible={setIsDeleteModalVisible}
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+      />
+    );
+
+  const onTableChange = (page: { index: number; size: number }) => {
+    setPageIndex(page.index);
+    setPageSize(page.size);
+  };
+
+  const onChangeAccelerationMethod = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+    updateRow: SkippingIndexRowType
+  ) => {
+    setAccelerationFormData({
+      ...accelerationFormData,
+      skippingIndexQueryData: accelerationFormData.skippingIndexQueryData.map((row) =>
+        row.id === updateRow.id
+          ? { ...row, accelerationMethod: e.target.value as SkippingIndexAccMethodType }
+          : row
+      ),
+    });
+  };
+
+  const columns = [
+    {
+      field: 'fieldName',
+      name: 'Field name',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'dataType',
+      name: 'Datatype',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      name: 'Acceleration method',
+      render: (item: SkippingIndexRowType) => (
+        <EuiSelect
+          id="selectDocExample"
+          options={SKIPPING_INDEX_ACCELERATION_METHODS}
+          value={item.accelerationMethod}
+          onChange={(e) => onChangeAccelerationMethod(e, item)}
+          aria-label="Use aria labels when no actual label is in use"
+        />
+      ),
+    },
+    {
+      name: 'Delete',
+      render: (item: SkippingIndexRowType) => {
+        return (
+          <EuiButtonIcon
+            onClick={() => {
+              setAccelerationFormData({
+                ...accelerationFormData,
+                skippingIndexQueryData: accelerationFormData.skippingIndexQueryData.filter(
+                  (o) => item.id !== o.id
+                ),
+              });
+            }}
+            iconType="trash"
+            color="danger"
+          />
+        );
+      },
+    },
+  ];
+
+  const pagination = {
+    pageIndex,
+    pageSize,
+    totalItemCount,
+    pageSizeOptions: [10, 20, 50],
+  };
+
+  useEffect(() => {
+    if (accelerationFormData.dataTableFields.length > 0) {
+      const tableRows: SkippingIndexRowType[] = [
+        {
+          ...accelerationFormData.dataTableFields[0],
+          accelerationMethod: 'PARTITION',
+        },
+      ];
+      setAccelerationFormData(
+        producer((accData) => {
+          accData.skippingIndexQueryData = tableRows;
+          accData.formErrors.skippingIndexError = validateSkippingIndexData(
+            accData.accelerationIndexType,
+            tableRows
+          );
+        })
+      );
+    } else {
+      setAccelerationFormData({ ...accelerationFormData, skippingIndexQueryData: [] });
+    }
+  }, [accelerationFormData.dataTableFields]);
+
+  useEffect(() => {
+    setTotalItemCount(accelerationFormData.skippingIndexQueryData.length);
+  }, [accelerationFormData.skippingIndexQueryData]);
+
+  return (
+    <>
+      <EuiText data-test-subj="skipping-index-builder">
+        <h3>Skipping index definition</h3>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiBasicTable
+        itemID="id"
+        items={accelerationFormData.skippingIndexQueryData.slice(
+          pageSize * pageIndex,
+          pageSize * (pageIndex + 1)
+        )}
+        columns={columns}
+        pagination={pagination}
+        onChange={({ page }) => onTableChange(page)}
+        hasActions={true}
+        error={accelerationFormData.formErrors.skippingIndexError.join('')}
+      />
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+        <EuiFlexItem grow={false}>
+          <EuiButton fill onClick={() => setIsAddModalVisible(true)}>
+            Add fields
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={() => setIsDeleteModalVisible(true)} color="danger">
+            Bulk delete
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {modal}
+    </>
+  );
+};

--- a/test/accelerations.ts
+++ b/test/accelerations.ts
@@ -1,0 +1,436 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+  ACCELERATION_TIME_INTERVAL,
+} from '../common/constants/data_sources';
+import {
+  CreateAccelerationForm,
+  MaterializedViewQueryType,
+  SkippingIndexRowType,
+} from '../common/types/data_connections';
+
+export const skippingIndexDataMock: SkippingIndexRowType[] = [
+  {
+    id: '1',
+    fieldName: 'field1',
+    dataType: 'string',
+    accelerationMethod: 'PARTITION',
+  },
+  {
+    id: '2',
+    fieldName: 'field2',
+    dataType: 'number',
+    accelerationMethod: 'VALUE_SET',
+  },
+];
+
+export const coveringIndexDataMock: string[] = ['field1', 'field2', 'field3'];
+
+export const materializedViewEmptyDataMock = {
+  columnsValues: [],
+  groupByTumbleValue: {
+    timeField: '',
+    tumbleWindow: 0,
+    tumbleInterval: '',
+  },
+};
+
+export const materializedViewEmptyTumbleDataMock: MaterializedViewQueryType = {
+  columnsValues: [
+    {
+      id: '1',
+      functionName: 'count',
+      functionParam: 'field1',
+    },
+  ],
+  groupByTumbleValue: {
+    timeField: '',
+    tumbleWindow: 0,
+    tumbleInterval: 'second',
+  },
+};
+
+export const materializedViewStaleDataMock: MaterializedViewQueryType = {
+  columnsValues: [],
+  groupByTumbleValue: {
+    timeField: 'timestamp',
+    tumbleWindow: 10,
+    tumbleInterval: 'hour',
+  },
+};
+
+export const materializedViewValidDataMock: MaterializedViewQueryType = {
+  columnsValues: [
+    {
+      id: '1',
+      functionName: 'count',
+      functionParam: 'field1',
+    },
+    {
+      id: '2',
+      functionName: 'sum',
+      functionParam: 'field2',
+    },
+  ],
+  groupByTumbleValue: {
+    timeField: 'timestamp',
+    tumbleWindow: 5,
+    tumbleInterval: 'hour',
+  },
+};
+
+export const createAccelerationEmptyDataMock: CreateAccelerationForm = {
+  dataSource: '',
+  dataTable: '',
+  database: '',
+  dataTableFields: [],
+  accelerationIndexType: 'skipping',
+  skippingIndexQueryData: [],
+  coveringIndexQueryData: [],
+  materializedViewQueryData: {
+    columnsValues: [],
+    groupByTumbleValue: {
+      timeField: '',
+      tumbleWindow: 0,
+      tumbleInterval: '',
+    },
+  },
+  accelerationIndexName: ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+  primaryShardsCount: 5,
+  replicaShardsCount: 1,
+  refreshType: 'auto',
+  checkpointLocation: undefined,
+  refreshIntervalOptions: {
+    refreshWindow: 1,
+    refreshInterval: ACCELERATION_TIME_INTERVAL[1].value,
+  },
+  watermarkDelay: {
+    delayWindow: 1,
+    delayInterval: ACCELERATION_TIME_INTERVAL[1].value,
+  },
+  formErrors: {
+    dataSourceError: [],
+    databaseError: [],
+    dataTableError: [],
+    skippingIndexError: [],
+    coveringIndexError: [],
+    materializedViewError: [],
+    indexNameError: [],
+    primaryShardsError: [],
+    replicaShardsError: [],
+    refreshIntervalError: [],
+    checkpointLocationError: [],
+    watermarkDelayError: [],
+  },
+};
+
+export const indexOptionsMock1: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  primaryShardsCount: 3,
+  replicaShardsCount: 2,
+  refreshType: 'auto',
+};
+
+export const indexOptionsMockResult1 = `WITH (
+index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
+auto_refresh = true
+)`;
+
+export const indexOptionsMock2: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  primaryShardsCount: 3,
+  replicaShardsCount: 2,
+  refreshType: 'interval',
+  refreshIntervalOptions: {
+    refreshWindow: 10,
+    refreshInterval: 'minute',
+  },
+};
+
+export const indexOptionsMockResult2 = `WITH (
+index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
+auto_refresh = true,
+refresh_interval = '10 minutes'
+)`;
+
+export const indexOptionsMock3: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  primaryShardsCount: 3,
+  replicaShardsCount: 2,
+  refreshType: 'auto',
+  checkpointLocation: 's3://path/to/checkpoint',
+};
+
+export const indexOptionsMockResult3 = `WITH (
+index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
+auto_refresh = true,
+checkpoint_location = 's3://path/to/checkpoint'
+)`;
+
+export const indexOptionsMock4: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  primaryShardsCount: 3,
+  replicaShardsCount: 2,
+  refreshType: 'manual',
+};
+
+export const indexOptionsMockResult4 = `WITH (
+index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
+auto_refresh = false
+)`;
+
+export const indexOptionsMock5: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  accelerationIndexType: 'materialized',
+  primaryShardsCount: 3,
+  replicaShardsCount: 2,
+  refreshType: 'manual',
+  watermarkDelay: {
+    delayWindow: 10,
+    delayInterval: 'minute',
+  },
+};
+
+export const indexOptionsMockResult5 = `WITH (
+index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
+auto_refresh = false,
+watermark_delay = '10 minutes'
+)`;
+
+export const skippingIndexBuilderMock1: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  dataSource: 'datasource',
+  database: 'database',
+  dataTable: 'table',
+  skippingIndexQueryData: [
+    {
+      id: '1',
+      fieldName: 'field1',
+      dataType: 'string',
+      accelerationMethod: 'PARTITION',
+    },
+    {
+      id: '2',
+      fieldName: 'field2',
+      dataType: 'int',
+      accelerationMethod: 'VALUE_SET',
+    },
+    {
+      id: '3',
+      fieldName: 'field3',
+      dataType: 'boolean',
+      accelerationMethod: 'MIN_MAX',
+    },
+  ],
+  primaryShardsCount: 9,
+  replicaShardsCount: 2,
+  refreshType: 'interval',
+  refreshIntervalOptions: {
+    refreshWindow: 1,
+    refreshInterval: 'minute',
+  },
+  checkpointLocation: 's3://test/',
+};
+
+export const indexOptionsMock6: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  primaryShardsCount: 1,
+  replicaShardsCount: 1,
+  refreshType: 'manual',
+  checkpointLocation: 's3://dsfsad/dasda',
+};
+
+export const indexOptionsMockResult6 = `WITH (
+index_settings = '{"number_of_shards":1,"number_of_replicas":1}',
+auto_refresh = false
+)`;
+
+export const skippingIndexBuilderMockResult1 = `CREATE SKIPPING INDEX
+ON datasource.database.table (
+   \`field1\` PARTITION, 
+   \`field2\` VALUE_SET, 
+   \`field3\` MIN_MAX
+  ) WITH (
+index_settings = '{"number_of_shards":9,"number_of_replicas":2}',
+auto_refresh = true,
+refresh_interval = '1 minute',
+checkpoint_location = 's3://test/'
+)`;
+
+export const skippingIndexBuilderMock2: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  dataSource: 'datasource',
+  database: 'database',
+  dataTable: 'table',
+  skippingIndexQueryData: [
+    {
+      id: '1',
+      fieldName: 'field1',
+      dataType: 'string',
+      accelerationMethod: 'PARTITION',
+    },
+  ],
+  primaryShardsCount: 5,
+  replicaShardsCount: 3,
+  refreshType: 'auto',
+  checkpointLocation: 's3://test/',
+};
+
+export const skippingIndexBuilderMockResult2 = `CREATE SKIPPING INDEX
+ON datasource.database.table (
+   \`field1\` PARTITION
+  ) WITH (
+index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
+auto_refresh = true,
+checkpoint_location = 's3://test/'
+)`;
+
+export const coveringIndexBuilderMock1: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  dataSource: 'datasource',
+  database: 'database',
+  dataTable: 'table',
+  accelerationIndexName: 'index_name',
+  coveringIndexQueryData: ['field1', 'field2', 'field3'],
+  primaryShardsCount: 9,
+  replicaShardsCount: 2,
+  refreshType: 'interval',
+  refreshIntervalOptions: {
+    refreshWindow: 1,
+    refreshInterval: 'minute',
+  },
+  checkpointLocation: 's3://test/',
+};
+
+export const coveringIndexBuilderMockResult1 = `CREATE INDEX index_name
+ON datasource.database.table (
+   \`field1\`, 
+   \`field2\`, 
+   \`field3\`
+  ) WITH (
+index_settings = '{"number_of_shards":9,"number_of_replicas":2}',
+auto_refresh = true,
+refresh_interval = '1 minute',
+checkpoint_location = 's3://test/'
+)`;
+
+export const coveringIndexBuilderMock2: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  dataSource: 'datasource',
+  database: 'database',
+  dataTable: 'table',
+  accelerationIndexName: 'index_name',
+  coveringIndexQueryData: ['field1'],
+  primaryShardsCount: 5,
+  replicaShardsCount: 3,
+  refreshType: 'auto',
+  checkpointLocation: 's3://test/',
+};
+
+export const coveringIndexBuilderMockResult2 = `CREATE INDEX index_name
+ON datasource.database.table (
+   \`field1\`
+  ) WITH (
+index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
+auto_refresh = true,
+checkpoint_location = 's3://test/'
+)`;
+
+export const materializedViewBuilderMock1: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  dataSource: 'datasource',
+  database: 'database',
+  dataTable: 'table',
+  accelerationIndexType: 'materialized',
+  accelerationIndexName: 'index_name',
+  materializedViewQueryData: {
+    columnsValues: [
+      { id: '1', functionName: 'count', functionParam: 'field', fieldAlias: 'counter' },
+      { id: '2', functionName: 'count', functionParam: '*', fieldAlias: 'counter1' },
+      { id: '3', functionName: 'sum', functionParam: 'field2' },
+      { id: '4', functionName: 'avg', functionParam: 'field3', fieldAlias: 'average' },
+    ],
+    groupByTumbleValue: {
+      timeField: 'timestamp',
+      tumbleWindow: 1,
+      tumbleInterval: 'minute',
+    },
+  },
+  primaryShardsCount: 9,
+  replicaShardsCount: 2,
+  refreshType: 'interval',
+  refreshIntervalOptions: {
+    refreshWindow: 1,
+    refreshInterval: 'minute',
+  },
+  watermarkDelay: {
+    delayWindow: 1,
+    delayInterval: 'minute',
+  },
+  checkpointLocation: 's3://test/',
+};
+
+export const materializedViewBuilderMockResult1 = `CREATE MATERIALIZED VIEW datasource.database.index_name
+AS SELECT
+   count(\`field\`) AS \`counter\`, 
+   count(*) AS \`counter1\`, 
+   sum(\`field2\`), 
+   avg(\`field3\`) AS \`average\`
+FROM datasource.database.table
+GROUP BY TUMBLE (\`timestamp\`, '1 minute')
+ WITH (
+index_settings = '{"number_of_shards":9,"number_of_replicas":2}',
+auto_refresh = true,
+refresh_interval = '1 minute',
+watermark_delay = '1 minute',
+checkpoint_location = 's3://test/'
+)`;
+
+export const materializedViewBuilderMock2: CreateAccelerationForm = {
+  ...createAccelerationEmptyDataMock,
+  dataSource: 'datasource',
+  database: 'database',
+  dataTable: 'table',
+  accelerationIndexType: 'materialized',
+  accelerationIndexName: 'index_name',
+  materializedViewQueryData: {
+    columnsValues: [{ id: '1', functionName: 'count', functionParam: 'field' }],
+    groupByTumbleValue: {
+      timeField: 'timestamp',
+      tumbleWindow: 2,
+      tumbleInterval: 'hour',
+    },
+  },
+  primaryShardsCount: 5,
+  replicaShardsCount: 3,
+  refreshType: 'auto',
+  checkpointLocation: 's3://test/',
+  watermarkDelay: {
+    delayWindow: 2,
+    delayInterval: 'minute',
+  },
+};
+
+export const materializedViewBuilderMockResult2 = `CREATE MATERIALIZED VIEW datasource.database.index_name
+AS SELECT
+   count(\`field\`)
+FROM datasource.database.table
+GROUP BY TUMBLE (\`timestamp\`, '2 hours')
+ WITH (
+index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
+auto_refresh = true,
+watermark_delay = '2 minutes',
+checkpoint_location = 's3://test/'
+)`;
+
+export const mockDatasourcesQuery = {
+  data: {
+    ok: true,
+    resp:
+      '[{  "name": "my_glue",  "description": "",  "connector": "S3GLUE",  "allowedRoles": [],  "properties": {      "glue.indexstore.opensearch.uri": "",      "glue.indexstore.opensearch.region": ""  }}]',
+  },
+};


### PR DESCRIPTION
### Description
We made a design choice to move create acceleration flyout from workbench to datasources. This was done as many components from datasource like the table, acceleration flyouts will be coming used workbench which are today present in datasources. This helps us to avoid a circular dependency between plugins. 

### Issues Resolved
* Keep workbench as a plugin dependent on datasources

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
