### PR TITLE
Add datasource field in accelerations cache

### DIFF
--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -83,19 +83,19 @@ export interface CachedColumn {
 
 export interface CachedTable {
   name: string;
-  columns: CachedColumn[];
+  columns?: CachedColumn[];
 }
 
 export interface CachedDatabase {
   name: string;
   tables: CachedTable[];
-  lastUpdated: string; // Assuming date string in UTC format
+  lastUpdated: string; // date string in UTC format
   status: CachedDataSourceStatus;
 }
 
 export interface CachedDataSource {
   name: string;
-  lastUpdated: string; // Assuming date string in UTC format
+  lastUpdated: string; // date string in UTC format
   status: CachedDataSourceStatus;
   databases: CachedDatabase[];
 }
@@ -115,11 +115,16 @@ export interface CachedAccelerations {
   status: string;
 }
 
+export interface CachedAcclerationByDataSource {
+  name: string;
+  accelerations: CachedAccelerations[];
+  lastUpdated: string; // date string in UTC format
+  status: CachedDataSourceStatus;
+}
+
 export interface AccelerationsCacheData {
   version: string;
-  accelerations: CachedAccelerations[];
-  lastUpdated: string; // Assuming date string in UTC format
-  status: CachedDataSourceStatus;
+  dataSources: CachedAcclerationByDataSource[];
 }
 
 export interface PollingSuccessResult {

--- a/public/framework/catalog_cache/cache_loader.test.tsx
+++ b/public/framework/catalog_cache/cache_loader.test.tsx
@@ -11,9 +11,11 @@ import {
   mockShowTablesPollingResult,
 } from '../../../test/datasources';
 import {
+  createLoadQuery,
   updateAccelerationsToCache,
   updateDatabasesToCache,
   updateTablesToCache,
+  updateToCache,
 } from './cache_loader';
 import { CatalogCacheManager } from './cache_manager';
 
@@ -146,10 +148,7 @@ describe('loadCacheTests', () => {
         dataSourceName,
         expect.objectContaining({
           name: databaseName,
-          tables: [
-            { name: 'Table1', columns: [] },
-            { name: 'Table2', columns: [] },
-          ],
+          tables: [{ name: 'Table1' }, { name: 'Table2' }],
           lastUpdated: expect.any(String),
           status: CachedDataSourceStatus.Updated,
         })
@@ -166,55 +165,169 @@ describe('loadCacheTests', () => {
     it('should save empty accelerations cache and status failed when polling result is null', () => {
       const pollingResult = null;
 
-      updateAccelerationsToCache(pollingResult);
+      updateAccelerationsToCache('sampleDS', pollingResult);
 
       // Verify that saveAccelerationsCache is called with the correct parameters
       expect(CatalogCacheManager.saveAccelerationsCache).toHaveBeenCalledWith({
         version: CATALOG_CACHE_VERSION,
-        accelerations: [],
-        lastUpdated: expect.any(String),
-        status: CachedDataSourceStatus.Failed,
+        dataSources: [
+          {
+            name: 'sampleDS',
+            accelerations: [],
+            lastUpdated: expect.any(String),
+            status: CachedDataSourceStatus.Failed,
+          },
+        ],
       });
     });
 
     it('should save new accelerations cache when polling result is not null', () => {
-      updateAccelerationsToCache(mockShowIndexesPollingResult);
+      updateAccelerationsToCache('sampleDS', mockShowIndexesPollingResult);
 
       // Verify that saveAccelerationsCache is called with the correct parameters
       expect(CatalogCacheManager.saveAccelerationsCache).toHaveBeenCalledWith({
         version: CATALOG_CACHE_VERSION,
-        accelerations: [
+        dataSources: [
           {
-            flintIndexName: 'flint_mys3_default_http_logs_skipping_index',
-            type: 'skipping',
-            database: 'default',
-            table: 'http_logs',
-            indexName: 'skipping_index',
-            autoRefresh: false,
-            status: 'Active',
-          },
-          {
-            flintIndexName: 'flint_mys3_default_http_logs_status_clientip_and_day_index',
-            type: 'covering',
-            database: 'default',
-            table: 'http_logs',
-            indexName: 'status_clientip_and_day',
-            autoRefresh: true,
-            status: 'Active',
-          },
-          {
-            flintIndexName: 'flint_mys3_default_http_count_view',
-            type: 'materialized',
-            database: 'default',
-            table: '',
-            indexName: 'http_count_view',
-            autoRefresh: true,
-            status: 'Active',
+            name: 'sampleDS',
+            accelerations: [
+              {
+                flintIndexName: 'flint_mys3_default_http_logs_skipping_index',
+                type: 'skipping',
+                database: 'default',
+                table: 'http_logs',
+                indexName: 'skipping_index',
+                autoRefresh: false,
+                status: 'Active',
+              },
+              {
+                flintIndexName: 'flint_mys3_default_http_logs_status_clientip_and_day_index',
+                type: 'covering',
+                database: 'default',
+                table: 'http_logs',
+                indexName: 'status_clientip_and_day',
+                autoRefresh: true,
+                status: 'Active',
+              },
+              {
+                flintIndexName: 'flint_mys3_default_http_count_view',
+                type: 'materialized',
+                database: 'default',
+                table: '',
+                indexName: 'http_count_view',
+                autoRefresh: true,
+                status: 'Active',
+              },
+            ],
+            lastUpdated: expect.any(String),
+            status: CachedDataSourceStatus.Updated,
           },
         ],
-        lastUpdated: expect.any(String),
+      });
+    });
+  });
+
+  describe('updateToCache', () => {
+    it('should call updateDatabasesToCache when loadCacheType is "databases"', () => {
+      const loadCacheType = 'databases';
+      const dataSourceName = 'TestDataSource';
+
+      updateToCache(mockShowDatabasesPollingResult, loadCacheType, dataSourceName);
+
+      // Verify that addOrUpdateDataSource is called
+      expect(CatalogCacheManager.addOrUpdateDataSource).toHaveBeenCalled();
+      expect(CatalogCacheManager.updateDatabase).not.toHaveBeenCalled();
+      expect(CatalogCacheManager.saveAccelerationsCache).not.toHaveBeenCalled();
+    });
+
+    it('should call updateTablesToCache when loadCacheType is "tables"', () => {
+      const loadCacheType = 'tables';
+      const dataSourceName = 'TestDataSource';
+      const databaseName = 'TestDatabase';
+
+      CatalogCacheManager.addOrUpdateDataSource({
+        databases: [
+          {
+            name: databaseName,
+            lastUpdated: '',
+            status: CachedDataSourceStatus.Empty,
+            tables: [],
+          },
+        ],
+        name: dataSourceName,
+        lastUpdated: new Date().toUTCString(),
         status: CachedDataSourceStatus.Updated,
       });
+
+      updateToCache(mockShowTablesPollingResult, loadCacheType, dataSourceName, databaseName);
+
+      // Verify that updateDatabase is called
+      expect(CatalogCacheManager.addOrUpdateDataSource).toHaveBeenCalled();
+      expect(CatalogCacheManager.updateDatabase).toHaveBeenCalled();
+      expect(CatalogCacheManager.saveAccelerationsCache).not.toHaveBeenCalled();
+    });
+
+    it('should call updateAccelerationsToCache when loadCacheType is "accelerations"', () => {
+      const loadCacheType = 'accelerations';
+      const dataSourceName = 'TestDataSource';
+
+      updateToCache(mockShowIndexesPollingResult, loadCacheType, dataSourceName);
+
+      // Verify that saveAccelerationsCache is called
+      expect(CatalogCacheManager.addOrUpdateDataSource).not.toHaveBeenCalled();
+      expect(CatalogCacheManager.updateDatabase).not.toHaveBeenCalled();
+      expect(CatalogCacheManager.saveAccelerationsCache).toHaveBeenCalled();
+    });
+
+    it('should not call any update function when loadCacheType is not recognized', () => {
+      const pollResults = {};
+      const loadCacheType = '';
+      const dataSourceName = 'TestDataSource';
+
+      updateToCache(pollResults, loadCacheType, dataSourceName);
+
+      // Verify that no update function is called
+      expect(CatalogCacheManager.addOrUpdateDataSource).not.toHaveBeenCalled();
+      expect(CatalogCacheManager.updateDatabase).not.toHaveBeenCalled();
+      expect(CatalogCacheManager.saveAccelerationsCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createLoadQuery', () => {
+    it('should create a query for loading databases', () => {
+      const loadCacheType = 'databases';
+      const dataSourceName = 'example';
+      const expectedQuery = 'SHOW SCHEMAS IN `example`';
+      expect(createLoadQuery(loadCacheType, dataSourceName)).toEqual(expectedQuery);
+    });
+
+    it('should create a query for loading tables', () => {
+      const loadCacheType = 'tables';
+      const dataSourceName = 'example';
+      const databaseName = 'test';
+      const expectedQuery = 'SHOW TABLES IN `example`.`test`';
+      expect(createLoadQuery(loadCacheType, dataSourceName, databaseName)).toEqual(expectedQuery);
+    });
+
+    it('should create a query for loading accelerations', () => {
+      const loadCacheType = 'accelerations';
+      const dataSourceName = 'example';
+      const expectedQuery = 'SHOW FLINT INDEX in `example`';
+      expect(createLoadQuery(loadCacheType, dataSourceName)).toEqual(expectedQuery);
+    });
+
+    it('should return an empty string for unknown loadCacheType', () => {
+      const loadCacheType = 'unknownType';
+      const dataSourceName = 'example';
+      expect(createLoadQuery(loadCacheType, dataSourceName)).toEqual('');
+    });
+
+    it('should properly handle backticks in database name', () => {
+      const loadCacheType = 'tables';
+      const dataSourceName = 'example';
+      const databaseName = '`sample`';
+      const expectedQuery = 'SHOW TABLES IN `example`.`sample`';
+      expect(createLoadQuery(loadCacheType, dataSourceName, databaseName)).toEqual(expectedQuery);
     });
   });
 });

--- a/public/framework/catalog_cache/cache_manager.test.tsx
+++ b/public/framework/catalog_cache/cache_manager.test.tsx
@@ -421,7 +421,6 @@ describe('CatalogCacheManager', () => {
         status: CachedDataSourceStatus.Updated,
         accelerations: [],
       };
-      // mockAccelerationsCacheData.dataSources = [initialDataSource];
 
       // Update the data source
       const updatedDataSource: CachedAcclerationByDataSource = {

--- a/public/framework/catalog_cache/cache_manager.test.tsx
+++ b/public/framework/catalog_cache/cache_manager.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../common/constants/shared';
 import {
   AccelerationsCacheData,
+  CachedAcclerationByDataSource,
   CachedDataSource,
   CachedDataSourceStatus,
   CachedDatabase,
@@ -134,9 +135,7 @@ describe('CatalogCacheManager', () => {
     it('should save accelerations cache to local storage', () => {
       const cacheData: AccelerationsCacheData = {
         version: CATALOG_CACHE_VERSION,
-        accelerations: [],
-        lastUpdated: '2024-03-07T12:00:00Z',
-        status: CachedDataSourceStatus.Empty,
+        dataSources: [],
       };
       CatalogCacheManager.saveAccelerationsCache(cacheData);
       expect(localStorage.setItem).toHaveBeenCalledWith(
@@ -150,20 +149,16 @@ describe('CatalogCacheManager', () => {
     it('should retrieve accelerations cache from local storage', () => {
       const cacheData: AccelerationsCacheData = {
         version: CATALOG_CACHE_VERSION,
-        accelerations: [],
-        lastUpdated: '2024-03-07T12:00:00Z',
-        status: CachedDataSourceStatus.Empty,
+        dataSources: [],
       };
       localStorage.setItem(ASYNC_QUERY_ACCELERATIONS_CACHE, JSON.stringify(cacheData));
       expect(CatalogCacheManager.getAccelerationsCache()).toEqual(cacheData);
     });
 
     it('should return default cache object if cache is not found', () => {
-      const defaultCacheObject = {
+      const defaultCacheObject: AccelerationsCacheData = {
         version: CATALOG_CACHE_VERSION,
-        accelerations: [],
-        lastUpdated: '',
-        status: CachedDataSourceStatus.Empty,
+        dataSources: [],
       };
       localStorage.removeItem(ASYNC_QUERY_ACCELERATIONS_CACHE);
       expect(CatalogCacheManager.getAccelerationsCache()).toEqual(defaultCacheObject);
@@ -394,6 +389,86 @@ describe('CatalogCacheManager', () => {
     it('should clear accelerations cache from local storage', () => {
       CatalogCacheManager.clearAccelerationsCache();
       expect(localStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_ACCELERATIONS_CACHE);
+    });
+  });
+
+  describe('addOrUpdateAccelerationsByDataSource', () => {
+    it('should add a new data source to the accelerations cache', () => {
+      const dataSource: CachedAcclerationByDataSource = {
+        name: 'TestDataSource',
+        lastUpdated: '2024-03-08T12:00:00Z',
+        status: CachedDataSourceStatus.Updated,
+        accelerations: [],
+      };
+
+      CatalogCacheManager.addOrUpdateAccelerationsByDataSource(dataSource);
+
+      // Verify that saveAccelerationsCache is called with the updated cache data
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        ASYNC_QUERY_ACCELERATIONS_CACHE,
+        JSON.stringify({
+          version: '1.0',
+          dataSources: [{ ...dataSource }],
+        })
+      );
+    });
+
+    it('should update an existing data source in the accelerations cache', () => {
+      // Set up initial cache data
+      const initialDataSource: CachedAcclerationByDataSource = {
+        name: 'TestDataSource',
+        lastUpdated: '2024-03-08T12:00:00Z',
+        status: CachedDataSourceStatus.Updated,
+        accelerations: [],
+      };
+      // mockAccelerationsCacheData.dataSources = [initialDataSource];
+
+      // Update the data source
+      const updatedDataSource: CachedAcclerationByDataSource = {
+        ...initialDataSource,
+        status: CachedDataSourceStatus.Failed,
+      };
+
+      CatalogCacheManager.addOrUpdateAccelerationsByDataSource(updatedDataSource);
+
+      // Verify that saveAccelerationsCache is called with the updated cache data
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        ASYNC_QUERY_ACCELERATIONS_CACHE,
+        JSON.stringify({
+          version: '1.0',
+          dataSources: [{ ...updatedDataSource }],
+        })
+      );
+    });
+  });
+
+  describe('getOrCreateAccelerationsByDataSource', () => {
+    it('should return an existing data source from the accelerations cache', () => {
+      // Set up initial cache data
+      const existingDataSource: CachedAcclerationByDataSource = {
+        name: 'TestDataSource',
+        lastUpdated: '2024-03-08T12:00:00Z',
+        status: CachedDataSourceStatus.Updated,
+        accelerations: [],
+      };
+
+      CatalogCacheManager.addOrUpdateAccelerationsByDataSource(existingDataSource);
+      const result = CatalogCacheManager.getOrCreateAccelerationsByDataSource('TestDataSource');
+
+      // Verify that the existing data source is returned
+      expect(result).toEqual(existingDataSource);
+    });
+
+    it('should create and return a new data source if not found in the accelerations cache', () => {
+      const result = CatalogCacheManager.getOrCreateAccelerationsByDataSource('TestDataSource1');
+
+      // Verify that the new data source is created and returned
+      expect(result).toEqual({
+        name: 'TestDataSource1',
+        lastUpdated: expect.any(String),
+        status: CachedDataSourceStatus.Empty,
+        accelerations: [],
+      });
     });
   });
 });

--- a/public/framework/catalog_cache/cache_manager.ts
+++ b/public/framework/catalog_cache/cache_manager.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../common/constants/shared';
 import {
   AccelerationsCacheData,
+  CachedAcclerationByDataSource,
   CachedDataSource,
   CachedDataSourceStatus,
   CachedDatabase,
@@ -75,12 +76,53 @@ export class CatalogCacheManager {
     } else {
       const defaultCacheObject = {
         version: CATALOG_CACHE_VERSION,
-        accelerations: [],
-        lastUpdated: '',
-        status: CachedDataSourceStatus.Empty,
+        dataSources: [],
       };
       this.saveAccelerationsCache(defaultCacheObject);
       return defaultCacheObject;
+    }
+  }
+
+  /**
+   * Adds or updates a data source in the accelerations cache.
+   * @param {CachedAcclerationByDataSource} dataSource - The data source to add or update.
+   */
+  static addOrUpdateAccelerationsByDataSource(dataSource: CachedAcclerationByDataSource): void {
+    const accCacheData = this.getAccelerationsCache();
+    const index = accCacheData.dataSources.findIndex(
+      (ds: CachedAcclerationByDataSource) => ds.name === dataSource.name
+    );
+    if (index !== -1) {
+      accCacheData.dataSources[index] = dataSource;
+    } else {
+      accCacheData.dataSources.push(dataSource);
+    }
+    this.saveAccelerationsCache(accCacheData);
+  }
+
+  /**
+   * Retrieves accelerations cache from local storage by the datasource name.
+   * @param {string} dataSourceName - The name of the data source.
+   * @returns {CachedAcclerationByDataSource} The retrieved accelerations by datasource in cache.
+   * @throws {Error} If the data source is not found.
+   */
+  static getOrCreateAccelerationsByDataSource(
+    dataSourceName: string
+  ): CachedAcclerationByDataSource {
+    const accCacheData = this.getAccelerationsCache();
+    const cachedDataSource = accCacheData.dataSources.find((ds) => ds.name === dataSourceName);
+
+    if (cachedDataSource) {
+      return cachedDataSource;
+    } else {
+      const defaultDataSourceObject = {
+        name: dataSourceName,
+        lastUpdated: '',
+        status: CachedDataSourceStatus.Empty,
+        accelerations: [],
+      };
+      this.addOrUpdateAccelerationsByDataSource(defaultDataSourceObject);
+      return defaultDataSourceObject;
     }
   }
 

--- a/public/framework/catalog_cache/cache_manager.ts
+++ b/public/framework/catalog_cache/cache_manager.ts
@@ -112,9 +112,8 @@ export class CatalogCacheManager {
     const accCacheData = this.getAccelerationsCache();
     const cachedDataSource = accCacheData.dataSources.find((ds) => ds.name === dataSourceName);
 
-    if (cachedDataSource) {
-      return cachedDataSource;
-    } else {
+    if (cachedDataSource) return cachedDataSource;
+    else {
       const defaultDataSourceObject = {
         name: dataSourceName,
         lastUpdated: '',


### PR DESCRIPTION
### Description
Updating the accelerations cache structure from:
```
export interface CachedAccelerations {
  flintIndexName: string;
  type: AccelerationIndexType;
  database: string;
  table: string;
  indexName: string;
  autoRefresh: boolean;
  status: string;
}

export interface AccelerationsCacheData {
  version: string;
  accelerations: CachedAccelerations[];
  lastUpdated: string; // date string in UTC format
  status: CachedDataSourceStatus;
}
```
To:
```
export interface CachedAccelerations {
  flintIndexName: string;
  type: AccelerationIndexType;
  database: string;
  table: string;
  indexName: string;
  autoRefresh: boolean;
  status: string;
}

export interface CachedAcclerationByDataSource {
  name: string;
  accelerations: CachedAccelerations[];
  lastUpdated: string; // date string in UTC format
  status: CachedDataSourceStatus;
}

export interface AccelerationsCacheData {
  version: string;
  dataSources: CachedAcclerationByDataSource[];
}
```

### Issues Resolved
#1484 
* Add relevant helper functions in the cache manager
* Increase cache test coverage

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
