### PR TITLE
[Log explorer] Remove modal for discover redirection

### DIFF
--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -15,11 +15,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
-  EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
   EuiPopover,
   EuiPopoverFooter,
   EuiText,
@@ -139,9 +134,6 @@ export const Search = (props: any) => {
   const sqlService = new SQLService(coreRefs.http);
   const { application } = coreRefs;
   const [nlqInput, setNlqInput] = useState('');
-  const [isModalVisible, setIsModalVisible] = useState(false);
-  const closeModal = () => setIsModalVisible(false);
-  const showModal = () => setIsModalVisible(true);
 
   const showQueryArea = !appLogEvents && coreRefs.queryAssistEnabled;
 
@@ -205,7 +197,7 @@ export const Search = (props: any) => {
 
   const handleQueryLanguageChange = (lang: string) => {
     if (lang === QUERY_LANGUAGE.DQL) {
-      showModal();
+      redirectToDiscover();
       return;
     }
     dispatch(
@@ -315,36 +307,6 @@ export const Search = (props: any) => {
   const redirectToDiscover = () => {
     application!.navigateToUrl('../app/data-explorer/discover');
   };
-
-  let redirectionModal = null;
-  if (isModalVisible) {
-    redirectionModal = (
-      <EuiModal onClose={closeModal}>
-        <EuiModalHeader>
-          <EuiModalHeaderTitle>
-            <h1>Open in Discover</h1>
-          </EuiModalHeaderTitle>
-        </EuiModalHeader>
-        <EuiModalBody>
-          <EuiText>
-            The OpenSearch Dashboards Query Language (DQL) offers a simplified query syntax and
-            support for scripted fields. Selecting this option will open the Discover application.
-          </EuiText>
-        </EuiModalBody>
-        <EuiModalFooter>
-          <EuiButtonEmpty onClick={closeModal}>Cancel</EuiButtonEmpty>
-          <EuiButton
-            onClick={() => {
-              redirectToDiscover();
-            }}
-            fill
-          >
-            Open in Discover
-          </EuiButton>
-        </EuiModalFooter>
-      </EuiModal>
-    );
-  }
 
   return (
     <div className="globalQueryBar">
@@ -594,7 +556,6 @@ export const Search = (props: any) => {
           </>
         )}
       </EuiFlexGroup>
-      {redirectionModal}
       {flyout}
     </div>
   );


### PR DESCRIPTION
### Description
Removal of modal for indicating user the redirection to Discover upon DQL clicked in language selector.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
