### PR TITLE
Add conditional installation for S3 integrations

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                           "connectionTableName": "sample",
                           "connectionType": "index",
                           "displayName": "sample Integration",
+                          "enabledWorkflows": Array [],
                         }
                       }
                       integration={
@@ -719,6 +720,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                 "connectionTableName": "sample",
                 "connectionType": "index",
                 "displayName": "sample Integration",
+                "enabledWorkflows": Array [],
               }
             }
             integration={
@@ -2054,9 +2056,17 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
       <EuiFormRow
         describedByIds={Array []}
         display="row"
+        error={
+          Array [
+            "Must select at least one workflow.",
+          ]
+        }
         fullWidth={false}
         hasChildLabel={true}
         hasEmptyLabelSpace={false}
+        helpText="Select from the available types of assets based on how your use case."
+        isInvalid={true}
+        label="Select installation workflows"
         labelType="label"
       >
         <div
@@ -2064,9 +2074,30 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
           id="random_html_id-row"
         >
           <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={true}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={true}
+              type="label"
+            >
+              <label
+                aria-invalid={true}
+                className="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+                htmlFor="random_html_id"
+              >
+                Select installation workflows
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
             className="euiFormRow__fieldWrapper"
           >
             <SetupWorkflowSelector
+              aria-describedby="random_html_id-help-0 random_html_id-error-0"
               id="random_html_id"
               integration={
                 Object {
@@ -2095,6 +2126,31 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
               toggleWorkflow={[Function]}
               useWorkflows={Array []}
             />
+            <EuiFormErrorText
+              className="euiFormRow__text"
+              id="random_html_id-error-0"
+              key="Must select at least one workflow."
+            >
+              <div
+                aria-live="polite"
+                className="euiFormErrorText euiFormRow__text"
+                id="random_html_id-error-0"
+              >
+                Must select at least one workflow.
+              </div>
+            </EuiFormErrorText>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select from the available types of assets based on how your use case."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select from the available types of assets based on how your use case.
+              </div>
+            </EuiFormHelpText>
           </div>
         </div>
       </EuiFormRow>

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -2051,6 +2051,53 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
           </div>
         </div>
       </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <SetupWorkflowSelector
+              id="random_html_id"
+              integration={
+                Object {
+                  "assets": Array [
+                    Object {
+                      "extension": "ndjson",
+                      "name": "sample",
+                      "type": "savedObjectBundle",
+                      "version": "1.0.1",
+                    },
+                  ],
+                  "components": Array [
+                    Object {
+                      "name": "logs",
+                      "version": "1.0.0",
+                    },
+                  ],
+                  "license": "Apache-2.0",
+                  "name": "sample",
+                  "type": "logs",
+                  "version": "2.0.0",
+                }
+              }
+              onBlur={[Function]}
+              onFocus={[Function]}
+              toggleWorkflow={[Function]}
+              useWorkflows={Array []}
+            />
+          </div>
+        </div>
+      </EuiFormRow>
     </div>
   </EuiForm>
 </SetupIntegrationForm>

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -1088,6 +1088,14 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
       "name": "sample",
       "type": "logs",
       "version": "2.0.0",
+      "workflows": Array [
+        Object {
+          "description": "This is a test workflow.",
+          "enabled_by_default": true,
+          "label": "Workflow 1",
+          "name": "workflow1",
+        },
+      ],
     }
   }
   setupCallout={
@@ -2053,6 +2061,25 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
           </div>
         </div>
       </EuiFormRow>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <h3>
+            Installation Flows
+          </h3>
+        </div>
+      </EuiText>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
       <EuiFormRow
         describedByIds={Array []}
         display="row"
@@ -2064,9 +2091,9 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
         fullWidth={false}
         hasChildLabel={true}
         hasEmptyLabelSpace={false}
-        helpText="Select from the available types of assets based on how your use case."
-        isInvalid={true}
-        label="Select installation workflows"
+        helpText="Select from the available asset types based on your use case. Choose at least one."
+        isInvalid={false}
+        label="Flows"
         labelType="label"
       >
         <div
@@ -2077,19 +2104,19 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
             className="euiFormRow__labelWrapper"
           >
             <EuiFormLabel
-              aria-invalid={true}
+              aria-invalid={false}
               className="euiFormRow__label"
               htmlFor="random_html_id"
               isFocused={false}
-              isInvalid={true}
+              isInvalid={false}
               type="label"
             >
               <label
-                aria-invalid={true}
-                className="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
                 htmlFor="random_html_id"
               >
-                Select installation workflows
+                Flows
               </label>
             </EuiFormLabel>
           </div>
@@ -2097,7 +2124,7 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
             className="euiFormRow__fieldWrapper"
           >
             <SetupWorkflowSelector
-              aria-describedby="random_html_id-help-0 random_html_id-error-0"
+              aria-describedby="random_html_id-help-0"
               id="random_html_id"
               integration={
                 Object {
@@ -2119,1037 +2146,143 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
                   "name": "sample",
                   "type": "logs",
                   "version": "2.0.0",
+                  "workflows": Array [
+                    Object {
+                      "description": "This is a test workflow.",
+                      "enabled_by_default": true,
+                      "label": "Workflow 1",
+                      "name": "workflow1",
+                    },
+                  ],
                 }
               }
               onBlur={[Function]}
               onFocus={[Function]}
               toggleWorkflow={[Function]}
-              useWorkflows={Array []}
-            />
-            <EuiFormErrorText
-              className="euiFormRow__text"
-              id="random_html_id-error-0"
-              key="Must select at least one workflow."
-            >
-              <div
-                aria-live="polite"
-                className="euiFormErrorText euiFormRow__text"
-                id="random_html_id-error-0"
-              >
-                Must select at least one workflow.
-              </div>
-            </EuiFormErrorText>
-            <EuiFormHelpText
-              className="euiFormRow__text"
-              id="random_html_id-help-0"
-              key="Select from the available types of assets based on how your use case."
-            >
-              <div
-                className="euiFormHelpText euiFormRow__text"
-                id="random_html_id-help-0"
-              >
-                Select from the available types of assets based on how your use case.
-              </div>
-            </EuiFormHelpText>
-          </div>
-        </div>
-      </EuiFormRow>
-    </div>
-  </EuiForm>
-</SetupIntegrationForm>
-`;
-
-exports[`Integration Setup Page Renders the S3 connector form with workflows 1`] = `
-<SetupIntegrationForm
-  config={
-    Object {
-      "connectionDataSource": "ss4o_logs-nginx-test",
-      "connectionLocation": "",
-      "connectionTableName": "",
-      "connectionType": "s3",
-      "displayName": "Test Instance Name",
-    }
-  }
-  integration={
-    Object {
-      "assets": Array [
-        Object {
-          "extension": "ndjson",
-          "name": "sample",
-          "type": "savedObjectBundle",
-          "version": "1.0.1",
-        },
-      ],
-      "components": Array [
-        Object {
-          "name": "logs",
-          "version": "1.0.0",
-        },
-      ],
-      "license": "Apache-2.0",
-      "name": "sample",
-      "type": "logs",
-      "version": "2.0.0",
-    }
-  }
-  setupCallout={
-    Object {
-      "show": false,
-    }
-  }
-  updateConfig={[Function]}
->
-  <EuiForm>
-    <div
-      className="euiForm"
-    >
-      <EuiTitle>
-        <h1
-          className="euiTitle euiTitle--medium"
-        >
-          Set Up Integration
-        </h1>
-      </EuiTitle>
-      <EuiSpacer>
-        <div
-          className="euiSpacer euiSpacer--l"
-        />
-      </EuiSpacer>
-      <EuiSpacer>
-        <div
-          className="euiSpacer euiSpacer--l"
-        />
-      </EuiSpacer>
-      <EuiText>
-        <div
-          className="euiText euiText--medium"
-        >
-          <h3>
-            Integration Details
-          </h3>
-        </div>
-      </EuiText>
-      <EuiSpacer>
-        <div
-          className="euiSpacer euiSpacer--l"
-        />
-      </EuiSpacer>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        error={
-          Array [
-            "Must be at least 1 character.",
-          ]
-        }
-        fullWidth={false}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        isInvalid={false}
-        label="Display Name"
-        labelType="label"
-      >
-        <div
-          className="euiFormRow"
-          id="random_html_id-row"
-        >
-          <div
-            className="euiFormRow__labelWrapper"
-          >
-            <EuiFormLabel
-              aria-invalid={false}
-              className="euiFormRow__label"
-              htmlFor="random_html_id"
-              isFocused={false}
-              isInvalid={false}
-              type="label"
-            >
-              <label
-                aria-invalid={false}
-                className="euiFormLabel euiFormRow__label"
-                htmlFor="random_html_id"
-              >
-                Display Name
-              </label>
-            </EuiFormLabel>
-          </div>
-          <div
-            className="euiFormRow__fieldWrapper"
-          >
-            <EuiFieldText
-              data-test-subj="new-instance-name"
-              id="random_html_id"
-              isInvalid={false}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder="sample Integration"
-              value="Test Instance Name"
-            >
-              <EuiFormControlLayout
-                fullWidth={false}
-                inputId="random_html_id"
-              >
-                <div
-                  className="euiFormControlLayout"
-                >
-                  <div
-                    className="euiFormControlLayout__childrenWrapper"
-                  >
-                    <EuiValidatableControl
-                      isInvalid={false}
-                    >
-                      <input
-                        className="euiFieldText"
-                        data-test-subj="new-instance-name"
-                        id="random_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="sample Integration"
-                        type="text"
-                        value="Test Instance Name"
-                      />
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons />
-                  </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiFieldText>
-          </div>
-        </div>
-      </EuiFormRow>
-      <EuiSpacer>
-        <div
-          className="euiSpacer euiSpacer--l"
-        />
-      </EuiSpacer>
-      <EuiText>
-        <div
-          className="euiText euiText--medium"
-        >
-          <h3>
-            Integration Connection
-          </h3>
-        </div>
-      </EuiText>
-      <EuiSpacer>
-        <div
-          className="euiSpacer euiSpacer--l"
-        />
-      </EuiSpacer>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        fullWidth={false}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        helpText="Select the type of connection to use for queries."
-        label="Connection Type"
-        labelType="label"
-      >
-        <div
-          className="euiFormRow"
-          id="random_html_id-row"
-        >
-          <div
-            className="euiFormRow__labelWrapper"
-          >
-            <EuiFormLabel
-              className="euiFormRow__label"
-              htmlFor="random_html_id"
-              isFocused={false}
-              type="label"
-            >
-              <label
-                className="euiFormLabel euiFormRow__label"
-                htmlFor="random_html_id"
-              >
-                Connection Type
-              </label>
-            </EuiFormLabel>
-          </div>
-          <div
-            className="euiFormRow__fieldWrapper"
-          >
-            <EuiSelect
-              aria-describedby="random_html_id-help-0"
-              id="random_html_id"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              options={
+              useWorkflows={
                 Array [
-                  Object {
-                    "text": "OpenSearch Index",
-                    "value": "index",
-                  },
+                  Array [
+                    "workflow1",
+                    true,
+                  ],
                 ]
               }
-              value="s3"
             >
-              <EuiFormControlLayout
-                compressed={false}
-                fullWidth={false}
-                icon={
-                  Object {
-                    "side": "right",
-                    "type": "arrowDown",
-                  }
-                }
-                inputId="random_html_id"
-                isLoading={false}
+              <EuiCheckableCard
+                checkableType="checkbox"
+                checked={true}
+                id="workflow-checkbox-workflow1"
+                key="workflow1"
+                label="Workflow 1"
+                onChange={[Function]}
+                value="workflow1"
               >
-                <div
-                  className="euiFormControlLayout"
+                <_EuiSplitPanelOuter
+                  className="euiCheckableCard euiCheckableCard-isChecked"
+                  direction="row"
+                  hasBorder={true}
+                  responsive={false}
                 >
-                  <div
-                    className="euiFormControlLayout__childrenWrapper"
-                  >
-                    <EuiValidatableControl>
-                      <select
-                        aria-describedby="random_html_id-help-0"
-                        className="euiSelect"
-                        id="random_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onMouseUp={[Function]}
-                        value="s3"
-                      >
-                        <option
-                          key="0"
-                          value="index"
-                        >
-                          OpenSearch Index
-                        </option>
-                      </select>
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons
-                      compressed={false}
-                      icon={
-                        Object {
-                          "side": "right",
-                          "type": "arrowDown",
-                        }
-                      }
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                      >
-                        <EuiFormControlLayoutCustomIcon
-                          size="m"
-                          type="arrowDown"
-                        >
-                          <span
-                            className="euiFormControlLayoutCustomIcon"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiFormControlLayoutCustomIcon__icon"
-                              size="m"
-                              type="arrowDown"
-                            >
-                              <EuiIconArrowDown
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                    fillRule="non-zero"
-                                  />
-                                </svg>
-                              </EuiIconArrowDown>
-                            </EuiIcon>
-                          </span>
-                        </EuiFormControlLayoutCustomIcon>
-                      </div>
-                    </EuiFormControlLayoutIcons>
-                  </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiSelect>
-            <EuiFormHelpText
-              className="euiFormRow__text"
-              id="random_html_id-help-0"
-              key="Select the type of connection to use for queries."
-            >
-              <div
-                className="euiFormHelpText euiFormRow__text"
-                id="random_html_id-help-0"
-              >
-                Select the type of connection to use for queries.
-              </div>
-            </EuiFormHelpText>
-          </div>
-        </div>
-      </EuiFormRow>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        fullWidth={false}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        helpText="Select a data source to pull the data from."
-        label="Data Source"
-        labelType="label"
-      >
-        <div
-          className="euiFormRow"
-          id="random_html_id-row"
-        >
-          <div
-            className="euiFormRow__labelWrapper"
-          >
-            <EuiFormLabel
-              className="euiFormRow__label"
-              htmlFor="random_html_id"
-              isFocused={false}
-              type="label"
-            >
-              <label
-                className="euiFormLabel euiFormRow__label"
-                htmlFor="random_html_id"
-              >
-                Data Source
-              </label>
-            </EuiFormLabel>
-          </div>
-          <div
-            className="euiFormRow__fieldWrapper"
-          >
-            <EuiComboBox
-              aria-describedby="random_html_id-help-0"
-              async={false}
-              compressed={false}
-              customOptionText="Select {searchValue} as your data_source"
-              data-test-subj="data-source-name"
-              fullWidth={false}
-              id="random_html_id"
-              isClearable={true}
-              isLoading={true}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onCreateOption={[Function]}
-              onFocus={[Function]}
-              options={Array []}
-              selectedOptions={
-                Array [
-                  Object {
-                    "label": "ss4o_logs-nginx-test",
-                  },
-                ]
-              }
-              singleSelection={
-                Object {
-                  "asPlainText": true,
-                }
-              }
-              sortMatchesBy="none"
-            >
-              <div
-                aria-describedby="random_html_id-help-0"
-                aria-expanded={false}
-                aria-haspopup="listbox"
-                className="euiComboBox"
-                data-test-subj="data-source-name"
-                onKeyDown={[Function]}
-                role="combobox"
-              >
-                <EuiComboBoxInput
-                  autoSizeInputRef={[Function]}
-                  compressed={false}
-                  fullWidth={false}
-                  hasSelectedOptions={true}
-                  id="random_html_id"
-                  inputRef={[Function]}
-                  isListOpen={false}
-                  isLoading={true}
-                  noIcon={false}
-                  onChange={[Function]}
-                  onClear={[Function]}
-                  onClick={[Function]}
-                  onCloseListClick={[Function]}
-                  onFocus={[Function]}
-                  onOpenListClick={[Function]}
-                  onRemoveOption={[Function]}
-                  rootId={[Function]}
-                  searchValue=""
-                  selectedOptions={
-                    Array [
-                      Object {
-                        "label": "ss4o_logs-nginx-test",
-                      },
-                    ]
-                  }
-                  singleSelection={
-                    Object {
-                      "asPlainText": true,
-                    }
-                  }
-                  toggleButtonRef={[Function]}
-                  updatePosition={[Function]}
-                  value="ss4o_logs-nginx-test"
-                >
-                  <EuiFormControlLayout
-                    clear={
-                      Object {
-                        "data-test-subj": "comboBoxClearButton",
-                        "onClick": [Function],
-                      }
-                    }
-                    compressed={false}
-                    fullWidth={false}
-                    icon={
-                      Object {
-                        "aria-label": "Open list of options",
-                        "data-test-subj": "comboBoxToggleListButton",
-                        "disabled": undefined,
-                        "onClick": [Function],
-                        "ref": [Function],
-                        "side": "right",
-                        "type": "arrowDown",
-                      }
-                    }
-                    isLoading={true}
+                  <EuiPanel
+                    className="euiSplitPanel euiSplitPanel--row euiCheckableCard euiCheckableCard-isChecked"
+                    grow={false}
+                    hasBorder={true}
+                    paddingSize="none"
                   >
                     <div
-                      className="euiFormControlLayout"
+                      className="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--hasBorder euiPanel--flexGrowZero euiSplitPanel euiSplitPanel--row euiCheckableCard euiCheckableCard-isChecked"
                     >
-                      <div
-                        className="euiFormControlLayout__childrenWrapper"
+                      <_EuiSplitPanelInner
+                        color="primary"
+                        grow={false}
+                        onClick={[Function]}
                       >
-                        <div
-                          className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
-                          data-test-subj="comboBoxInput"
+                        <EuiPanel
+                          borderRadius="none"
+                          className="euiSplitPanel__inner"
+                          color="primary"
+                          element="div"
+                          grow={false}
+                          hasBorder={false}
+                          hasShadow={false}
                           onClick={[Function]}
-                          tabIndex={-1}
-                        >
-                          <EuiComboBoxPill
-                            asPlainText={true}
-                            color="hollow"
-                            key="ss4o_logs-nginx-test"
-                            option={
-                              Object {
-                                "label": "ss4o_logs-nginx-test",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiComboBoxPill euiComboBoxPill--plainText"
-                            >
-                              ss4o_logs-nginx-test
-                            </span>
-                          </EuiComboBoxPill>
-                          <AutosizeInput
-                            aria-controls=""
-                            className="euiComboBox__input"
-                            data-test-subj="comboBoxSearchInput"
-                            id="random_html_id"
-                            injectStyles={true}
-                            inputRef={[Function]}
-                            minWidth={1}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            role="textbox"
-                            style={
-                              Object {
-                                "fontSize": 14,
-                              }
-                            }
-                            value=""
-                          >
-                            <div
-                              className="euiComboBox__input"
-                              style={
-                                Object {
-                                  "display": "inline-block",
-                                  "fontSize": 14,
-                                }
-                              }
-                            >
-                              <input
-                                aria-controls=""
-                                data-test-subj="comboBoxSearchInput"
-                                id="random_html_id"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                role="textbox"
-                                style={
-                                  Object {
-                                    "boxSizing": "content-box",
-                                    "width": "2px",
-                                  }
-                                }
-                                value=""
-                              />
-                              <div
-                                style={
-                                  Object {
-                                    "height": 0,
-                                    "left": 0,
-                                    "overflow": "scroll",
-                                    "position": "absolute",
-                                    "top": 0,
-                                    "visibility": "hidden",
-                                    "whiteSpace": "pre",
-                                  }
-                                }
-                              />
-                            </div>
-                          </AutosizeInput>
-                        </div>
-                        <EuiFormControlLayoutIcons
-                          clear={
-                            Object {
-                              "data-test-subj": "comboBoxClearButton",
-                              "onClick": [Function],
-                            }
-                          }
-                          compressed={false}
-                          icon={
-                            Object {
-                              "aria-label": "Open list of options",
-                              "data-test-subj": "comboBoxToggleListButton",
-                              "disabled": undefined,
-                              "onClick": [Function],
-                              "ref": [Function],
-                              "side": "right",
-                              "type": "arrowDown",
-                            }
-                          }
-                          isLoading={true}
                         >
                           <div
-                            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--primary euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiPanel--isClickable euiSplitPanel__inner"
+                            onClick={[Function]}
                           >
-                            <EuiFormControlLayoutClearButton
-                              data-test-subj="comboBoxClearButton"
-                              onClick={[Function]}
-                              size="m"
+                            <EuiCheckbox
+                              checked={true}
+                              compressed={false}
+                              disabled={false}
+                              id="workflow-checkbox-workflow1"
+                              indeterminate={false}
+                              onChange={[Function]}
+                              value="workflow1"
                             >
-                              <EuiI18n
-                                default="Clear input"
-                                token="euiFormControlLayoutClearButton.label"
+                              <div
+                                className="euiCheckbox euiCheckbox--noLabel"
                               >
-                                <button
-                                  aria-label="Clear input"
-                                  className="euiFormControlLayoutClearButton"
-                                  data-test-subj="comboBoxClearButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <EuiIcon
-                                    className="euiFormControlLayoutClearButton__icon"
-                                    type="cross"
-                                  >
-                                    <EuiIconCross
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
-                                        />
-                                      </svg>
-                                    </EuiIconCross>
-                                  </EuiIcon>
-                                </button>
-                              </EuiI18n>
-                            </EuiFormControlLayoutClearButton>
-                            <EuiLoadingSpinner
-                              size="m"
-                            >
-                              <span
-                                className="euiLoadingSpinner euiLoadingSpinner--medium"
-                              />
-                            </EuiLoadingSpinner>
-                            <EuiFormControlLayoutCustomIcon
-                              aria-label="Open list of options"
-                              data-test-subj="comboBoxToggleListButton"
-                              iconRef={[Function]}
-                              onClick={[Function]}
-                              size="m"
-                              type="arrowDown"
-                            >
-                              <button
-                                aria-label="Open list of options"
-                                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                data-test-subj="comboBoxToggleListButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiFormControlLayoutCustomIcon__icon"
-                                  size="m"
-                                  type="arrowDown"
-                                >
-                                  <EuiIconArrowDown
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    role="img"
-                                    style={null}
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height={16}
-                                      role="img"
-                                      style={null}
-                                      viewBox="0 0 16 16"
-                                      width={16}
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                        fillRule="non-zero"
-                                      />
-                                    </svg>
-                                  </EuiIconArrowDown>
-                                </EuiIcon>
-                              </button>
-                            </EuiFormControlLayoutCustomIcon>
+                                <input
+                                  checked={true}
+                                  className="euiCheckbox__input"
+                                  disabled={false}
+                                  id="workflow-checkbox-workflow1"
+                                  onChange={[Function]}
+                                  type="checkbox"
+                                  value="workflow1"
+                                />
+                                <div
+                                  className="euiCheckbox__square"
+                                />
+                              </div>
+                            </EuiCheckbox>
                           </div>
-                        </EuiFormControlLayoutIcons>
-                      </div>
+                        </EuiPanel>
+                      </_EuiSplitPanelInner>
+                      <_EuiSplitPanelInner>
+                        <EuiPanel
+                          borderRadius="none"
+                          className="euiSplitPanel__inner"
+                          color="transparent"
+                          element="div"
+                          hasBorder={false}
+                          hasShadow={false}
+                        >
+                          <div
+                            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiSplitPanel__inner"
+                          >
+                            <label
+                              aria-describedby="workflow-checkbox-workflow1-details"
+                              className="euiCheckableCard__label"
+                              htmlFor="workflow-checkbox-workflow1"
+                            >
+                              Workflow 1
+                            </label>
+                            <div
+                              className="euiCheckableCard__children"
+                              id="workflow-checkbox-workflow1-details"
+                            >
+                              This is a test workflow.
+                            </div>
+                          </div>
+                        </EuiPanel>
+                      </_EuiSplitPanelInner>
                     </div>
-                  </EuiFormControlLayout>
-                </EuiComboBoxInput>
-              </div>
-            </EuiComboBox>
+                  </EuiPanel>
+                </_EuiSplitPanelOuter>
+              </EuiCheckableCard>
+            </SetupWorkflowSelector>
             <EuiFormHelpText
               className="euiFormRow__text"
               id="random_html_id-help-0"
-              key="Select a data source to pull the data from."
+              key="Select from the available asset types based on your use case. Choose at least one."
             >
               <div
                 className="euiFormHelpText euiFormRow__text"
                 id="random_html_id-help-0"
               >
-                Select a data source to pull the data from.
-              </div>
-            </EuiFormHelpText>
-          </div>
-        </div>
-      </EuiFormRow>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        error={
-          Array [
-            "Must be at least 1 character.",
-          ]
-        }
-        fullWidth={false}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        helpText="Select a table name to associate with your data."
-        isInvalid={true}
-        label="Flint Table Name"
-        labelType="label"
-      >
-        <div
-          className="euiFormRow"
-          id="random_html_id-row"
-        >
-          <div
-            className="euiFormRow__labelWrapper"
-          >
-            <EuiFormLabel
-              aria-invalid={true}
-              className="euiFormRow__label"
-              htmlFor="random_html_id"
-              isFocused={false}
-              isInvalid={true}
-              type="label"
-            >
-              <label
-                aria-invalid={true}
-                className="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
-                htmlFor="random_html_id"
-              >
-                Flint Table Name
-              </label>
-            </EuiFormLabel>
-          </div>
-          <div
-            className="euiFormRow__fieldWrapper"
-          >
-            <EuiFieldText
-              aria-describedby="random_html_id-help-0 random_html_id-error-0"
-              id="random_html_id"
-              isInvalid={true}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder="sample"
-              value=""
-            >
-              <EuiFormControlLayout
-                fullWidth={false}
-                inputId="random_html_id"
-              >
-                <div
-                  className="euiFormControlLayout"
-                >
-                  <div
-                    className="euiFormControlLayout__childrenWrapper"
-                  >
-                    <EuiValidatableControl
-                      isInvalid={true}
-                    >
-                      <input
-                        aria-describedby="random_html_id-help-0 random_html_id-error-0"
-                        className="euiFieldText"
-                        id="random_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="sample"
-                        type="text"
-                        value=""
-                      />
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons />
-                  </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiFieldText>
-            <EuiFormErrorText
-              className="euiFormRow__text"
-              id="random_html_id-error-0"
-              key="Must be at least 1 character."
-            >
-              <div
-                aria-live="polite"
-                className="euiFormErrorText euiFormRow__text"
-                id="random_html_id-error-0"
-              >
-                Must be at least 1 character.
-              </div>
-            </EuiFormErrorText>
-            <EuiFormHelpText
-              className="euiFormRow__text"
-              id="random_html_id-help-0"
-              key="Select a table name to associate with your data."
-            >
-              <div
-                className="euiFormHelpText euiFormRow__text"
-                id="random_html_id-help-0"
-              >
-                Select a table name to associate with your data.
-              </div>
-            </EuiFormHelpText>
-          </div>
-        </div>
-      </EuiFormRow>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        error={
-          Array [
-            "Must be a URL starting with 's3://'.",
-          ]
-        }
-        fullWidth={false}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        isInvalid={false}
-        label="S3 Bucket Location"
-        labelType="label"
-      >
-        <div
-          className="euiFormRow"
-          id="random_html_id-row"
-        >
-          <div
-            className="euiFormRow__labelWrapper"
-          >
-            <EuiFormLabel
-              aria-invalid={false}
-              className="euiFormRow__label"
-              htmlFor="random_html_id"
-              isFocused={false}
-              isInvalid={false}
-              type="label"
-            >
-              <label
-                aria-invalid={false}
-                className="euiFormLabel euiFormRow__label"
-                htmlFor="random_html_id"
-              >
-                S3 Bucket Location
-              </label>
-            </EuiFormLabel>
-          </div>
-          <div
-            className="euiFormRow__fieldWrapper"
-          >
-            <EuiFieldText
-              id="random_html_id"
-              isInvalid={false}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder="s3://"
-              value=""
-            >
-              <EuiFormControlLayout
-                fullWidth={false}
-                inputId="random_html_id"
-              >
-                <div
-                  className="euiFormControlLayout"
-                >
-                  <div
-                    className="euiFormControlLayout__childrenWrapper"
-                  >
-                    <EuiValidatableControl
-                      isInvalid={false}
-                    >
-                      <input
-                        className="euiFieldText"
-                        id="random_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="s3://"
-                        type="text"
-                        value=""
-                      />
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons />
-                  </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiFieldText>
-          </div>
-        </div>
-      </EuiFormRow>
-      <EuiFormRow
-        describedByIds={Array []}
-        display="row"
-        error={
-          Array [
-            "Must be a URL starting with 's3://'.",
-          ]
-        }
-        fullWidth={false}
-        hasChildLabel={true}
-        hasEmptyLabelSpace={false}
-        helpText="The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results."
-        isInvalid={false}
-        label="S3 Checkpoint Location"
-        labelType="label"
-      >
-        <div
-          className="euiFormRow"
-          id="random_html_id-row"
-        >
-          <div
-            className="euiFormRow__labelWrapper"
-          >
-            <EuiFormLabel
-              aria-invalid={false}
-              className="euiFormRow__label"
-              htmlFor="random_html_id"
-              isFocused={false}
-              isInvalid={false}
-              type="label"
-            >
-              <label
-                aria-invalid={false}
-                className="euiFormLabel euiFormRow__label"
-                htmlFor="random_html_id"
-              >
-                S3 Checkpoint Location
-              </label>
-            </EuiFormLabel>
-          </div>
-          <div
-            className="euiFormRow__fieldWrapper"
-          >
-            <EuiFieldText
-              aria-describedby="random_html_id-help-0"
-              id="random_html_id"
-              isInvalid={false}
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder="s3://"
-            >
-              <EuiFormControlLayout
-                fullWidth={false}
-                inputId="random_html_id"
-              >
-                <div
-                  className="euiFormControlLayout"
-                >
-                  <div
-                    className="euiFormControlLayout__childrenWrapper"
-                  >
-                    <EuiValidatableControl
-                      isInvalid={false}
-                    >
-                      <input
-                        aria-describedby="random_html_id-help-0"
-                        className="euiFieldText"
-                        id="random_html_id"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder="s3://"
-                        type="text"
-                      />
-                    </EuiValidatableControl>
-                    <EuiFormControlLayoutIcons />
-                  </div>
-                </div>
-              </EuiFormControlLayout>
-            </EuiFieldText>
-            <EuiFormHelpText
-              className="euiFormRow__text"
-              id="random_html_id-help-0"
-              key="The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results."
-            >
-              <div
-                className="euiFormHelpText euiFormRow__text"
-                id="random_html_id-help-0"
-              >
-                The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results.
+                Select from the available asset types based on your use case. Choose at least one.
               </div>
             </EuiFormHelpText>
           </div>
@@ -4193,6 +3326,14 @@ exports[`Integration Setup Page Renders the index form as expected 1`] = `
       "name": "sample",
       "type": "logs",
       "version": "2.0.0",
+      "workflows": Array [
+        Object {
+          "description": "This is a test workflow.",
+          "enabled_by_default": true,
+          "label": "Workflow 1",
+          "name": "workflow1",
+        },
+      ],
     }
   }
   setupCallout={

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -2159,6 +2159,2009 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
 </SetupIntegrationForm>
 `;
 
+exports[`Integration Setup Page Renders the S3 connector form with workflows 1`] = `
+<SetupIntegrationForm
+  config={
+    Object {
+      "connectionDataSource": "ss4o_logs-nginx-test",
+      "connectionLocation": "",
+      "connectionTableName": "",
+      "connectionType": "s3",
+      "displayName": "Test Instance Name",
+    }
+  }
+  integration={
+    Object {
+      "assets": Array [
+        Object {
+          "extension": "ndjson",
+          "name": "sample",
+          "type": "savedObjectBundle",
+          "version": "1.0.1",
+        },
+      ],
+      "components": Array [
+        Object {
+          "name": "logs",
+          "version": "1.0.0",
+        },
+      ],
+      "license": "Apache-2.0",
+      "name": "sample",
+      "type": "logs",
+      "version": "2.0.0",
+    }
+  }
+  setupCallout={
+    Object {
+      "show": false,
+    }
+  }
+  updateConfig={[Function]}
+>
+  <EuiForm>
+    <div
+      className="euiForm"
+    >
+      <EuiTitle>
+        <h1
+          className="euiTitle euiTitle--medium"
+        >
+          Set Up Integration
+        </h1>
+      </EuiTitle>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <h3>
+            Integration Details
+          </h3>
+        </div>
+      </EuiText>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be at least 1 character.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        isInvalid={false}
+        label="Display Name"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={false}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={false}
+              type="label"
+            >
+              <label
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                Display Name
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              data-test-subj="new-instance-name"
+              id="random_html_id"
+              isInvalid={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="sample Integration"
+              value="Test Instance Name"
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={false}
+                    >
+                      <input
+                        className="euiFieldText"
+                        data-test-subj="new-instance-name"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="sample Integration"
+                        type="text"
+                        value="Test Instance Name"
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <h3>
+            Integration Connection
+          </h3>
+        </div>
+      </EuiText>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="Select the type of connection to use for queries."
+        label="Connection Type"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              type="label"
+            >
+              <label
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                Connection Type
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiSelect
+              aria-describedby="random_html_id-help-0"
+              id="random_html_id"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              options={
+                Array [
+                  Object {
+                    "text": "OpenSearch Index",
+                    "value": "index",
+                  },
+                ]
+              }
+              value="s3"
+            >
+              <EuiFormControlLayout
+                compressed={false}
+                fullWidth={false}
+                icon={
+                  Object {
+                    "side": "right",
+                    "type": "arrowDown",
+                  }
+                }
+                inputId="random_html_id"
+                isLoading={false}
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl>
+                      <select
+                        aria-describedby="random_html_id-help-0"
+                        className="euiSelect"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onMouseUp={[Function]}
+                        value="s3"
+                      >
+                        <option
+                          key="0"
+                          value="index"
+                        >
+                          OpenSearch Index
+                        </option>
+                      </select>
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons
+                      compressed={false}
+                      icon={
+                        Object {
+                          "side": "right",
+                          "type": "arrowDown",
+                        }
+                      }
+                      isLoading={false}
+                    >
+                      <div
+                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <EuiFormControlLayoutCustomIcon
+                          size="m"
+                          type="arrowDown"
+                        >
+                          <span
+                            className="euiFormControlLayoutCustomIcon"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiFormControlLayoutCustomIcon__icon"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconArrowDown
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fillRule="non-zero"
+                                  />
+                                </svg>
+                              </EuiIconArrowDown>
+                            </EuiIcon>
+                          </span>
+                        </EuiFormControlLayoutCustomIcon>
+                      </div>
+                    </EuiFormControlLayoutIcons>
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiSelect>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select the type of connection to use for queries."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select the type of connection to use for queries.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="Select a data source to pull the data from."
+        label="Data Source"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              type="label"
+            >
+              <label
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                Data Source
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiComboBox
+              aria-describedby="random_html_id-help-0"
+              async={false}
+              compressed={false}
+              customOptionText="Select {searchValue} as your data_source"
+              data-test-subj="data-source-name"
+              fullWidth={false}
+              id="random_html_id"
+              isClearable={true}
+              isLoading={true}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onCreateOption={[Function]}
+              onFocus={[Function]}
+              options={Array []}
+              selectedOptions={
+                Array [
+                  Object {
+                    "label": "ss4o_logs-nginx-test",
+                  },
+                ]
+              }
+              singleSelection={
+                Object {
+                  "asPlainText": true,
+                }
+              }
+              sortMatchesBy="none"
+            >
+              <div
+                aria-describedby="random_html_id-help-0"
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                className="euiComboBox"
+                data-test-subj="data-source-name"
+                onKeyDown={[Function]}
+                role="combobox"
+              >
+                <EuiComboBoxInput
+                  autoSizeInputRef={[Function]}
+                  compressed={false}
+                  fullWidth={false}
+                  hasSelectedOptions={true}
+                  id="random_html_id"
+                  inputRef={[Function]}
+                  isListOpen={false}
+                  isLoading={true}
+                  noIcon={false}
+                  onChange={[Function]}
+                  onClear={[Function]}
+                  onClick={[Function]}
+                  onCloseListClick={[Function]}
+                  onFocus={[Function]}
+                  onOpenListClick={[Function]}
+                  onRemoveOption={[Function]}
+                  rootId={[Function]}
+                  searchValue=""
+                  selectedOptions={
+                    Array [
+                      Object {
+                        "label": "ss4o_logs-nginx-test",
+                      },
+                    ]
+                  }
+                  singleSelection={
+                    Object {
+                      "asPlainText": true,
+                    }
+                  }
+                  toggleButtonRef={[Function]}
+                  updatePosition={[Function]}
+                  value="ss4o_logs-nginx-test"
+                >
+                  <EuiFormControlLayout
+                    clear={
+                      Object {
+                        "data-test-subj": "comboBoxClearButton",
+                        "onClick": [Function],
+                      }
+                    }
+                    compressed={false}
+                    fullWidth={false}
+                    icon={
+                      Object {
+                        "aria-label": "Open list of options",
+                        "data-test-subj": "comboBoxToggleListButton",
+                        "disabled": undefined,
+                        "onClick": [Function],
+                        "ref": [Function],
+                        "side": "right",
+                        "type": "arrowDown",
+                      }
+                    }
+                    isLoading={true}
+                  >
+                    <div
+                      className="euiFormControlLayout"
+                    >
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <div
+                          className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                          data-test-subj="comboBoxInput"
+                          onClick={[Function]}
+                          tabIndex={-1}
+                        >
+                          <EuiComboBoxPill
+                            asPlainText={true}
+                            color="hollow"
+                            key="ss4o_logs-nginx-test"
+                            option={
+                              Object {
+                                "label": "ss4o_logs-nginx-test",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiComboBoxPill euiComboBoxPill--plainText"
+                            >
+                              ss4o_logs-nginx-test
+                            </span>
+                          </EuiComboBoxPill>
+                          <AutosizeInput
+                            aria-controls=""
+                            className="euiComboBox__input"
+                            data-test-subj="comboBoxSearchInput"
+                            id="random_html_id"
+                            injectStyles={true}
+                            inputRef={[Function]}
+                            minWidth={1}
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            role="textbox"
+                            style={
+                              Object {
+                                "fontSize": 14,
+                              }
+                            }
+                            value=""
+                          >
+                            <div
+                              className="euiComboBox__input"
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "fontSize": 14,
+                                }
+                              }
+                            >
+                              <input
+                                aria-controls=""
+                                data-test-subj="comboBoxSearchInput"
+                                id="random_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                role="textbox"
+                                style={
+                                  Object {
+                                    "boxSizing": "content-box",
+                                    "width": "2px",
+                                  }
+                                }
+                                value=""
+                              />
+                              <div
+                                style={
+                                  Object {
+                                    "height": 0,
+                                    "left": 0,
+                                    "overflow": "scroll",
+                                    "position": "absolute",
+                                    "top": 0,
+                                    "visibility": "hidden",
+                                    "whiteSpace": "pre",
+                                  }
+                                }
+                              />
+                            </div>
+                          </AutosizeInput>
+                        </div>
+                        <EuiFormControlLayoutIcons
+                          clear={
+                            Object {
+                              "data-test-subj": "comboBoxClearButton",
+                              "onClick": [Function],
+                            }
+                          }
+                          compressed={false}
+                          icon={
+                            Object {
+                              "aria-label": "Open list of options",
+                              "data-test-subj": "comboBoxToggleListButton",
+                              "disabled": undefined,
+                              "onClick": [Function],
+                              "ref": [Function],
+                              "side": "right",
+                              "type": "arrowDown",
+                            }
+                          }
+                          isLoading={true}
+                        >
+                          <div
+                            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <EuiFormControlLayoutClearButton
+                              data-test-subj="comboBoxClearButton"
+                              onClick={[Function]}
+                              size="m"
+                            >
+                              <EuiI18n
+                                default="Clear input"
+                                token="euiFormControlLayoutClearButton.label"
+                              >
+                                <button
+                                  aria-label="Clear input"
+                                  className="euiFormControlLayoutClearButton"
+                                  data-test-subj="comboBoxClearButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    className="euiFormControlLayoutClearButton__icon"
+                                    type="cross"
+                                  >
+                                    <EuiIconCross
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+                                        />
+                                      </svg>
+                                    </EuiIconCross>
+                                  </EuiIcon>
+                                </button>
+                              </EuiI18n>
+                            </EuiFormControlLayoutClearButton>
+                            <EuiLoadingSpinner
+                              size="m"
+                            >
+                              <span
+                                className="euiLoadingSpinner euiLoadingSpinner--medium"
+                              />
+                            </EuiLoadingSpinner>
+                            <EuiFormControlLayoutCustomIcon
+                              aria-label="Open list of options"
+                              data-test-subj="comboBoxToggleListButton"
+                              iconRef={[Function]}
+                              onClick={[Function]}
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <button
+                                aria-label="Open list of options"
+                                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                data-test-subj="comboBoxToggleListButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiFormControlLayoutCustomIcon__icon"
+                                  size="m"
+                                  type="arrowDown"
+                                >
+                                  <EuiIconArrowDown
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                        fillRule="non-zero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowDown>
+                                </EuiIcon>
+                              </button>
+                            </EuiFormControlLayoutCustomIcon>
+                          </div>
+                        </EuiFormControlLayoutIcons>
+                      </div>
+                    </div>
+                  </EuiFormControlLayout>
+                </EuiComboBoxInput>
+              </div>
+            </EuiComboBox>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select a data source to pull the data from."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select a data source to pull the data from.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be at least 1 character.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="Select a table name to associate with your data."
+        isInvalid={true}
+        label="Flint Table Name"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={true}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={true}
+              type="label"
+            >
+              <label
+                aria-invalid={true}
+                className="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+                htmlFor="random_html_id"
+              >
+                Flint Table Name
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              aria-describedby="random_html_id-help-0 random_html_id-error-0"
+              id="random_html_id"
+              isInvalid={true}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="sample"
+              value=""
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={true}
+                    >
+                      <input
+                        aria-describedby="random_html_id-help-0 random_html_id-error-0"
+                        className="euiFieldText"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="sample"
+                        type="text"
+                        value=""
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+            <EuiFormErrorText
+              className="euiFormRow__text"
+              id="random_html_id-error-0"
+              key="Must be at least 1 character."
+            >
+              <div
+                aria-live="polite"
+                className="euiFormErrorText euiFormRow__text"
+                id="random_html_id-error-0"
+              >
+                Must be at least 1 character.
+              </div>
+            </EuiFormErrorText>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select a table name to associate with your data."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select a table name to associate with your data.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be a URL starting with 's3://'.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        isInvalid={false}
+        label="S3 Bucket Location"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={false}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={false}
+              type="label"
+            >
+              <label
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                S3 Bucket Location
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              id="random_html_id"
+              isInvalid={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="s3://"
+              value=""
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={false}
+                    >
+                      <input
+                        className="euiFieldText"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="s3://"
+                        type="text"
+                        value=""
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be a URL starting with 's3://'.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results."
+        isInvalid={false}
+        label="S3 Checkpoint Location"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={false}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={false}
+              type="label"
+            >
+              <label
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                S3 Checkpoint Location
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              aria-describedby="random_html_id-help-0"
+              id="random_html_id"
+              isInvalid={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="s3://"
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={false}
+                    >
+                      <input
+                        aria-describedby="random_html_id-help-0"
+                        className="euiFieldText"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="s3://"
+                        type="text"
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+    </div>
+  </EuiForm>
+</SetupIntegrationForm>
+`;
+
+exports[`Integration Setup Page Renders the S3 connector form without workflows 1`] = `
+<SetupIntegrationForm
+  config={
+    Object {
+      "connectionDataSource": "ss4o_logs-nginx-test",
+      "connectionLocation": "",
+      "connectionTableName": "",
+      "connectionType": "s3",
+      "displayName": "Test Instance Name",
+    }
+  }
+  integration={
+    Object {
+      "assets": Array [
+        Object {
+          "extension": "ndjson",
+          "name": "sample",
+          "type": "savedObjectBundle",
+          "version": "1.0.1",
+        },
+      ],
+      "components": Array [
+        Object {
+          "name": "logs",
+          "version": "1.0.0",
+        },
+      ],
+      "license": "Apache-2.0",
+      "name": "sample",
+      "type": "logs",
+      "version": "2.0.0",
+      "workflows": undefined,
+    }
+  }
+  setupCallout={
+    Object {
+      "show": false,
+    }
+  }
+  updateConfig={[Function]}
+>
+  <EuiForm>
+    <div
+      className="euiForm"
+    >
+      <EuiTitle>
+        <h1
+          className="euiTitle euiTitle--medium"
+        >
+          Set Up Integration
+        </h1>
+      </EuiTitle>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <h3>
+            Integration Details
+          </h3>
+        </div>
+      </EuiText>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be at least 1 character.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        isInvalid={false}
+        label="Display Name"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={false}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={false}
+              type="label"
+            >
+              <label
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                Display Name
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              data-test-subj="new-instance-name"
+              id="random_html_id"
+              isInvalid={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="sample Integration"
+              value="Test Instance Name"
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={false}
+                    >
+                      <input
+                        className="euiFieldText"
+                        data-test-subj="new-instance-name"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="sample Integration"
+                        type="text"
+                        value="Test Instance Name"
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiText>
+        <div
+          className="euiText euiText--medium"
+        >
+          <h3>
+            Integration Connection
+          </h3>
+        </div>
+      </EuiText>
+      <EuiSpacer>
+        <div
+          className="euiSpacer euiSpacer--l"
+        />
+      </EuiSpacer>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="Select the type of connection to use for queries."
+        label="Connection Type"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              type="label"
+            >
+              <label
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                Connection Type
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiSelect
+              aria-describedby="random_html_id-help-0"
+              id="random_html_id"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              options={
+                Array [
+                  Object {
+                    "text": "OpenSearch Index",
+                    "value": "index",
+                  },
+                ]
+              }
+              value="s3"
+            >
+              <EuiFormControlLayout
+                compressed={false}
+                fullWidth={false}
+                icon={
+                  Object {
+                    "side": "right",
+                    "type": "arrowDown",
+                  }
+                }
+                inputId="random_html_id"
+                isLoading={false}
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl>
+                      <select
+                        aria-describedby="random_html_id-help-0"
+                        className="euiSelect"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onMouseUp={[Function]}
+                        value="s3"
+                      >
+                        <option
+                          key="0"
+                          value="index"
+                        >
+                          OpenSearch Index
+                        </option>
+                      </select>
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons
+                      compressed={false}
+                      icon={
+                        Object {
+                          "side": "right",
+                          "type": "arrowDown",
+                        }
+                      }
+                      isLoading={false}
+                    >
+                      <div
+                        className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <EuiFormControlLayoutCustomIcon
+                          size="m"
+                          type="arrowDown"
+                        >
+                          <span
+                            className="euiFormControlLayoutCustomIcon"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiFormControlLayoutCustomIcon__icon"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconArrowDown
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fillRule="non-zero"
+                                  />
+                                </svg>
+                              </EuiIconArrowDown>
+                            </EuiIcon>
+                          </span>
+                        </EuiFormControlLayoutCustomIcon>
+                      </div>
+                    </EuiFormControlLayoutIcons>
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiSelect>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select the type of connection to use for queries."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select the type of connection to use for queries.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="Select a data source to pull the data from."
+        label="Data Source"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              type="label"
+            >
+              <label
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                Data Source
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiComboBox
+              aria-describedby="random_html_id-help-0"
+              async={false}
+              compressed={false}
+              customOptionText="Select {searchValue} as your data_source"
+              data-test-subj="data-source-name"
+              fullWidth={false}
+              id="random_html_id"
+              isClearable={true}
+              isLoading={true}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onCreateOption={[Function]}
+              onFocus={[Function]}
+              options={Array []}
+              selectedOptions={
+                Array [
+                  Object {
+                    "label": "ss4o_logs-nginx-test",
+                  },
+                ]
+              }
+              singleSelection={
+                Object {
+                  "asPlainText": true,
+                }
+              }
+              sortMatchesBy="none"
+            >
+              <div
+                aria-describedby="random_html_id-help-0"
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                className="euiComboBox"
+                data-test-subj="data-source-name"
+                onKeyDown={[Function]}
+                role="combobox"
+              >
+                <EuiComboBoxInput
+                  autoSizeInputRef={[Function]}
+                  compressed={false}
+                  fullWidth={false}
+                  hasSelectedOptions={true}
+                  id="random_html_id"
+                  inputRef={[Function]}
+                  isListOpen={false}
+                  isLoading={true}
+                  noIcon={false}
+                  onChange={[Function]}
+                  onClear={[Function]}
+                  onClick={[Function]}
+                  onCloseListClick={[Function]}
+                  onFocus={[Function]}
+                  onOpenListClick={[Function]}
+                  onRemoveOption={[Function]}
+                  rootId={[Function]}
+                  searchValue=""
+                  selectedOptions={
+                    Array [
+                      Object {
+                        "label": "ss4o_logs-nginx-test",
+                      },
+                    ]
+                  }
+                  singleSelection={
+                    Object {
+                      "asPlainText": true,
+                    }
+                  }
+                  toggleButtonRef={[Function]}
+                  updatePosition={[Function]}
+                  value="ss4o_logs-nginx-test"
+                >
+                  <EuiFormControlLayout
+                    clear={
+                      Object {
+                        "data-test-subj": "comboBoxClearButton",
+                        "onClick": [Function],
+                      }
+                    }
+                    compressed={false}
+                    fullWidth={false}
+                    icon={
+                      Object {
+                        "aria-label": "Open list of options",
+                        "data-test-subj": "comboBoxToggleListButton",
+                        "disabled": undefined,
+                        "onClick": [Function],
+                        "ref": [Function],
+                        "side": "right",
+                        "type": "arrowDown",
+                      }
+                    }
+                    isLoading={true}
+                  >
+                    <div
+                      className="euiFormControlLayout"
+                    >
+                      <div
+                        className="euiFormControlLayout__childrenWrapper"
+                      >
+                        <div
+                          className="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading euiComboBox__inputWrap-isClearable"
+                          data-test-subj="comboBoxInput"
+                          onClick={[Function]}
+                          tabIndex={-1}
+                        >
+                          <EuiComboBoxPill
+                            asPlainText={true}
+                            color="hollow"
+                            key="ss4o_logs-nginx-test"
+                            option={
+                              Object {
+                                "label": "ss4o_logs-nginx-test",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiComboBoxPill euiComboBoxPill--plainText"
+                            >
+                              ss4o_logs-nginx-test
+                            </span>
+                          </EuiComboBoxPill>
+                          <AutosizeInput
+                            aria-controls=""
+                            className="euiComboBox__input"
+                            data-test-subj="comboBoxSearchInput"
+                            id="random_html_id"
+                            injectStyles={true}
+                            inputRef={[Function]}
+                            minWidth={1}
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            role="textbox"
+                            style={
+                              Object {
+                                "fontSize": 14,
+                              }
+                            }
+                            value=""
+                          >
+                            <div
+                              className="euiComboBox__input"
+                              style={
+                                Object {
+                                  "display": "inline-block",
+                                  "fontSize": 14,
+                                }
+                              }
+                            >
+                              <input
+                                aria-controls=""
+                                data-test-subj="comboBoxSearchInput"
+                                id="random_html_id"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                role="textbox"
+                                style={
+                                  Object {
+                                    "boxSizing": "content-box",
+                                    "width": "2px",
+                                  }
+                                }
+                                value=""
+                              />
+                              <div
+                                style={
+                                  Object {
+                                    "height": 0,
+                                    "left": 0,
+                                    "overflow": "scroll",
+                                    "position": "absolute",
+                                    "top": 0,
+                                    "visibility": "hidden",
+                                    "whiteSpace": "pre",
+                                  }
+                                }
+                              />
+                            </div>
+                          </AutosizeInput>
+                        </div>
+                        <EuiFormControlLayoutIcons
+                          clear={
+                            Object {
+                              "data-test-subj": "comboBoxClearButton",
+                              "onClick": [Function],
+                            }
+                          }
+                          compressed={false}
+                          icon={
+                            Object {
+                              "aria-label": "Open list of options",
+                              "data-test-subj": "comboBoxToggleListButton",
+                              "disabled": undefined,
+                              "onClick": [Function],
+                              "ref": [Function],
+                              "side": "right",
+                              "type": "arrowDown",
+                            }
+                          }
+                          isLoading={true}
+                        >
+                          <div
+                            className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <EuiFormControlLayoutClearButton
+                              data-test-subj="comboBoxClearButton"
+                              onClick={[Function]}
+                              size="m"
+                            >
+                              <EuiI18n
+                                default="Clear input"
+                                token="euiFormControlLayoutClearButton.label"
+                              >
+                                <button
+                                  aria-label="Clear input"
+                                  className="euiFormControlLayoutClearButton"
+                                  data-test-subj="comboBoxClearButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    className="euiFormControlLayoutClearButton__icon"
+                                    type="cross"
+                                  >
+                                    <EuiIconCross
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+                                        />
+                                      </svg>
+                                    </EuiIconCross>
+                                  </EuiIcon>
+                                </button>
+                              </EuiI18n>
+                            </EuiFormControlLayoutClearButton>
+                            <EuiLoadingSpinner
+                              size="m"
+                            >
+                              <span
+                                className="euiLoadingSpinner euiLoadingSpinner--medium"
+                              />
+                            </EuiLoadingSpinner>
+                            <EuiFormControlLayoutCustomIcon
+                              aria-label="Open list of options"
+                              data-test-subj="comboBoxToggleListButton"
+                              iconRef={[Function]}
+                              onClick={[Function]}
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <button
+                                aria-label="Open list of options"
+                                className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                data-test-subj="comboBoxToggleListButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <EuiIcon
+                                  aria-hidden="true"
+                                  className="euiFormControlLayoutCustomIcon__icon"
+                                  size="m"
+                                  type="arrowDown"
+                                >
+                                  <EuiIconArrowDown
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    role="img"
+                                    style={null}
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                        fillRule="non-zero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowDown>
+                                </EuiIcon>
+                              </button>
+                            </EuiFormControlLayoutCustomIcon>
+                          </div>
+                        </EuiFormControlLayoutIcons>
+                      </div>
+                    </div>
+                  </EuiFormControlLayout>
+                </EuiComboBoxInput>
+              </div>
+            </EuiComboBox>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select a data source to pull the data from."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select a data source to pull the data from.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be at least 1 character.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="Select a table name to associate with your data."
+        isInvalid={true}
+        label="Flint Table Name"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={true}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={true}
+              type="label"
+            >
+              <label
+                aria-invalid={true}
+                className="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+                htmlFor="random_html_id"
+              >
+                Flint Table Name
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              aria-describedby="random_html_id-help-0 random_html_id-error-0"
+              id="random_html_id"
+              isInvalid={true}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="sample"
+              value=""
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={true}
+                    >
+                      <input
+                        aria-describedby="random_html_id-help-0 random_html_id-error-0"
+                        className="euiFieldText"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="sample"
+                        type="text"
+                        value=""
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+            <EuiFormErrorText
+              className="euiFormRow__text"
+              id="random_html_id-error-0"
+              key="Must be at least 1 character."
+            >
+              <div
+                aria-live="polite"
+                className="euiFormErrorText euiFormRow__text"
+                id="random_html_id-error-0"
+              >
+                Must be at least 1 character.
+              </div>
+            </EuiFormErrorText>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="Select a table name to associate with your data."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Select a table name to associate with your data.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be a URL starting with 's3://'.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        isInvalid={false}
+        label="S3 Bucket Location"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={false}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={false}
+              type="label"
+            >
+              <label
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                S3 Bucket Location
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              id="random_html_id"
+              isInvalid={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="s3://"
+              value=""
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={false}
+                    >
+                      <input
+                        className="euiFieldText"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="s3://"
+                        type="text"
+                        value=""
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+          </div>
+        </div>
+      </EuiFormRow>
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error={
+          Array [
+            "Must be a URL starting with 's3://'.",
+          ]
+        }
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        helpText="The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results."
+        isInvalid={false}
+        label="S3 Checkpoint Location"
+        labelType="label"
+      >
+        <div
+          className="euiFormRow"
+          id="random_html_id-row"
+        >
+          <div
+            className="euiFormRow__labelWrapper"
+          >
+            <EuiFormLabel
+              aria-invalid={false}
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              isInvalid={false}
+              type="label"
+            >
+              <label
+                aria-invalid={false}
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
+              >
+                S3 Checkpoint Location
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiFieldText
+              aria-describedby="random_html_id-help-0"
+              id="random_html_id"
+              isInvalid={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="s3://"
+            >
+              <EuiFormControlLayout
+                fullWidth={false}
+                inputId="random_html_id"
+              >
+                <div
+                  className="euiFormControlLayout"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl
+                      isInvalid={false}
+                    >
+                      <input
+                        aria-describedby="random_html_id-help-0"
+                        className="euiFieldText"
+                        id="random_html_id"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder="s3://"
+                        type="text"
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons />
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldText>
+            <EuiFormHelpText
+              className="euiFormRow__text"
+              id="random_html_id-help-0"
+              key="The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results."
+            >
+              <div
+                className="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                The Checkpoint location must be a unique directory and not the same as the Bucket location. It will be used for caching intermediary results.
+              </div>
+            </EuiFormHelpText>
+          </div>
+        </div>
+      </EuiFormRow>
+    </div>
+  </EuiForm>
+</SetupIntegrationForm>
+`;
+
 exports[`Integration Setup Page Renders the index form as expected 1`] = `
 <SetupIntegrationForm
   config={

--- a/public/components/integrations/components/__tests__/setup_integration.test.tsx
+++ b/public/components/integrations/components/__tests__/setup_integration.test.tsx
@@ -53,4 +53,19 @@ describe('Integration Setup Page', () => {
       expect(wrapper).toMatchSnapshot();
     });
   });
+
+  it('Renders the S3 connector form without workflows', async () => {
+    const wrapper = mount(
+      <SetupIntegrationForm
+        config={{ ...TEST_INTEGRATION_SETUP_INPUTS, connectionType: 's3' }}
+        updateConfig={() => {}}
+        integration={{ ...TEST_INTEGRATION_CONFIG, workflows: undefined }}
+        setupCallout={{ show: false }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 });

--- a/public/components/integrations/components/create_integration_helpers.ts
+++ b/public/components/integrations/components/create_integration_helpers.ts
@@ -282,7 +282,8 @@ export async function addIntegrationRequest(
   integration: IntegrationConfig,
   setToast: (title: string, color?: Color, text?: string | undefined) => void,
   name?: string,
-  dataSource?: string
+  dataSource?: string,
+  workflows?: string[]
 ): Promise<boolean> {
   const http = coreRefs.http!;
   if (addSample) {
@@ -298,7 +299,7 @@ export async function addIntegrationRequest(
 
   let response: boolean = await http
     .post(`${INTEGRATIONS_BASE}/store/${templateName}`, {
-      body: JSON.stringify({ name, dataSource }),
+      body: JSON.stringify({ name, dataSource, workflows }),
     })
     .then((res) => {
       setToast(`${name} integration successfully added!`, 'success');

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -482,7 +482,8 @@ const addIntegration = async ({
       integration,
       setCalloutLikeToast,
       config.displayName,
-      `flint_${config.connectionDataSource}_default_${config.connectionTableName}_mview`
+      `flint_${config.connectionDataSource}_default_${config.connectionTableName}_mview`,
+      config.enabledWorkflows
     );
     if (!res) {
       setLoading(false);

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -8,6 +8,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
+  EuiCheckableCard,
   EuiComboBox,
   EuiEmptyPrompt,
   EuiFieldText,
@@ -182,6 +183,37 @@ const runQuery = async (
   }
 };
 
+export function SetupWorkflowSelector({
+  integration,
+  useWorkflows,
+  toggleWorkflow,
+}: {
+  integration: IntegrationConfig;
+  useWorkflows: Map<string, boolean>;
+  toggleWorkflow: (name: string) => void;
+}) {
+  if (!integration.workflows) {
+    return null;
+  }
+
+  const cards = integration.workflows.map((workflow) => {
+    return (
+      <EuiCheckableCard
+        id={`workflow-checkbox-${workflow.name}`}
+        label={workflow.label}
+        checkableType="checkbox"
+        value={workflow.name}
+        checked={useWorkflows.get(workflow.name)}
+        onChange={() => toggleWorkflow(workflow.name)}
+      >
+        {workflow.description}
+      </EuiCheckableCard>
+    );
+  });
+
+  return cards;
+}
+
 export function SetupIntegrationForm({
   config,
   updateConfig,
@@ -196,6 +228,17 @@ export function SetupIntegrationForm({
   const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(true);
   const [isBucketBlurred, setIsBucketBlurred] = useState(false);
   const [isCheckpointBlurred, setIsCheckpointBlurred] = useState(false);
+
+  const [useWorkflows, setUseWorkflows] = useState(new Map());
+  const toggleWorkflow = (name: string) => {
+    setUseWorkflows(new Map(useWorkflows.set(name, !useWorkflows.get(name))));
+  };
+
+  useEffect(() => {
+    if (integration.workflows) {
+      setUseWorkflows(new Map(integration.workflows.map((w) => [w.name, w.enabled_by_default])));
+    }
+  }, [integration.workflows]);
 
   useEffect(() => {
     const updateDataSources = async () => {
@@ -337,6 +380,13 @@ export function SetupIntegrationForm({
               onBlur={() => {
                 setIsCheckpointBlurred(true);
               }}
+            />
+          </EuiFormRow>
+          <EuiFormRow>
+            <SetupWorkflowSelector
+              integration={integration}
+              useWorkflows={useWorkflows}
+              toggleWorkflow={toggleWorkflow}
             />
           </EuiFormRow>
         </>

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -493,11 +493,14 @@ const addIntegration = async ({
   }
 };
 
-const isConfigValid = (config: IntegrationSetupInputs): boolean => {
+const isConfigValid = (config: IntegrationSetupInputs, integration: IntegrationConfig): boolean => {
   if (config.displayName.length < 1 || config.connectionDataSource.length < 1) {
     return false;
   }
   if (config.connectionType === 's3') {
+    if (integration.workflows && config.enabledWorkflows.length < 1) {
+      return false;
+    }
     return (
       config.connectionLocation.startsWith('s3://') && config.checkpointLocation.startsWith('s3://')
     );
@@ -552,7 +555,7 @@ export function SetupBottomBar({
             iconType="arrowRight"
             iconSide="right"
             isLoading={loading}
-            disabled={!isConfigValid(config)}
+            disabled={!isConfigValid(config, integration)}
             onClick={async () =>
               addIntegration({ integration, config, setLoading, setCalloutLikeToast })
             }
@@ -586,6 +589,7 @@ export function SetupIntegrationPage({ integration }: { integration: string }) {
     connectionLocation: '',
     checkpointLocation: '',
     connectionTableName: integration,
+    enabledWorkflows: [],
   });
 
   const [template, setTemplate] = useState({

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -392,18 +392,29 @@ export function SetupIntegrationForm({
               }}
             />
           </EuiFormRow>
-          <EuiFormRow
-            label="Select installation workflows"
-            helpText={'Select from the available types of assets based on how your use case.'}
-            isInvalid={![...useWorkflows.values()].includes(true)}
-            error={['Must select at least one workflow.']}
-          >
-            <SetupWorkflowSelector
-              integration={integration}
-              useWorkflows={useWorkflows}
-              toggleWorkflow={toggleWorkflow}
-            />
-          </EuiFormRow>
+          {integration.workflows ? (
+            <>
+              <EuiSpacer />
+              <EuiText>
+                <h3>Installation Flows</h3>
+              </EuiText>
+              <EuiSpacer />
+              <EuiFormRow
+                label={'Flows'}
+                helpText={
+                  'Select from the available asset types based on your use case. Choose at least one.'
+                }
+                isInvalid={![...useWorkflows.values()].includes(true)}
+                error={['Must select at least one workflow.']}
+              >
+                <SetupWorkflowSelector
+                  integration={integration}
+                  useWorkflows={useWorkflows}
+                  toggleWorkflow={toggleWorkflow}
+                />
+              </EuiFormRow>
+            </>
+          ) : null}
         </>
       ) : null}
     </EuiForm>

--- a/server/adaptors/integrations/__data__/repository/aws_elb/aws_elb-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/aws_elb/aws_elb-1.0.0.json
@@ -8,6 +8,20 @@
   "labels": ["Observability", "Logs", "AWS", "Flint S3", "Cloud"],
   "author": "OpenSearch",
   "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/aws_elb/info",
+  "workflows": [
+    {
+      "name": "queries",
+      "label": "Queries (recommended)",
+      "description": "Tables and pre-written queries for quickly getting insights on your data.",
+      "enabled_by_default": true
+    },
+    {
+      "name": "dashboards",
+      "label": "Dashboards & Visualizations",
+      "description": "Dashboards and indices that enable you to easily visualize important metrics.",
+      "enabled_by_default": false
+    }
+  ],
   "statics": {
     "logo": {
       "annotation": "ELB Logo",
@@ -51,7 +65,8 @@
       "name": "aws_elb",
       "version": "1.0.0",
       "extension": "ndjson",
-      "type": "savedObjectBundle"
+      "type": "savedObjectBundle",
+      "workflows": ["dashboards"]
     },
     {
       "name": "create_table",
@@ -63,7 +78,8 @@
       "name": "create_mv",
       "version": "1.0.0",
       "extension": "sql",
-      "type": "query"
+      "type": "query",
+      "workflows": ["dashboards"]
     }
   ],
   "sampleData": {

--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/aws_vpc_flow-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/aws_vpc_flow-1.0.0.json
@@ -8,6 +8,20 @@
   "labels": ["Observability", "Logs", "AWS", "Cloud", "Flint S3"],
   "author": "Haidong Wang",
   "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/aws_vpc_flow/info",
+  "workflows": [
+    {
+      "name": "queries",
+      "label": "Queries (recommended)",
+      "description": "Tables and pre-written queries for quickly getting insights on your data.",
+      "enabled_by_default": true
+    },
+    {
+      "name": "dashboards",
+      "label": "Dashboards & Visualizations",
+      "description": "Dashboards and indices that enable you to easily visualize important metrics.",
+      "enabled_by_default": false
+    }
+  ],
   "statics": {
     "logo": {
       "annotation": "AWS VPC Logo",
@@ -47,7 +61,8 @@
       "name": "aws_vpc_flow",
       "version": "1.0.0",
       "extension": "ndjson",
-      "type": "savedObjectBundle"
+      "type": "savedObjectBundle",
+      "workflows": ["dashboards"]
     },
     {
       "name": "create_table_vpc",
@@ -59,7 +74,8 @@
       "name": "create_mv_vpc",
       "version": "1.0.0",
       "extension": "sql",
-      "type": "query"
+      "type": "query",
+      "workflows": ["dashboards"]
     }
   ],
   "sampleData": {

--- a/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
+++ b/server/adaptors/integrations/__data__/repository/nginx/nginx-1.0.0.json
@@ -8,6 +8,20 @@
   "labels": ["Observability", "Logs", "Flint S3"],
   "author": "OpenSearch",
   "sourceUrl": "https://github.com/opensearch-project/dashboards-observability/tree/main/server/adaptors/integrations/__data__/repository/nginx/info",
+  "workflows": [
+    {
+      "name": "queries",
+      "label": "Queries (recommended)",
+      "description": "Tables and pre-written queries for quickly getting insights on your data.",
+      "enabled_by_default": true
+    },
+    {
+      "name": "dashboards",
+      "label": "Dashboards & Visualizations",
+      "description": "Dashboards and indices that enable you to easily visualize important metrics.",
+      "enabled_by_default": false
+    }
+  ],
   "statics": {
     "logo": {
       "annotation": "NginX Logo",
@@ -43,7 +57,8 @@
       "name": "nginx",
       "version": "1.0.0",
       "extension": "ndjson",
-      "type": "savedObjectBundle"
+      "type": "savedObjectBundle",
+      "workflows": ["dashboards"]
     },
     {
       "name": "create_table",
@@ -55,7 +70,8 @@
       "name": "create_mv",
       "version": "1.0.0",
       "extension": "sql",
-      "type": "query"
+      "type": "query",
+      "workflows": ["dashboards"]
     }
   ],
   "sampleData": {

--- a/server/adaptors/integrations/__test__/builder.test.ts
+++ b/server/adaptors/integrations/__test__/builder.test.ts
@@ -343,3 +343,74 @@ describe('IntegrationInstanceBuilder', () => {
     });
   });
 });
+
+describe('getSavedObjectBundles', () => {
+  let builder: IntegrationInstanceBuilder;
+
+  beforeEach(() => {
+    builder = new IntegrationInstanceBuilder(mockSavedObjectsClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should filter assets correctly without workflows and includeWorkflows', () => {
+    const assets = [
+      {
+        type: 'savedObjectBundle' as const,
+        data: [{ id: '1', type: 'type1', attributes: { title: 'Title 1' } }],
+      },
+      {
+        type: 'savedObjectBundle' as const,
+        data: [{ id: '2', type: 'type2', attributes: { title: 'Title 2' } }],
+      },
+      { type: 'query' as const, query: 'query', language: 'language' },
+    ];
+    const result = builder.getSavedObjectBundles(assets);
+    expect(result.length).toBe(2);
+  });
+
+  it('should filter assets correctly with specified workflows', () => {
+    const assets = [
+      {
+        type: 'savedObjectBundle' as const,
+        workflows: ['workflow1'],
+        data: [{ id: '1', type: 'type1', attributes: { title: 'Title 1' } }],
+      },
+      {
+        type: 'savedObjectBundle' as const,
+        workflows: ['workflow2'],
+        data: [{ id: '2', type: 'type2', attributes: { title: 'Title 2' } }],
+      },
+      { type: 'query' as const, query: 'query', language: 'language' },
+    ];
+    const result = builder.getSavedObjectBundles(assets, ['workflow1']);
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('should filter assets correctly with no matching workflows', () => {
+    const assets = [
+      {
+        type: 'savedObjectBundle' as const,
+        workflows: ['workflow1'],
+        data: [{ id: '1', type: 'type1', attributes: { title: 'Title 1' } }],
+      },
+      {
+        type: 'savedObjectBundle' as const,
+        workflows: ['workflow2'],
+        data: [{ id: '2', type: 'type2', attributes: { title: 'Title 2' } }],
+      },
+      { type: 'query' as const, query: 'query', language: 'language' },
+    ];
+    const result = builder.getSavedObjectBundles(assets, ['workflow3']);
+    expect(result.length).toBe(0);
+  });
+
+  it('should return an empty array if no savedObjectBundle assets are present', () => {
+    const assets = [{ type: 'query' as const, query: 'query', language: 'language' }];
+    const result = builder.getSavedObjectBundles(assets);
+    expect(result.length).toBe(0);
+  });
+});

--- a/server/adaptors/integrations/integrations_adaptor.ts
+++ b/server/adaptors/integrations/integrations_adaptor.ts
@@ -17,7 +17,8 @@ export interface IntegrationsAdaptor {
   loadIntegrationInstance: (
     templateName: string,
     name: string,
-    dataSource: string
+    dataSource: string,
+    workflows?: string[]
   ) => Promise<IntegrationInstance>;
 
   deleteIntegrationInstance: (id: string) => Promise<unknown>;

--- a/server/adaptors/integrations/integrations_builder.ts
+++ b/server/adaptors/integrations/integrations_builder.ts
@@ -12,6 +12,7 @@ import { deepCheck } from './repository/utils';
 interface BuilderOptions {
   name: string;
   dataSource: string;
+  workflows?: string[];
 }
 
 interface SavedObject {
@@ -28,32 +29,28 @@ export class IntegrationInstanceBuilder {
     this.client = client;
   }
 
-  build(integration: IntegrationReader, options: BuilderOptions): Promise<IntegrationInstance> {
-    const instance = deepCheck(integration)
-      .then((result) => {
-        if (!result.ok) {
-          return Promise.reject(result.error);
-        }
-        return integration.getAssets();
-      })
-      .then((assets) => {
-        if (!assets.ok) {
-          return Promise.reject(assets.error);
-        }
-        return assets.value;
-      })
-      .then((assets) =>
-        this.remapIDs(
-          assets
-            .filter((asset) => asset.type === 'savedObjectBundle')
-            .map((asset) => (asset as { type: 'savedObjectBundle'; data: object[] }).data)
-            .flat() as SavedObject[]
-        )
-      )
-      .then((assets) => this.remapDataSource(assets, options.dataSource))
-      .then((assets) => this.postAssets(assets))
-      .then((refs) => this.buildInstance(integration, refs, options));
-    return instance;
+  async build(
+    integration: IntegrationReader,
+    options: BuilderOptions
+  ): Promise<IntegrationInstance> {
+    const instance = await deepCheck(integration);
+    if (!instance.ok) {
+      return Promise.reject(instance.error);
+    }
+    const assets = await integration.getAssets();
+    if (!assets.ok) {
+      return Promise.reject(assets.error);
+    }
+    const remapped = this.remapIDs(
+      assets.value
+        .filter((asset) => asset.type === 'savedObjectBundle')
+        .map((asset) => (asset as { type: 'savedObjectBundle'; data: object[] }).data)
+        .flat() as SavedObject[]
+    );
+    const withDataSource = this.remapDataSource(remapped, options.dataSource);
+    const refs = await this.postAssets(withDataSource);
+    const builtInstance = await this.buildInstance(integration, refs, options);
+    return builtInstance;
   }
 
   remapDataSource(

--- a/server/adaptors/integrations/integrations_manager.ts
+++ b/server/adaptors/integrations/integrations_manager.ts
@@ -157,7 +157,8 @@ export class IntegrationsManager implements IntegrationsAdaptor {
   loadIntegrationInstance = async (
     templateName: string,
     name: string,
-    dataSource: string
+    dataSource: string,
+    workflows?: string[]
   ): Promise<IntegrationInstance> => {
     const template = await this.repository.getIntegration(templateName);
     if (template === null) {
@@ -171,6 +172,7 @@ export class IntegrationsManager implements IntegrationsAdaptor {
       const result = await this.instanceBuilder.build(template, {
         name,
         dataSource,
+        workflows,
       });
       const test = await this.client.create('integration-instance', result);
       return Promise.resolve({ ...result, id: test.id });

--- a/server/adaptors/integrations/repository/integration_reader.ts
+++ b/server/adaptors/integrations/repository/integration_reader.ts
@@ -202,12 +202,14 @@ export class IntegrationReader {
         case 'savedObjectBundle':
           resultValue.push({
             type: 'savedObjectBundle',
+            workflows: asset.workflows,
             data: JSON.parse(serializedResult.value.data),
           });
           break;
         case 'query':
           resultValue.push({
             type: 'query',
+            workflows: asset.workflows,
             query: serializedResult.value.data,
             language: asset.extension,
           });

--- a/server/adaptors/integrations/types.ts
+++ b/server/adaptors/integrations/types.ts
@@ -69,8 +69,8 @@ interface IntegrationWorkflow {
 }
 
 type ParsedIntegrationAsset =
-  | { type: 'savedObjectBundle'; data: object[] }
-  | { type: 'query'; query: string; language: string };
+  | { type: 'savedObjectBundle'; workflows?: string[]; data: object[] }
+  | { type: 'query'; workflows?: string[]; query: string; language: string };
 
 interface SerializedIntegrationAsset extends IntegrationAsset {
   data: string;

--- a/server/adaptors/integrations/types.ts
+++ b/server/adaptors/integrations/types.ts
@@ -19,6 +19,7 @@ interface IntegrationConfig {
   author?: string;
   description?: string;
   sourceUrl?: string;
+  workflows?: IntegrationWorkflow[];
   statics?: IntegrationStatics;
   components: IntegrationComponent[];
   assets: IntegrationAsset[];
@@ -57,6 +58,14 @@ interface IntegrationAsset {
   version: string;
   extension: string;
   type: SupportedAssetType;
+  workflows?: string[];
+}
+
+interface IntegrationWorkflow {
+  name: string;
+  label: string;
+  description: string;
+  enabled_by_default: boolean;
 }
 
 type ParsedIntegrationAsset =

--- a/server/adaptors/integrations/validators.ts
+++ b/server/adaptors/integrations/validators.ts
@@ -31,6 +31,20 @@ const templateSchema: JSONSchemaType<IntegrationConfig> = {
     author: { type: 'string', nullable: true },
     description: { type: 'string', nullable: true },
     sourceUrl: { type: 'string', nullable: true },
+    workflows: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          label: { type: 'string' },
+          description: { type: 'string' },
+          enabled_by_default: { type: 'boolean' },
+        },
+        required: ['name', 'label', 'description', 'enabled_by_default'],
+      },
+      nullable: true,
+    },
     statics: {
       type: 'object',
       properties: {
@@ -64,6 +78,11 @@ const templateSchema: JSONSchemaType<IntegrationConfig> = {
           extension: { type: 'string' },
           type: { type: 'string' },
           data: { type: 'string', nullable: true },
+          workflows: {
+            type: 'array',
+            items: { type: 'string' },
+            nullable: true,
+          },
         },
         required: ['name', 'version', 'extension', 'type'],
         additionalProperties: false,

--- a/server/routes/integrations/integrations_router.ts
+++ b/server/routes/integrations/integrations_router.ts
@@ -82,6 +82,7 @@ export function registerIntegrationsRoute(router: IRouter) {
         body: schema.object({
           name: schema.string(),
           dataSource: schema.string(),
+          workflows: schema.maybe(schema.arrayOf(schema.string())),
         }),
       },
     },
@@ -91,7 +92,8 @@ export function registerIntegrationsRoute(router: IRouter) {
         return a.loadIntegrationInstance(
           request.params.templateName,
           request.body.name,
-          request.body.dataSource
+          request.body.dataSource,
+          request.body.workflows
         );
       });
     }

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -574,6 +574,14 @@ export const TEST_INTEGRATION_CONFIG: IntegrationConfig = {
   version: '2.0.0',
   license: 'Apache-2.0',
   type: 'logs',
+  workflows: [
+    {
+      name: 'workflow1',
+      label: 'Workflow 1',
+      description: 'This is a test workflow.',
+      enabled_by_default: true,
+    },
+  ],
   components: [
     {
       name: 'logs',


### PR DESCRIPTION
### Description
Adds rudimentary support for toggling some parts of the integration installation process. There's still some parts that need to be updated:
- [x] The build process on the backend still can't check if it's supposed to load saved objects/which ones. We need to include workflows as part of the build request.
- [X] The UI for the checkbox still needs a nicer header.
  - [ ] Since the UI is larger now it also is probably a good idea to fix the clipping with the bottom bar overlapping the content on smaller screens.
- [x] It'd be nice to support enabling workflows for different data source types, but this might be complex enough to warrant a different issue and PR.
- [x] Add workflows to remaining S3 integrations
<img width="444" alt="image" src="https://github.com/opensearch-project/dashboards-observability/assets/31739405/546b6676-c16b-4cfb-9579-40ff6092c652">

### Issues Resolved
Closes #1462 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
