### PR TITLE
Add auto-suggestions for skipping index definition and export types

### DIFF
--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -70,6 +70,7 @@ export const observabilityDataConnectionsTitle = 'Data sources';
 export const observabilityDataConnectionsPluginOrder = 9030;
 
 export const queryWorkbenchPluginID = 'opensearch-query-workbench';
+export const queryWorkbenchPluginCheck = 'plugin:queryWorkbenchDashboards';
 
 // Shared Constants
 export const SQL_DOCUMENTATION_URL = 'https://opensearch.org/docs/latest/search-plugins/sql/index/';

--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -4,6 +4,7 @@
  */
 
 import { EuiComboBoxOptionOption } from '@elastic/eui';
+import { DirectQueryLoadingStatus } from './explorer';
 
 export type AccelerationStatus = 'ACTIVE' | 'INACTIVE';
 
@@ -232,4 +233,10 @@ export interface CreateAccelerationForm {
   watermarkDelay: WatermarkDelayType;
   refreshIntervalOptions: RefreshIntervalType;
   formErrors: FormErrorsType;
+}
+
+export interface LoadCachehookOutput {
+  loadStatus: DirectQueryLoadingStatus;
+  startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void;
+  stopLoading: () => void;
 }

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -814,7 +814,7 @@ Array [
                                   <span
                                     class="euiTableCellContent__text"
                                   >
-                                    No items found
+                                    Please add fields
                                   </span>
                                 </div>
                               </td>
@@ -824,31 +824,57 @@ Array [
                       </div>
                     </div>
                     <div
-                      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                     >
                       <div
-                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                        class="euiFlexItem"
                       >
-                        <button
-                          class="euiButton euiButton--primary euiButton--fill"
-                          type="button"
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
                         >
-                          <span
-                            class="euiButtonContent euiButton__content"
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <span
-                              class="euiButton__text"
+                            <button
+                              class="euiButton euiButton--primary"
+                              type="button"
                             >
-                              Add fields
-                            </span>
-                          </span>
-                        </button>
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text"
+                                >
+                                  Add fields
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <button
+                              class="euiButton euiButton--danger"
+                              type="button"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text"
+                                >
+                                  Bulk delete
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                        </div>
                       </div>
                       <div
                         class="euiFlexItem euiFlexItem--flexGrowZero"
                       >
                         <button
-                          class="euiButton euiButton--danger"
+                          class="euiButton euiButton--primary"
                           type="button"
                         >
                           <span
@@ -857,7 +883,7 @@ Array [
                             <span
                               class="euiButton__text"
                             >
-                              Bulk delete
+                              Generate
                             </span>
                           </span>
                         </button>
@@ -1188,36 +1214,7 @@ Array [
                               </div>
                               <div
                                 class="euiFlexItem euiFlexItem--flexGrowZero"
-                              >
-                                <button
-                                  class="euiButton euiButton--primary"
-                                  type="button"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButtonContent--iconRight euiButton__content"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                      />
-                                    </svg>
-                                    <span
-                                      class="euiButton__text"
-                                    >
-                                      Open in Query Workbench
-                                    </span>
-                                  </span>
-                                </button>
-                              </div>
+                              />
                             </div>
                             <div
                               class="euiSpacer euiSpacer--l"
@@ -1556,6 +1553,7 @@ Array [
                                         <input
                                           aria-controls=""
                                           data-test-subj="comboBoxSearchInput"
+                                          disabled={false}
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           onFocus={[Function]}
@@ -1590,6 +1588,7 @@ Array [
                                         aria-label="Open list of options"
                                         className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
                                         data-test-subj="comboBoxToggleListButton"
+                                        disabled={false}
                                         onClick={[Function]}
                                         type="button"
                                       >
@@ -1713,6 +1712,7 @@ Array [
                                         <input
                                           aria-controls=""
                                           data-test-subj="comboBoxSearchInput"
+                                          disabled={false}
                                           onBlur={[Function]}
                                           onChange={[Function]}
                                           onFocus={[Function]}
@@ -1747,6 +1747,7 @@ Array [
                                         aria-label="Open list of options"
                                         className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
                                         data-test-subj="comboBoxToggleListButton"
+                                        disabled={false}
                                         onClick={[Function]}
                                         type="button"
                                       >
@@ -2270,7 +2271,7 @@ Array [
                                       <span
                                         className="euiTableCellContent__text"
                                       >
-                                        No items found
+                                        Please add fields
                                       </span>
                                     </div>
                                   </td>
@@ -2280,57 +2281,93 @@ Array [
                           </div>
                         </div>,
                         <div
-                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                         >
                           <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                            className="euiFlexItem"
                           >
-                            <button
-                              className="euiButton euiButton--primary euiButton--fill"
-                              disabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
-                                }
-                              }
-                              type="button"
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
                             >
-                              <span
-                                className="euiButtonContent euiButton__content"
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
                               >
-                                <span
-                                  className="euiButton__text"
+                                <button
+                                  className="euiButton euiButton--primary"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
+                                  type="button"
                                 >
-                                  Add fields
-                                </span>
-                              </span>
-                            </button>
+                                  <span
+                                    className="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Add fields
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <button
+                                  className="euiButton euiButton--danger"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
+                                  type="button"
+                                >
+                                  <span
+                                    className="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Bulk delete
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
                           </div>
                           <div
                             className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <button
-                              className="euiButton euiButton--danger"
-                              disabled={false}
-                              onClick={[Function]}
-                              style={
-                                Object {
-                                  "minWidth": undefined,
+                            Array [
+                              <button
+                                className="euiButton euiButton--primary"
+                                disabled={false}
+                                onClick={[Function]}
+                                style={
+                                  Object {
+                                    "minWidth": undefined,
+                                  }
                                 }
-                              }
-                              type="button"
-                            >
-                              <span
-                                className="euiButtonContent euiButton__content"
+                                type="button"
                               >
                                 <span
-                                  className="euiButton__text"
+                                  className="euiButtonContent euiButton__content"
                                 >
-                                  Bulk delete
+                                  <span
+                                    className="euiButton__text"
+                                  >
+                                    Generate
+                                  </span>
                                 </span>
-                              </span>
-                            </button>
+                              </button>,
+                              "",
+                            ]
                           </div>
                         </div>,
                       ],
@@ -2691,43 +2728,7 @@ Array [
                               </div>
                               <div
                                 className="euiFlexItem euiFlexItem--flexGrowZero"
-                              >
-                                <button
-                                  className="euiButton euiButton--primary"
-                                  disabled={false}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                  type="button"
-                                >
-                                  <span
-                                    className="euiButtonContent euiButtonContent--iconRight euiButton__content"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                      focusable="false"
-                                      height={16}
-                                      role="img"
-                                      style={null}
-                                      viewBox="0 0 16 16"
-                                      width={16}
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                      />
-                                    </svg>
-                                    <span
-                                      className="euiButton__text"
-                                    >
-                                      Open in Query Workbench
-                                    </span>
-                                  </span>
-                                </button>
-                              </div>
+                              />
                             </div>
                             <div
                               className="euiSpacer euiSpacer--l"

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/create_acceleration.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/create_acceleration.test.tsx
@@ -9,10 +9,23 @@ import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
 import React from 'react';
 import { coreMock } from '../../../../../../../../../../../src/core/public/mocks';
+import { queryWorkbenchPluginCheck } from '../../../../../../../../../common/constants/shared';
 import { mockDatasourcesQuery } from '../../../../../../../../../test/accelerations';
 import { CreateAcceleration } from '../create_acceleration';
 
 const coreStartMock = coreMock.createStart();
+
+// @ts-ignore
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        status: {
+          statuses: [{ id: queryWorkbenchPluginCheck }],
+        },
+      }),
+  })
+);
 
 describe('Create acceleration flyout components', () => {
   configure({ adapter: new Adapter() });

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/utils.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/utils.test.tsx
@@ -109,13 +109,13 @@ describe('validateReplicaCount', () => {
 
 describe('validateRefreshInterval', () => {
   it('should return an array with an error message when refreshType is "interval" and refreshWindow is less than 1', () => {
-    expect(validateRefreshInterval('interval', 0)).toEqual([
+    expect(validateRefreshInterval('autoInterval', 0)).toEqual([
       'refresh window should be greater than 0',
     ]);
-    expect(validateRefreshInterval('interval', -1)).toEqual([
+    expect(validateRefreshInterval('autoInterval', -1)).toEqual([
       'refresh window should be greater than 0',
     ]);
-    expect(validateRefreshInterval('interval', -10)).toEqual([
+    expect(validateRefreshInterval('autoInterval', -10)).toEqual([
       'refresh window should be greater than 0',
     ]);
   });
@@ -123,8 +123,10 @@ describe('validateRefreshInterval', () => {
   it('should return an empty array when refreshType is not "interval" or when refreshWindow is greater than or equal to 1', () => {
     expect(validateRefreshInterval('auto', 0)).toEqual([]);
     expect(validateRefreshInterval('auto', 1)).toEqual([]);
-    expect(validateRefreshInterval('interval', 1)).toEqual([]);
-    expect(validateRefreshInterval('auto', 5)).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 1)).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 5)).toEqual([]);
+    expect(validateRefreshInterval('manual', 0)).toEqual([]);
+    expect(validateRefreshInterval('manualIncrement', 0)).toEqual([]);
   });
 });
 

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -97,7 +97,11 @@ export const CreateAcceleration = ({
     },
   });
   const [tableFieldsLoading, setTableFieldsLoading] = useState(false);
-  const { loadStatus, startLoading } = useLoadTableColumnsToCache();
+  const {
+    loadStatus,
+    startLoading,
+    stopLoading: stopLoadingTableFields,
+  } = useLoadTableColumnsToCache();
 
   const loadColumnsToAccelerationForm = (cachedTable: CachedTable) => {
     const idPrefix = htmlIdGenerator()();
@@ -117,6 +121,7 @@ export const CreateAcceleration = ({
       ...accelerationFormData,
       dataTableFields: [],
     });
+    stopLoadingTableFields();
     if (dataTable !== '') {
       setTableFieldsLoading(true);
       const cachedTable = CatalogCacheManager.getTable(dataSource, database, dataTable);
@@ -179,6 +184,7 @@ export const CreateAcceleration = ({
               setAccelerationFormData={setAccelerationFormData}
               selectedDatasource={selectedDatasource}
               dataSourcesPreselected={dataSourcesPreselected}
+              tableFieldsLoading={tableFieldsLoading}
             />
             <EuiSpacer size="xxl" />
             <IndexTypeSelector

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/utils.tsx
@@ -49,7 +49,7 @@ export const validateRefreshInterval = (
   refreshType: AccelerationRefreshType,
   refreshWindow: number
 ) => {
-  return refreshType !== 'auto' && refreshType !== 'manual' && refreshWindow < 1
+  return refreshType === 'autoInterval' && refreshWindow < 1
     ? ['refresh window should be greater than 0']
     : [];
 };

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/preview_sql_defintion.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/preview_sql_defintion.test.tsx.snap
@@ -90,43 +90,7 @@ exports[`Preview SQL acceleration components renders Preview SQL settings with d
           </div>
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <button
-              className="euiButton euiButton--primary"
-              disabled={false}
-              style={
-                Object {
-                  "minWidth": undefined,
-                }
-              }
-              type="button"
-            >
-              <span
-                className="euiButtonContent euiButtonContent--iconRight euiButton__content"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                  focusable="false"
-                  height={16}
-                  role="img"
-                  style={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                  />
-                </svg>
-                <span
-                  className="euiButton__text"
-                >
-                  Open in Query Workbench
-                </span>
-              </span>
-            </button>
-          </div>
+          />
         </div>
         <div
           className="euiSpacer euiSpacer--l"
@@ -240,43 +204,7 @@ exports[`Preview SQL acceleration components renders Preview SQL settings with d
           </div>
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <button
-              className="euiButton euiButton--primary"
-              disabled={false}
-              style={
-                Object {
-                  "minWidth": undefined,
-                }
-              }
-              type="button"
-            >
-              <span
-                className="euiButtonContent euiButtonContent--iconRight euiButton__content"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                  focusable="false"
-                  height={16}
-                  role="img"
-                  style={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                  />
-                </svg>
-                <span
-                  className="euiButton__text"
-                >
-                  Open in Query Workbench
-                </span>
-              </span>
-            </button>
-          </div>
+          />
         </div>
         <div
           className="euiSpacer euiSpacer--l"
@@ -391,43 +319,7 @@ exports[`Preview SQL acceleration components renders Preview SQL settings with e
           </div>
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <button
-              className="euiButton euiButton--primary"
-              disabled={false}
-              style={
-                Object {
-                  "minWidth": undefined,
-                }
-              }
-              type="button"
-            >
-              <span
-                className="euiButtonContent euiButtonContent--iconRight euiButton__content"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                  focusable="false"
-                  height={16}
-                  role="img"
-                  style={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                  />
-                </svg>
-                <span
-                  className="euiButton__text"
-                >
-                  Open in Query Workbench
-                </span>
-              </span>
-            </button>
-          </div>
+          />
         </div>
         <div
           className="euiSpacer euiSpacer--l"
@@ -542,43 +434,7 @@ exports[`Preview SQL acceleration components renders Preview SQL settings with m
           </div>
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <button
-              className="euiButton euiButton--primary"
-              disabled={false}
-              style={
-                Object {
-                  "minWidth": undefined,
-                }
-              }
-              type="button"
-            >
-              <span
-                className="euiButtonContent euiButtonContent--iconRight euiButton__content"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                  focusable="false"
-                  height={16}
-                  role="img"
-                  style={null}
-                  viewBox="0 0 16 16"
-                  width={16}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                  />
-                </svg>
-                <span
-                  className="euiButton__text"
-                >
-                  Open in Query Workbench
-                </span>
-              </span>
-            </button>
-          </div>
+          />
         </div>
         <div
           className="euiSpacer euiSpacer--l"

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
@@ -104,6 +104,7 @@ Array [
                     <input
                       aria-controls=""
                       data-test-subj="comboBoxSearchInput"
+                      disabled={false}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -138,6 +139,7 @@ Array [
                     aria-label="Open list of options"
                     className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
                     data-test-subj="comboBoxToggleListButton"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >
@@ -261,6 +263,7 @@ Array [
                     <input
                       aria-controls=""
                       data-test-subj="comboBoxSearchInput"
+                      disabled={false}
                       onBlur={[Function]}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -295,6 +298,7 @@ Array [
                     aria-label="Open list of options"
                     className="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
                     data-test-subj="comboBoxToggleListButton"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/preview_sql_defintion.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/preview_sql_defintion.test.tsx
@@ -8,6 +8,7 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
 import React from 'react';
+import { queryWorkbenchPluginCheck } from '../../../../../../../../../common/constants/shared';
 import { CreateAccelerationForm } from '../../../../../../../../../common/types/data_connections';
 import {
   coveringIndexBuilderMock1,
@@ -15,6 +16,18 @@ import {
   materializedViewBuilderMock2,
 } from '../../../../../../../../../test/accelerations';
 import { PreviewSQLDefinition } from '../preview_sql_defintion';
+
+// @ts-ignore
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        status: {
+          statuses: [{ id: queryWorkbenchPluginCheck }],
+        },
+      }),
+  })
+);
 
 describe('Preview SQL acceleration components', () => {
   configure({ adapter: new Adapter() });

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/source_selector.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/source_selector.test.tsx
@@ -35,6 +35,7 @@ describe('Source selector components', () => {
         accelerationFormData={accelerationFormData}
         setAccelerationFormData={setAccelerationFormData}
         dataSourcesPreselected={false}
+        tableFieldsLoading={false}
       />
     );
     wrapper.update();
@@ -67,6 +68,7 @@ describe('Source selector components', () => {
         accelerationFormData={accelerationFormData}
         setAccelerationFormData={setAccelerationFormData}
         dataSourcesPreselected={true}
+        tableFieldsLoading={false}
       />
     );
     wrapper.update();

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
@@ -76,7 +76,6 @@ export const PreviewSQLDefinition = ({
       })
       .then((data) => {
         for (let i = 0; i < data.status.statuses.length; ++i) {
-          console.log('id:', data.status.statuses[i].id);
           if (data.status.statuses[i].id.includes(queryWorkbenchPluginCheck)) {
             setSQLWorkbenchPluginExists(true);
           }
@@ -113,7 +112,6 @@ export const PreviewSQLDefinition = ({
   }, [accelerationFormData]);
 
   useEffect(() => {
-    console.log('ran useffect');
     checkIfSQLWorkbenchPluginIsInstalled();
   }, []);
 

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
@@ -13,7 +13,13 @@ import {
   EuiText,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
+import {
+  queryWorkbenchPluginCheck,
+  queryWorkbenchPluginID,
+} from '../../../../../../../../common/constants/shared';
 import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
+import { coreRefs } from '../../../../../../../framework/core_refs';
+import { useToast } from '../../../../../../common/toast';
 import { formValidator, hasError } from '../create/utils';
 import { accelerationQueryBuilder } from '../visual_editors/query_builder';
 
@@ -26,14 +32,22 @@ export const PreviewSQLDefinition = ({
   accelerationFormData,
   setAccelerationFormData,
 }: PreviewSQLDefinitionProps) => {
+  const { setToast } = useToast();
   const [isPreviewStale, setIsPreviewStale] = useState(false);
   const [isPreviewTriggered, setIsPreviewTriggered] = useState(false);
   const [sqlCode, setSQLcode] = useState('');
+  const [sqlWorkbenchPLuginExists, setSQLWorkbenchPluginExists] = useState(false);
 
-  const onClickPreview = () => {
+  const checkForErrors = () => {
     const errors = formValidator(accelerationFormData);
     if (hasError(errors)) {
       setAccelerationFormData({ ...accelerationFormData, formErrors: errors });
+      return true;
+    } else return false;
+  };
+
+  const onClickPreview = () => {
+    if (checkForErrors()) {
       return;
     }
     setSQLcode(accelerationQueryBuilder(accelerationFormData));
@@ -41,9 +55,67 @@ export const PreviewSQLDefinition = ({
     setIsPreviewTriggered(true);
   };
 
+  const checkIfSQLWorkbenchPluginIsInstalled = () => {
+    fetch('../api/status', {
+      headers: {
+        'Content-Type': 'application/json',
+        'osd-xsrf': 'true',
+        'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
+        pragma: 'no-cache',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+      },
+      method: 'GET',
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      mode: 'cors',
+      credentials: 'include',
+    })
+      .then(function (response) {
+        return response.json();
+      })
+      .then((data) => {
+        for (let i = 0; i < data.status.statuses.length; ++i) {
+          console.log('id:', data.status.statuses[i].id);
+          if (data.status.statuses[i].id.includes(queryWorkbenchPluginCheck)) {
+            setSQLWorkbenchPluginExists(true);
+          }
+        }
+      })
+      .catch((error) => {
+        setToast('Error checking Query Workbench Plugin Installation status.', 'danger');
+        console.error(error);
+      });
+  };
+
+  const openInWorkbench = () => {
+    if (!checkForErrors()) {
+      coreRefs?.application!.navigateToApp(queryWorkbenchPluginID, {
+        path: `#/${accelerationFormData.dataSource}`,
+        state: {
+          language: 'sql',
+          queryToRun: '',
+        },
+      });
+    }
+  };
+
+  const queryWorkbenchButton = sqlWorkbenchPLuginExists ? (
+    <EuiButton iconType="popout" iconSide="right" onClick={openInWorkbench}>
+      Open in Query Workbench
+    </EuiButton>
+  ) : (
+    <></>
+  );
+
   useEffect(() => {
     setIsPreviewStale(true);
   }, [accelerationFormData]);
+
+  useEffect(() => {
+    console.log('ran useffect');
+    checkIfSQLWorkbenchPluginIsInstalled();
+  }, []);
 
   return (
     <>
@@ -73,11 +145,7 @@ export const PreviewSQLDefinition = ({
               </EuiButton>
             )}
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButton iconType="popout" iconSide="right">
-              Open in Query Workbench
-            </EuiButton>
-          </EuiFlexItem>
+          <EuiFlexItem grow={false}>{queryWorkbenchButton}</EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="l" />
         <EuiCodeBlock language="sql" fontSize="m" paddingSize="m" isCopyable>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
@@ -93,7 +93,7 @@ export const PreviewSQLDefinition = ({
         path: `#/${accelerationFormData.dataSource}`,
         state: {
           language: 'sql',
-          queryToRun: '',
+          queryToRun: accelerationQueryBuilder(accelerationFormData),
         },
       });
     }

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_databases.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_databases.tsx
@@ -11,11 +11,27 @@ import { useLoadDatabasesToCache } from '../../../../../../../../framework/catal
 interface SelectorLoadDatabasesProps {
   dataSourceName: string;
   loadDatabases: () => void;
+  loadingComboBoxes: {
+    dataSource: boolean;
+    database: boolean;
+    dataTable: boolean;
+  };
+  setLoadingComboBoxes: React.Dispatch<
+    React.SetStateAction<{
+      dataSource: boolean;
+      database: boolean;
+      dataTable: boolean;
+    }>
+  >;
+  tableFieldsLoading: boolean;
 }
 
 export const SelectorLoadDatabases = ({
   dataSourceName,
   loadDatabases,
+  loadingComboBoxes,
+  setLoadingComboBoxes,
+  tableFieldsLoading,
 }: SelectorLoadDatabasesProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const {
@@ -42,6 +58,10 @@ export const SelectorLoadDatabases = ({
     }
   }, [loadDatabasesStatus]);
 
+  useEffect(() => {
+    setLoadingComboBoxes({ ...loadingComboBoxes, database: isLoading });
+  }, [isLoading]);
+
   return (
     <>
       {isLoading ? (
@@ -52,6 +72,9 @@ export const SelectorLoadDatabases = ({
           size="m"
           display="base"
           onClick={onClickRefreshDatabases}
+          isDisabled={
+            loadingComboBoxes.database || loadingComboBoxes.dataTable || tableFieldsLoading
+          }
         />
       )}
     </>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
@@ -16,12 +16,28 @@ interface SelectorLoadDatabasesProps {
   dataSourceName: string;
   databaseName: string;
   loadTables: () => void;
+  loadingComboBoxes: {
+    dataSource: boolean;
+    database: boolean;
+    dataTable: boolean;
+  };
+  setLoadingComboBoxes: React.Dispatch<
+    React.SetStateAction<{
+      dataSource: boolean;
+      database: boolean;
+      dataTable: boolean;
+    }>
+  >;
+  tableFieldsLoading: boolean;
 }
 
 export const SelectorLoadObjects = ({
   dataSourceName,
   databaseName,
   loadTables,
+  loadingComboBoxes,
+  setLoadingComboBoxes,
+  tableFieldsLoading,
 }: SelectorLoadDatabasesProps) => {
   const { setToast } = useToast();
   const [isLoading, setIsLoading] = useState({
@@ -77,6 +93,10 @@ export const SelectorLoadObjects = ({
     }
   }, [loadAccelerationsStatus]);
 
+  useEffect(() => {
+    setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: isEitherLoading });
+  }, [isEitherLoading]);
+
   return (
     <>
       {isEitherLoading ? (
@@ -87,6 +107,9 @@ export const SelectorLoadObjects = ({
           size="m"
           display="base"
           onClick={onClickRefreshDatabases}
+          isDisabled={
+            loadingComboBoxes.database || loadingComboBoxes.dataTable || tableFieldsLoading
+          }
         />
       )}
     </>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
@@ -35,6 +35,7 @@ interface AccelerationDataSourceSelectorProps {
   setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
   selectedDatasource: string;
   dataSourcesPreselected: boolean;
+  tableFieldsLoading: boolean;
 }
 
 export const AccelerationDataSourceSelector = ({
@@ -43,6 +44,7 @@ export const AccelerationDataSourceSelector = ({
   setAccelerationFormData,
   selectedDatasource,
   dataSourcesPreselected,
+  tableFieldsLoading,
 }: AccelerationDataSourceSelectorProps) => {
   const { setToast } = useToast();
   const [databases, setDatabases] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
@@ -89,7 +91,6 @@ export const AccelerationDataSourceSelector = ({
   };
 
   const loadDatabases = () => {
-    setLoadingComboBoxes({ ...loadingComboBoxes, database: true });
     const dsCache = CatalogCacheManager.getOrCreateDataSource(accelerationFormData.dataSource);
 
     if (dsCache.status === CachedDataSourceStatus.Updated && dsCache.databases.length > 0) {
@@ -106,11 +107,9 @@ export const AccelerationDataSourceSelector = ({
     setTables([]);
     setSelectedTable([]);
     setAccelerationFormData({ ...accelerationFormData, database: '', dataTable: '' });
-    setLoadingComboBoxes({ ...loadingComboBoxes, database: false });
   };
 
   const loadTables = () => {
-    setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: true });
     if (selectedDatabase.length > 0) {
       const dbCache = CatalogCacheManager.getDatabase(
         accelerationFormData.dataSource,
@@ -127,7 +126,6 @@ export const AccelerationDataSourceSelector = ({
       }
       setSelectedTable([]);
       setAccelerationFormData({ ...accelerationFormData, dataTable: '' });
-      setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: false });
     }
   };
 
@@ -212,20 +210,29 @@ export const AccelerationDataSourceSelector = ({
                   }}
                   isClearable={false}
                   isInvalid={hasError(accelerationFormData.formErrors, 'databaseError')}
-                  isLoading={loadingComboBoxes.database}
+                  isDisabled={
+                    loadingComboBoxes.database || loadingComboBoxes.dataTable || tableFieldsLoading
+                  }
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <SelectorLoadDatabases
                   dataSourceName={accelerationFormData.dataSource}
                   loadDatabases={loadDatabases}
+                  loadingComboBoxes={loadingComboBoxes}
+                  setLoadingComboBoxes={setLoadingComboBoxes}
+                  tableFieldsLoading={tableFieldsLoading}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFormRow>
           <EuiFormRow
             label="Table"
-            helpText="Select the Spark table that has the data you would like to index."
+            helpText={
+              tableFieldsLoading
+                ? 'Loading tables fields'
+                : 'Select the Spark table that has the data you would like to index.'
+            }
             isInvalid={hasError(accelerationFormData.formErrors, 'dataTableError')}
             error={accelerationFormData.formErrors.dataTableError}
           >
@@ -251,7 +258,9 @@ export const AccelerationDataSourceSelector = ({
                   }}
                   isClearable={false}
                   isInvalid={hasError(accelerationFormData.formErrors, 'dataTableError')}
-                  isLoading={loadingComboBoxes.dataTable}
+                  isDisabled={
+                    loadingComboBoxes.database || loadingComboBoxes.dataTable || tableFieldsLoading
+                  }
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
@@ -259,6 +268,9 @@ export const AccelerationDataSourceSelector = ({
                   dataSourceName={accelerationFormData.dataSource}
                   databaseName={accelerationFormData.database}
                   loadTables={loadTables}
+                  loadingComboBoxes={loadingComboBoxes}
+                  setLoadingComboBoxes={setLoadingComboBoxes}
+                  tableFieldsLoading={tableFieldsLoading}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
@@ -241,7 +241,7 @@ Array [
                   <span
                     className="euiTableCellContent__text"
                   >
-                    No items found
+                    Please add fields
                   </span>
                 </div>
               </td>
@@ -251,57 +251,93 @@ Array [
       </div>
     </div>,
     <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
-        className="euiFlexItem euiFlexItem--flexGrowZero"
+        className="euiFlexItem"
       >
-        <button
-          className="euiButton euiButton--primary euiButton--fill"
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "minWidth": undefined,
-            }
-          }
-          type="button"
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
         >
-          <span
-            className="euiButtonContent euiButton__content"
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <span
-              className="euiButton__text"
+            <button
+              className="euiButton euiButton--primary"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "minWidth": undefined,
+                }
+              }
+              type="button"
             >
-              Add fields
-            </span>
-          </span>
-        </button>
+              <span
+                className="euiButtonContent euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Add fields
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <button
+              className="euiButton euiButton--danger"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "minWidth": undefined,
+                }
+              }
+              type="button"
+            >
+              <span
+                className="euiButtonContent euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Bulk delete
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
       </div>
       <div
         className="euiFlexItem euiFlexItem--flexGrowZero"
       >
-        <button
-          className="euiButton euiButton--danger"
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "minWidth": undefined,
+        Array [
+          <button
+            className="euiButton euiButton--primary"
+            disabled={false}
+            onClick={[Function]}
+            style={
+              Object {
+                "minWidth": undefined,
+              }
             }
-          }
-          type="button"
-        >
-          <span
-            className="euiButtonContent euiButton__content"
+            type="button"
           >
             <span
-              className="euiButton__text"
+              className="euiButtonContent euiButton__content"
             >
-              Bulk delete
+              <span
+                className="euiButton__text"
+              >
+                Generate
+              </span>
             </span>
-          </span>
-        </button>
+          </button>,
+          "",
+        ]
       </div>
     </div>,
   ],
@@ -601,6 +637,7 @@ Array [
             >
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -624,6 +661,7 @@ Array [
               </td>
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -647,6 +685,7 @@ Array [
               </td>
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -729,6 +768,7 @@ Array [
               </td>
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -773,6 +813,7 @@ Array [
             >
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -796,6 +837,7 @@ Array [
               </td>
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -819,6 +861,7 @@ Array [
               </td>
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -901,6 +944,7 @@ Array [
               </td>
               <td
                 className="euiTableRowCell"
+                readOnly={false}
                 style={
                   Object {
                     "width": undefined,
@@ -1084,57 +1128,93 @@ Array [
       </div>
     </div>,
     <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
-        className="euiFlexItem euiFlexItem--flexGrowZero"
+        className="euiFlexItem"
       >
-        <button
-          className="euiButton euiButton--primary euiButton--fill"
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "minWidth": undefined,
-            }
-          }
-          type="button"
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
         >
-          <span
-            className="euiButtonContent euiButton__content"
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <span
-              className="euiButton__text"
+            <button
+              className="euiButton euiButton--primary"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "minWidth": undefined,
+                }
+              }
+              type="button"
             >
-              Add fields
-            </span>
-          </span>
-        </button>
+              <span
+                className="euiButtonContent euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Add fields
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <button
+              className="euiButton euiButton--danger"
+              disabled={false}
+              onClick={[Function]}
+              style={
+                Object {
+                  "minWidth": undefined,
+                }
+              }
+              type="button"
+            >
+              <span
+                className="euiButtonContent euiButton__content"
+              >
+                <span
+                  className="euiButton__text"
+                >
+                  Bulk delete
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
       </div>
       <div
         className="euiFlexItem euiFlexItem--flexGrowZero"
       >
-        <button
-          className="euiButton euiButton--danger"
-          disabled={false}
-          onClick={[Function]}
-          style={
-            Object {
-              "minWidth": undefined,
+        Array [
+          <button
+            className="euiButton euiButton--primary"
+            disabled={false}
+            onClick={[Function]}
+            style={
+              Object {
+                "minWidth": undefined,
+              }
             }
-          }
-          type="button"
-        >
-          <span
-            className="euiButtonContent euiButton__content"
+            type="button"
           >
             <span
-              className="euiButton__text"
+              className="euiButtonContent euiButton__content"
             >
-              Bulk delete
+              <span
+                className="euiButton__text"
+              >
+                Generate
+              </span>
             </span>
-          </span>
-        </button>
+          </button>,
+          "",
+        ]
       </div>
     </div>,
   ],

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/generate_fields.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/generate_fields.test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Generate fields in skipping index Generate fields in skipping index with default options 1`] = `
+Array [
+  <button
+    className="euiButton euiButton--primary"
+    disabled={false}
+    onClick={[Function]}
+    style={
+      Object {
+        "minWidth": undefined,
+      }
+    }
+    type="button"
+  >
+    <span
+      className="euiButtonContent euiButton__content"
+    >
+      <span
+        className="euiButton__text"
+      >
+        Generate
+      </span>
+    </span>
+  </button>,
+  "",
+]
+`;

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
@@ -151,7 +151,7 @@ Array [
                 <span
                   className="euiTableCellContent__text"
                 >
-                  No items found
+                  Please add fields
                 </span>
               </div>
             </td>
@@ -161,57 +161,93 @@ Array [
     </div>
   </div>,
   <div
-    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
   >
     <div
-      className="euiFlexItem euiFlexItem--flexGrowZero"
+      className="euiFlexItem"
     >
-      <button
-        className="euiButton euiButton--primary euiButton--fill"
-        disabled={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "minWidth": undefined,
-          }
-        }
-        type="button"
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
       >
-        <span
-          className="euiButtonContent euiButton__content"
+        <div
+          className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <span
-            className="euiButton__text"
+          <button
+            className="euiButton euiButton--primary"
+            disabled={false}
+            onClick={[Function]}
+            style={
+              Object {
+                "minWidth": undefined,
+              }
+            }
+            type="button"
           >
-            Add fields
-          </span>
-        </span>
-      </button>
+            <span
+              className="euiButtonContent euiButton__content"
+            >
+              <span
+                className="euiButton__text"
+              >
+                Add fields
+              </span>
+            </span>
+          </button>
+        </div>
+        <div
+          className="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <button
+            className="euiButton euiButton--danger"
+            disabled={false}
+            onClick={[Function]}
+            style={
+              Object {
+                "minWidth": undefined,
+              }
+            }
+            type="button"
+          >
+            <span
+              className="euiButtonContent euiButton__content"
+            >
+              <span
+                className="euiButton__text"
+              >
+                Bulk delete
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
     </div>
     <div
       className="euiFlexItem euiFlexItem--flexGrowZero"
     >
-      <button
-        className="euiButton euiButton--danger"
-        disabled={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "minWidth": undefined,
+      Array [
+        <button
+          className="euiButton euiButton--primary"
+          disabled={false}
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
           }
-        }
-        type="button"
-      >
-        <span
-          className="euiButtonContent euiButton__content"
+          type="button"
         >
           <span
-            className="euiButton__text"
+            className="euiButtonContent euiButton__content"
           >
-            Bulk delete
+            <span
+              className="euiButton__text"
+            >
+              Generate
+            </span>
           </span>
-        </span>
-      </button>
+        </button>,
+        "",
+      ]
     </div>
   </div>,
 ]
@@ -355,6 +391,7 @@ Array [
           >
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -378,6 +415,7 @@ Array [
             </td>
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -401,6 +439,7 @@ Array [
             </td>
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -483,6 +522,7 @@ Array [
             </td>
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -527,6 +567,7 @@ Array [
           >
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -550,6 +591,7 @@ Array [
             </td>
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -573,6 +615,7 @@ Array [
             </td>
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -655,6 +698,7 @@ Array [
             </td>
             <td
               className="euiTableRowCell"
+              readOnly={false}
               style={
                 Object {
                   "width": undefined,
@@ -838,57 +882,93 @@ Array [
     </div>
   </div>,
   <div
-    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
+    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
   >
     <div
-      className="euiFlexItem euiFlexItem--flexGrowZero"
+      className="euiFlexItem"
     >
-      <button
-        className="euiButton euiButton--primary euiButton--fill"
-        disabled={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "minWidth": undefined,
-          }
-        }
-        type="button"
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--wrap"
       >
-        <span
-          className="euiButtonContent euiButton__content"
+        <div
+          className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <span
-            className="euiButton__text"
+          <button
+            className="euiButton euiButton--primary"
+            disabled={false}
+            onClick={[Function]}
+            style={
+              Object {
+                "minWidth": undefined,
+              }
+            }
+            type="button"
           >
-            Add fields
-          </span>
-        </span>
-      </button>
+            <span
+              className="euiButtonContent euiButton__content"
+            >
+              <span
+                className="euiButton__text"
+              >
+                Add fields
+              </span>
+            </span>
+          </button>
+        </div>
+        <div
+          className="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <button
+            className="euiButton euiButton--danger"
+            disabled={false}
+            onClick={[Function]}
+            style={
+              Object {
+                "minWidth": undefined,
+              }
+            }
+            type="button"
+          >
+            <span
+              className="euiButtonContent euiButton__content"
+            >
+              <span
+                className="euiButton__text"
+              >
+                Bulk delete
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
     </div>
     <div
       className="euiFlexItem euiFlexItem--flexGrowZero"
     >
-      <button
-        className="euiButton euiButton--danger"
-        disabled={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "minWidth": undefined,
+      Array [
+        <button
+          className="euiButton euiButton--primary"
+          disabled={false}
+          onClick={[Function]}
+          style={
+            Object {
+              "minWidth": undefined,
+            }
           }
-        }
-        type="button"
-      >
-        <span
-          className="euiButtonContent euiButton__content"
+          type="button"
         >
           <span
-            className="euiButton__text"
+            className="euiButtonContent euiButton__content"
           >
-            Bulk delete
+            <span
+              className="euiButton__text"
+            >
+              Generate
+            </span>
           </span>
-        </span>
-      </button>
+        </button>,
+        "",
+      ]
     </div>
   </div>,
 ]

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/generate_fields.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/generate_fields.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { waitFor } from '@testing-library/dom';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+import { createAccelerationEmptyDataMock } from '../../../../../../../../../../test/accelerations';
+import { GenerateFields } from '../generate_fields';
+
+describe('Generate fields in skipping index', () => {
+  configure({ adapter: new Adapter() });
+
+  it('Generate fields in skipping index with default options', async () => {
+    const accelerationFormData = createAccelerationEmptyDataMock;
+    const setAccelerationFormData = jest.fn();
+    const wrapper = mount(
+      <GenerateFields
+        accelerationFormData={accelerationFormData}
+        setAccelerationFormData={setAccelerationFormData}
+        isSkippingtableLoading={false}
+        setIsSkippingtableLoading={jest.fn()}
+      />
+    );
+    wrapper.update();
+    await waitFor(() => {
+      expect(
+        toJson(wrapper, {
+          noKey: false,
+          mode: 'deep',
+        })
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/generate_fields.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/generate_fields.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButton, EuiConfirmModal } from '@elastic/eui';
+import producer from 'immer';
+import React, { useEffect, useState } from 'react';
+import {
+  CreateAccelerationForm,
+  SkippingIndexRowType,
+} from '../../../../../../../../../common/types/data_connections';
+import {
+  DirectQueryLoadingStatus,
+  DirectQueryRequest,
+} from '../../../../../../../../../common/types/explorer';
+import {
+  addBackticksIfNeeded,
+  combineSchemaAndDatarows,
+} from '../../../../../../../../../common/utils/shared';
+import { useDirectQuery } from '../../../../../../../../framework/datasources/direct_query_hook';
+import { validateSkippingIndexData } from '../../create/utils';
+
+interface GenerateFieldsProps {
+  accelerationFormData: CreateAccelerationForm;
+  setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+  isSkippingtableLoading: boolean;
+  setIsSkippingtableLoading: React.Dispatch<boolean>;
+}
+
+export const GenerateFields = ({
+  accelerationFormData,
+  setAccelerationFormData,
+  isSkippingtableLoading,
+  setIsSkippingtableLoading,
+}: GenerateFieldsProps) => {
+  const [isGenerateRun, setIsGenerateRun] = useState(false);
+  const { loadStatus, startLoading, stopLoading: _stopLoading, pollingResult } = useDirectQuery();
+  const [replaceDefinitionModal, setReplaceDefinitionModal] = useState(<></>);
+
+  const mapToDataTableFields = (fieldName: string) => {
+    return accelerationFormData.dataTableFields.find((field) => field.fieldName === fieldName);
+  };
+
+  const loadSkippingIndexDefinition = () => {
+    const combinedData = combineSchemaAndDatarows(pollingResult.schema, pollingResult.datarows);
+    const skippingIndexRows = combinedData.map((field: any) => {
+      return {
+        ...mapToDataTableFields(field.column_name),
+        accelerationMethod: field.skipping_type.split(' ')[0],
+      } as SkippingIndexRowType;
+    });
+    setAccelerationFormData(
+      producer((accData) => {
+        accData.skippingIndexQueryData = skippingIndexRows;
+        accData.formErrors.skippingIndexError = validateSkippingIndexData(
+          accData.accelerationIndexType,
+          skippingIndexRows
+        );
+      })
+    );
+  };
+
+  useEffect(() => {
+    const status = loadStatus.toLowerCase();
+    if (status === DirectQueryLoadingStatus.SUCCESS) {
+      loadSkippingIndexDefinition();
+      setIsSkippingtableLoading(false);
+    } else if (
+      status === DirectQueryLoadingStatus.FAILED ||
+      status === DirectQueryLoadingStatus.CANCELED
+    ) {
+      setIsSkippingtableLoading(false);
+    }
+  }, [loadStatus]);
+
+  const runGeneration = () => {
+    const requestPayload: DirectQueryRequest = {
+      lang: 'sql',
+      query: `ANALYZE SKIPPING INDEX ON ${addBackticksIfNeeded(
+        accelerationFormData.dataSource
+      )}.${addBackticksIfNeeded(accelerationFormData.database)}.${addBackticksIfNeeded(
+        accelerationFormData.dataTable
+      )}`,
+      datasource: accelerationFormData.dataSource,
+    };
+    startLoading(requestPayload);
+    setIsSkippingtableLoading(true);
+    setIsGenerateRun(true);
+    setReplaceDefinitionModal(<></>);
+  };
+
+  const replaceModalComponent = (
+    <EuiConfirmModal
+      title="Replace definitions?"
+      onCancel={() => setReplaceDefinitionModal(<></>)}
+      onConfirm={runGeneration}
+      cancelButtonText="Cancel"
+      confirmButtonText="Replace"
+      defaultFocusedButton="confirm"
+    >
+      <p>
+        Existing definitions will be removed and replaced with auto-generated definitions. Do you
+        want to continue?
+      </p>
+    </EuiConfirmModal>
+  );
+
+  const onClickGenerate = () => {
+    if (accelerationFormData.skippingIndexQueryData.length > 0) {
+      setReplaceDefinitionModal(replaceModalComponent);
+    } else {
+      runGeneration();
+    }
+  };
+
+  return (
+    <>
+      <EuiButton onClick={onClickGenerate} isDisabled={isSkippingtableLoading}>
+        {isGenerateRun ? 'Regenerate' : 'Generate'}
+      </EuiButton>
+      {replaceDefinitionModal}
+    </>
+  );
+};

--- a/public/framework/core_refs.ts
+++ b/public/framework/core_refs.ts
@@ -10,6 +10,7 @@ import {
   CoreStart,
   HttpStart,
   IToasts,
+  OverlayStart,
   SavedObjectsClientContract,
 } from '../../../../src/core/public';
 import { DashboardStart } from '../../../../src/plugins/dashboard/public';
@@ -30,6 +31,7 @@ class CoreRefs {
   public summarizeEnabled?: boolean;
   public dashboard?: DashboardStart;
   public dashboardProviders?: unknown;
+  public overlays?: OverlayStart;
   private constructor() {
     // ...
   }

--- a/public/framework/datasources/direct_query_hook.tsx
+++ b/public/framework/datasources/direct_query_hook.tsx
@@ -88,5 +88,5 @@ export const useDirectQuery = () => {
     }
   }, [pollingResult, pollingError]);
 
-  return { loadStatus, startLoading, stopLoading };
+  return { loadStatus, startLoading, stopLoading, pollingResult };
 };

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -73,6 +73,13 @@ import {
 } from './embeddable/observability_embeddable';
 import { ObservabilityEmbeddableFactoryDefinition } from './embeddable/observability_embeddable_factory';
 import { catalogCacheInterceptError } from './framework/catalog_cache/cache_intercept';
+import {
+  useLoadAccelerationsToCache,
+  useLoadDatabasesToCache,
+  useLoadTableColumnsToCache,
+  useLoadTablesToCache,
+} from './framework/catalog_cache/cache_loader';
+import { CatalogCacheManager } from './framework/catalog_cache/cache_manager';
 import { coreRefs } from './framework/core_refs';
 import { DataSourcePluggable } from './framework/datasource_pluggables/datasource_pluggable';
 import { S3DataSource } from './framework/datasources/s3_datasource';
@@ -371,6 +378,7 @@ export class ObservabilityPlugin
     coreRefs.dashboard = startDeps.dashboard;
     coreRefs.queryAssistEnabled = this.config.query_assist.enabled;
     coreRefs.summarizeEnabled = this.config.summarize.enabled;
+    coreRefs.overlays = core.overlays;
 
     const { dataSourceService, dataSourceFactory } = startDeps.data.dataSources;
 
@@ -445,11 +453,21 @@ export class ObservabilityPlugin
     };
     setRenderCreateAccelerationFlyout(renderCreateAccelerationFlyout);
 
+    const CatalogCacheManagerInstance = CatalogCacheManager;
+    const useLoadDatabasesToCacheHook = useLoadDatabasesToCache;
+    const useLoadTablesToCacheHook = useLoadTablesToCache;
+    const useLoadTableColumnsToCacheHook = useLoadTableColumnsToCache;
+    const useLoadAccelerationsToCacheHook = useLoadAccelerationsToCache;
     // Export so other plugins can use this flyout
     return {
       renderAccelerationDetailsFlyout,
       renderAssociatedObjectsDetailsFlyout,
       renderCreateAccelerationFlyout,
+      CatalogCacheManagerInstance,
+      useLoadDatabasesToCacheHook,
+      useLoadTablesToCacheHook,
+      useLoadTableColumnsToCacheHook,
+      useLoadAccelerationsToCacheHook,
     };
   }
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -11,12 +11,11 @@ import { ManagementOverViewPluginSetup } from '../../../src/plugins/management_o
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
 import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
 import { VisualizationsSetup } from '../../../src/plugins/visualizations/public';
-<<<<<<< HEAD
-import { AssociatedObject, CachedAcceleration } from '../common/types/data_connections';
-import { DirectQueryLoadingStatus } from '../common/types/explorer';
-=======
-import { AssociatedObject, LoadCachehookOutput } from '../common/types/data_connections';
->>>>>>> f1aef4fa (expose types for cachemanager)
+import {
+  AssociatedObject,
+  CachedAcceleration,
+  LoadCachehookOutput,
+} from '../common/types/data_connections';
 import { CatalogCacheManager } from './framework/catalog_cache/cache_manager';
 import { AssistantSetup } from './types';
 

--- a/public/types.ts
+++ b/public/types.ts
@@ -11,8 +11,12 @@ import { ManagementOverViewPluginSetup } from '../../../src/plugins/management_o
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
 import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
 import { VisualizationsSetup } from '../../../src/plugins/visualizations/public';
+<<<<<<< HEAD
 import { AssociatedObject, CachedAcceleration } from '../common/types/data_connections';
 import { DirectQueryLoadingStatus } from '../common/types/explorer';
+=======
+import { AssociatedObject, LoadCachehookOutput } from '../common/types/data_connections';
+>>>>>>> f1aef4fa (expose types for cachemanager)
 import { CatalogCacheManager } from './framework/catalog_cache/cache_manager';
 import { AssistantSetup } from './types';
 
@@ -31,12 +35,6 @@ export interface SetupDependencies {
   uiActions: UiActionsStart;
   managementOverview?: ManagementOverViewPluginSetup;
   assistantDashboards?: AssistantSetup;
-}
-
-interface LoadCachehookOutput {
-  loadStatus: DirectQueryLoadingStatus;
-  startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void;
-  stopLoading: () => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -64,6 +62,9 @@ export interface ObservabilityStart {
   useLoadTableColumnsToCacheHook: () => LoadCachehookOutput;
   useLoadAccelerationsToCacheHook: () => LoadCachehookOutput;
 }
+
+export type CatalogCacheManagerType = typeof CatalogCacheManager;
+export type LoadCachehookOutputType = LoadCachehookOutput;
 
 /**
  * Introduce a compile dependency on dashboards-assistant

--- a/public/types.ts
+++ b/public/types.ts
@@ -12,6 +12,8 @@ import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/pub
 import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
 import { VisualizationsSetup } from '../../../src/plugins/visualizations/public';
 import { AssociatedObject, CachedAcceleration } from '../common/types/data_connections';
+import { DirectQueryLoadingStatus } from '../common/types/explorer';
+import { CatalogCacheManager } from './framework/catalog_cache/cache_manager';
 import { AssistantSetup } from './types';
 
 export interface AppPluginStartDependencies {
@@ -31,6 +33,12 @@ export interface SetupDependencies {
   assistantDashboards?: AssistantSetup;
 }
 
+interface LoadCachehookOutput {
+  loadStatus: DirectQueryLoadingStatus;
+  startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void;
+  stopLoading: () => void;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ObservabilitySetup {}
 
@@ -40,11 +48,21 @@ export interface ObservabilityStart {
     datasourceName: string,
     handleRefresh?: () => void
   ) => void;
-  renderAssociatedObjectsDetailsFlyout: (
-    tableDetail: AssociatedObject,
-    datasourceName: string
+  renderAssociatedObjectsDetailsFlyout: ({
+    tableDetail,
+  }: {
+    tableDetail: AssociatedObject;
+  }) => void;
+  renderCreateAccelerationFlyout: (
+    dataSource: string,
+    databaseName?: string,
+    tableName?: string
   ) => void;
-  renderCreateAccelerationFlyout: (selectedDatasource: string) => void;
+  CatalogCacheManagerInstance: typeof CatalogCacheManager;
+  useLoadDatabasesToCacheHook: () => LoadCachehookOutput;
+  useLoadTablesToCacheHook: () => LoadCachehookOutput;
+  useLoadTableColumnsToCacheHook: () => LoadCachehookOutput;
+  useLoadAccelerationsToCacheHook: () => LoadCachehookOutput;
 }
 
 /**


### PR DESCRIPTION
### Description
Add auto-suggestions for skipping index definition and export types

### Issues Resolved
1. Generate suggestions for skipping index
2. Check plugin status to show open in workbench button
3. Export CacheManager for usage in query workbench

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
