### PR TITLE
Implement results from no timestamp in Explorer

### DIFF
--- a/public/components/common/query_utils/index.ts
+++ b/public/components/common/query_utils/index.ts
@@ -371,27 +371,17 @@ export const composeFinalQueryWithoutTimestamp = (
   appBaseQuery: string,
   selectedPatternField?: string,
   patternRegex?: string,
-  filteredPattern?: string) => {
-    let fullQuery = curQuery.includes(appBaseQuery) ? curQuery : buildQuery(appBaseQuery, curQuery);
-    if (isEmpty(fullQuery)) return '';
+  filteredPattern?: string
+) => {
+  let fullQuery = curQuery.includes(appBaseQuery) ? curQuery : buildQuery(appBaseQuery, curQuery);
+  if (isEmpty(fullQuery)) return '';
 
-    // TODO: should any prometheus logic be included here?
-    // const promQLTokens = parsePromQLIntoKeywords(fullQuery);
-    // if (promQLTokens?.connection) {
-    //   return updatePromQLQueryFilters(fullQuery, startTime, endTime);
-    // }
+  // if a pattern is selected as filter, build it into finalQuery
+  if (selectedPatternField && filteredPattern)
+    fullQuery = buildPatternsQuery(fullQuery, selectedPatternField, patternRegex, filteredPattern);
 
-    // if a pattern is selected as filter, build it into finalQuery
-    if (selectedPatternField && filteredPattern)
-      fullQuery = buildPatternsQuery(
-        fullQuery,
-        selectedPatternField,
-        patternRegex,
-        filteredPattern
-      );
-  
-    return fullQuery;
-}
+  return fullQuery;
+};
 
 export const removeBacktick = (stringContainsBacktick: string) => {
   if (!stringContainsBacktick) return '';

--- a/public/components/common/query_utils/index.ts
+++ b/public/components/common/query_utils/index.ts
@@ -368,7 +368,6 @@ export const composeFinalQuery = (
 
 export const composeFinalQueryWithoutTimestamp = (
   curQuery: string,
-  isLiveQuery: boolean,
   appBaseQuery: string,
   selectedPatternField?: string,
   patternRegex?: string,

--- a/public/components/common/query_utils/index.ts
+++ b/public/components/common/query_utils/index.ts
@@ -366,6 +366,34 @@ export const composeFinalQuery = (
   });
 };
 
+export const composeFinalQueryWithoutTimestamp = (
+  curQuery: string,
+  isLiveQuery: boolean,
+  appBaseQuery: string,
+  selectedPatternField?: string,
+  patternRegex?: string,
+  filteredPattern?: string) => {
+    let fullQuery = curQuery.includes(appBaseQuery) ? curQuery : buildQuery(appBaseQuery, curQuery);
+    if (isEmpty(fullQuery)) return '';
+
+    // TODO: should any prometheus logic be included here?
+    // const promQLTokens = parsePromQLIntoKeywords(fullQuery);
+    // if (promQLTokens?.connection) {
+    //   return updatePromQLQueryFilters(fullQuery, startTime, endTime);
+    // }
+
+    // if a pattern is selected as filter, build it into finalQuery
+    if (selectedPatternField && filteredPattern)
+      fullQuery = buildPatternsQuery(
+        fullQuery,
+        selectedPatternField,
+        patternRegex,
+        filteredPattern
+      );
+  
+    return fullQuery;
+}
+
 export const removeBacktick = (stringContainsBacktick: string) => {
   if (!stringContainsBacktick) return '';
   return stringContainsBacktick.replace(/`/g, '');

--- a/public/components/common/search/date_picker.tsx
+++ b/public/components/common/search/date_picker.tsx
@@ -25,22 +25,22 @@ export function DatePicker(props: IDatePickerProps) {
 
   const handleTimeChange = (e: any) => handleTimePickerChange([e.start, e.end]);
 
-  let setStartTime;
-  let setEndTime;
+  let finalizedStartTime;
+  let finalizedEndTime;
   let setDisabled;
   let toolTipMessage;
 
   if (coreRefs.queryAssistEnabled && !isAppAnalytics) {
     // is query assistant inside log explorer
-    setStartTime = QUERY_ASSIST_START_TIME;
-    setEndTime = QUERY_ASSIST_END_TIME;
+    finalizedStartTime = QUERY_ASSIST_START_TIME;
+    finalizedEndTime = QUERY_ASSIST_END_TIME;
     setDisabled = true;
     toolTipMessage = i18n.translate('discover.queryAssistant.timePickerDisabledMessage', {
       defaultMessage: 'Date range has been disabled to accomodate timerange of all datasets',
     });
   } else {
-    setStartTime = startTime;
-    setEndTime = endTime;
+    finalizedStartTime = startTime;
+    finalizedEndTime = endTime;
     setDisabled = false;
     toolTipMessage = false;
   }
@@ -50,8 +50,8 @@ export function DatePicker(props: IDatePickerProps) {
       <EuiToolTip position="bottom" content={toolTipMessage}>
         <EuiSuperDatePicker
           data-test-subj="pplSearchDatePicker"
-          start={setStartTime}
-          end={setEndTime}
+          start={finalizedStartTime}
+          end={finalizedEndTime}
           dateFormat={uiSettingsService.get('dateFormat')}
           onTimeChange={handleTimeChange}
           onRefresh={handleTimeRangePickerRefresh}

--- a/public/components/common/search/date_picker.tsx
+++ b/public/components/common/search/date_picker.tsx
@@ -5,6 +5,7 @@
 
 import { EuiSuperDatePicker, EuiToolTip } from '@elastic/eui';
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import { uiSettingsService } from '../../../../common/utils';
 import { coreRefs } from '../../../framework/core_refs';
 import { IDatePickerProps } from './search';
@@ -12,7 +13,6 @@ import {
   QUERY_ASSIST_END_TIME,
   QUERY_ASSIST_START_TIME,
 } from '../../../../common/constants/shared';
-import { i18n } from '@osd/i18n';
 
 export function DatePicker(props: IDatePickerProps) {
   const {

--- a/public/components/common/search/date_picker.tsx
+++ b/public/components/common/search/date_picker.tsx
@@ -21,7 +21,6 @@ export function DatePicker(props: IDatePickerProps) {
     handleTimePickerChange,
     handleTimeRangePickerRefresh,
     isAppAnalytics,
-    includesTimestamp,
   } = props;
 
   const handleTimeChange = (e: any) => handleTimePickerChange([e.start, e.end]);
@@ -31,27 +30,19 @@ export function DatePicker(props: IDatePickerProps) {
   let setDisabled;
   let toolTipMessage;
 
-  switch (true) {
-    case coreRefs.queryAssistEnabled && !isAppAnalytics: // is query assistant inside log explorer
-      setStartTime = QUERY_ASSIST_START_TIME;
-      setEndTime = QUERY_ASSIST_END_TIME;
-      setDisabled = true;
-      toolTipMessage = i18n.translate('discover.queryAssistant.timePickerDisabledMessage', {
-        defaultMessage: 'Date range has been disabled to accomodate timerange of all datasets',
-      });
-      break;
-    case !includesTimestamp: // there is no timestamp
-      setStartTime = 'now';
-      setDisabled = true;
-      toolTipMessage = i18n.translate('discover.events.timePickerNotFoundMessage', {
-        defaultMessage: 'There is no timestamp found in the index',
-      });
-      break;
-    default:
-      setStartTime = startTime;
-      setEndTime = endTime;
-      setDisabled = false;
-      toolTipMessage = false;
+  if (coreRefs.queryAssistEnabled && !isAppAnalytics) {
+    // is query assistant inside log explorer
+    setStartTime = QUERY_ASSIST_START_TIME;
+    setEndTime = QUERY_ASSIST_END_TIME;
+    setDisabled = true;
+    toolTipMessage = i18n.translate('discover.queryAssistant.timePickerDisabledMessage', {
+      defaultMessage: 'Date range has been disabled to accomodate timerange of all datasets',
+    });
+  } else {
+    setStartTime = startTime;
+    setEndTime = endTime;
+    setDisabled = false;
+    toolTipMessage = false;
   }
 
   return (

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -45,7 +45,7 @@ import {
   resetSummary,
   selectQueryAssistantSummarization,
 } from '../../event_analytics/redux/slices/query_assistant_summarization_slice';
-import { reset } from '../../event_analytics/redux/slices/query_result_slice';
+import { reset, selectQueryResult } from '../../event_analytics/redux/slices/query_result_slice';
 import {
   changeData,
   changeQuery,
@@ -78,7 +78,6 @@ export interface IDatePickerProps {
   handleTimePickerChange: (timeRange: string[]) => any;
   handleTimeRangePickerRefresh: () => any;
   isAppAnalytics: boolean;
-  includesTimestamp: boolean;
 }
 
 export const Search = (props: any) => {
@@ -124,6 +123,7 @@ export const Search = (props: any) => {
   } = props;
 
   const queryRedux = useSelector(selectQueries)[tabId];
+  const queryResults = useSelector(selectQueryResult)[tabId];
   const queryAssistantSummarization = useSelector(selectQueryAssistantSummarization)[tabId];
   const dispatch = useDispatch();
   const appLogEvents = tabId.match(APP_ANALYTICS_TAB_ID_REGEX);
@@ -410,34 +410,35 @@ export const Search = (props: any) => {
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false} />
-            <EuiFlexItem className="euiFlexItem--flexGrowZero event-date-picker" grow={false}>
-              {!isLiveTailOn && (
-                <DatePicker
-                  startTime={startTime}
-                  endTime={endTime}
-                  setStartTime={setStartTime}
-                  setEndTime={setEndTime}
-                  setIsOutputStale={setIsOutputStale}
-                  liveStreamChecked={props.liveStreamChecked}
-                  onLiveStreamChange={props.onLiveStreamChange}
-                  handleTimePickerChange={(tRange: string[]) => {
-                    // modifies run button to look like the update button, if there is a time change, disables timepicker setting update if timepicker is disabled
-                    setNeedsUpdate(
-                      !showQueryArea && // keeps statement false if using query assistant ui, timepicker shouldn't change run button
-                        !(tRange[0] === startTime && tRange[1] === endTime) // checks to see if the time given is different from prev
-                    );
-                    // keeps the time range change local, to be used when update pressed
-                    setStartTime(tRange[0]);
-                    setEndTime(tRange[1]);
-                  }}
-                  handleTimeRangePickerRefresh={() => {
-                    onQuerySearch(queryLang);
-                  }}
-                  isAppAnalytics={isAppAnalytics}
-                  includesTimestamp={queryRedux.selectedTimestamp !== ''}
-                />
-              )}
-            </EuiFlexItem>
+            {!(queryRedux.selectedTimestamp === '' && queryResults?.datarows) && ( // index with no timestamp, dont show timepicker
+              <EuiFlexItem className="euiFlexItem--flexGrowZero event-date-picker" grow={false}>
+                {!isLiveTailOn && (
+                  <DatePicker
+                    startTime={startTime}
+                    endTime={endTime}
+                    setStartTime={setStartTime}
+                    setEndTime={setEndTime}
+                    setIsOutputStale={setIsOutputStale}
+                    liveStreamChecked={props.liveStreamChecked}
+                    onLiveStreamChange={props.onLiveStreamChange}
+                    handleTimePickerChange={(tRange: string[]) => {
+                      // modifies run button to look like the update button, if there is a time change, disables timepicker setting update if timepicker is disabled
+                      setNeedsUpdate(
+                        !showQueryArea && // keeps statement false if using query assistant ui, timepicker shouldn't change run button
+                          !(tRange[0] === startTime && tRange[1] === endTime) // checks to see if the time given is different from prev
+                      );
+                      // keeps the time range change local, to be used when update pressed
+                      setStartTime(tRange[0]);
+                      setEndTime(tRange[1]);
+                    }}
+                    handleTimeRangePickerRefresh={() => {
+                      onQuerySearch(queryLang);
+                    }}
+                    isAppAnalytics={isAppAnalytics}
+                  />
+                )}
+              </EuiFlexItem>
+            )}
             {!showQueryArea && (
               <EuiFlexItem grow={false}>
                 <EuiToolTip position="bottom" content={needsUpdate ? 'Click to apply' : false}>

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -78,6 +78,7 @@ export interface IDatePickerProps {
   handleTimePickerChange: (timeRange: string[]) => any;
   handleTimeRangePickerRefresh: () => any;
   isAppAnalytics: boolean;
+  includesTimestamp: boolean;
 }
 
 export const Search = (props: any) => {
@@ -433,6 +434,7 @@ export const Search = (props: any) => {
                     onQuerySearch(queryLang);
                   }}
                   isAppAnalytics={isAppAnalytics}
+                  includesTimestamp={queryRedux.selectedTimestamp !== ''}
                 />
               )}
             </EuiFlexItem>

--- a/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
+++ b/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
@@ -979,3 +979,630 @@ exports[`Datagrid component renders data grid with different timestamp 1`] = `
   </DataGrid>
 </Provider>
 `;
+
+exports[`Datagrid component renders data grid with no timestamp 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(Symbol.observable): [Function],
+    }
+  }
+>
+  <DataGrid
+    endTime="now"
+    explorerFields={
+      Object {
+        "availableFields": Array [
+          Object {
+            "name": "agent",
+            "type": "string",
+          },
+          Object {
+            "name": "bytes",
+            "type": "long",
+          },
+          Object {
+            "name": "clientip",
+            "type": "ip",
+          },
+          Object {
+            "name": "event",
+            "type": "struct",
+          },
+          Object {
+            "name": "extension",
+            "type": "string",
+          },
+          Object {
+            "name": "geo",
+            "type": "struct",
+          },
+          Object {
+            "name": "host",
+            "type": "string",
+          },
+          Object {
+            "name": "index",
+            "type": "string",
+          },
+          Object {
+            "name": "ip",
+            "type": "ip",
+          },
+          Object {
+            "name": "machine",
+            "type": "struct",
+          },
+          Object {
+            "name": "memory",
+            "type": "double",
+          },
+          Object {
+            "name": "message",
+            "type": "string",
+          },
+          Object {
+            "name": "phpmemory",
+            "type": "long",
+          },
+          Object {
+            "name": "referer",
+            "type": "string",
+          },
+          Object {
+            "name": "request",
+            "type": "string",
+          },
+          Object {
+            "name": "response",
+            "type": "string",
+          },
+          Object {
+            "name": "tags",
+            "type": "string",
+          },
+          Object {
+            "name": "timestamp",
+            "type": "timestamp",
+          },
+          Object {
+            "name": "url",
+            "type": "string",
+          },
+          Object {
+            "name": "utc_time",
+            "type": "timestamp",
+          },
+        ],
+        "queriedFields": Array [
+          Object {
+            "name": "double_per_ip_bytes",
+            "type": "long",
+          },
+          Object {
+            "name": "host",
+            "type": "text",
+          },
+          Object {
+            "name": "ip_count",
+            "type": "integer",
+          },
+          Object {
+            "name": "per_ip_bytes",
+            "type": "long",
+          },
+          Object {
+            "name": "resp_code",
+            "type": "text",
+          },
+          Object {
+            "name": "sum_bytes",
+            "type": "long",
+          },
+        ],
+        "selectedFields": Array [],
+        "unselectedFields": Array [],
+      }
+    }
+    http={
+      Object {
+        "addLoadingCountSource": [MockFunction],
+        "anonymousPaths": Object {
+          "isAnonymous": [MockFunction],
+          "register": [MockFunction],
+        },
+        "basePath": BasePath {
+          "basePath": "",
+          "clientBasePath": "",
+          "get": [Function],
+          "getBasePath": [Function],
+          "prepend": [Function],
+          "remove": [Function],
+          "serverBasePath": "",
+        },
+        "delete": [MockFunction],
+        "fetch": [MockFunction],
+        "get": [MockFunction],
+        "getLoadingCount$": [MockFunction],
+        "head": [MockFunction],
+        "intercept": [MockFunction],
+        "options": [MockFunction],
+        "patch": [MockFunction],
+        "post": [MockFunction],
+        "put": [MockFunction],
+      }
+    }
+    pplService={
+      PPLService {
+        "fetch": [Function],
+        "http": Object {
+          "addLoadingCountSource": [MockFunction],
+          "anonymousPaths": Object {
+            "isAnonymous": [MockFunction],
+            "register": [MockFunction],
+          },
+          "basePath": BasePath {
+            "basePath": "",
+            "clientBasePath": "",
+            "get": [Function],
+            "getBasePath": [Function],
+            "prepend": [Function],
+            "remove": [Function],
+            "serverBasePath": "",
+          },
+          "delete": [MockFunction],
+          "fetch": [MockFunction],
+          "get": [MockFunction],
+          "getLoadingCount$": [MockFunction],
+          "head": [MockFunction],
+          "intercept": [MockFunction],
+          "options": [MockFunction],
+          "patch": [MockFunction],
+          "post": [MockFunction],
+          "put": [MockFunction],
+        },
+      }
+    }
+    rawQuery="source = opensearch_dashboards_sample_data_logs | where match(request,'filebeat')"
+    requestParams={
+      Object {
+        "tabId": "explorer-tab-_fbef9141-48eb-11ee-a60a-af33302cfb3c",
+      }
+    }
+    rows={
+      Array [
+        Object {
+          "AvgTicketPrice": 841.2656,
+          "Cancelled": "false",
+          "Carrier": "OpenSearch Dashboards Airlines",
+          "Dest": "Sydney Kingsford Smith International Airport",
+          "DestAirportID": "SYD",
+          "DestCityName": "Sydney",
+          "DestCountry": "AU",
+          "DestLocation": "{\\"lat\\":-33.94609833,\\"lon\\":151.177002}",
+          "DestRegion": "SE-BD",
+          "DestWeather": "Rain",
+          "DistanceKilometers": 16492.326,
+          "DistanceMiles": 10247.856,
+          "FlightDelay": "false",
+          "FlightDelayMin": 0,
+          "FlightDelayType": "No Delay",
+          "FlightNum": "9HY9SWR",
+          "FlightTimeHour": "17.179506930998397",
+          "FlightTimeMin": 1030.7704,
+          "Origin": "Frankfurt am Main Airport",
+          "OriginAirportID": "FRA",
+          "OriginCityName": "Frankfurt am Main",
+          "OriginCountry": "DE",
+          "OriginLocation": "{\\"lat\\":50.033333,\\"lon\\":8.570556}",
+          "OriginRegion": "DE-HE",
+          "OriginWeather": "Sunny",
+          "dayOfWeek": 0,
+          "timestamp": "2021-05-24 00:00:00",
+        },
+        Object {
+          "AvgTicketPrice": 882.98267,
+          "Cancelled": "false",
+          "Carrier": "Logstash Airways",
+          "Dest": "Venice Marco Polo Airport",
+          "DestAirportID": "VE05",
+          "DestCityName": "Venice",
+          "DestCountry": "IT",
+          "DestLocation": "{\\"lat\\":45.505299,\\"lon\\":12.3519}",
+          "DestRegion": "IT-34",
+          "DestWeather": "Sunny",
+          "DistanceKilometers": 8823.4,
+          "DistanceMiles": 5482.6064,
+          "FlightDelay": "false",
+          "FlightDelayMin": 0,
+          "FlightDelayType": "No Delay",
+          "FlightNum": "X98CCZO",
+          "FlightTimeHour": "7.73982468459836",
+          "FlightTimeMin": 464.3895,
+          "Origin": "Cape Town International Airport",
+          "OriginAirportID": "CPT",
+          "OriginCityName": "Cape Town",
+          "OriginCountry": "ZA",
+          "OriginLocation": "{\\"lat\\":-33.96480179,\\"lon\\":18.60169983}",
+          "OriginRegion": "SE-BD",
+          "OriginWeather": "Clear",
+          "dayOfWeek": 0,
+          "timestamp": "2021-05-24 18:27:00",
+        },
+      ]
+    }
+    startTime="now/y"
+    storedSelectedColumns={
+      Array [
+        Object {
+          "name": "_source",
+          "type": "string",
+        },
+      ]
+    }
+    timeStampField=""
+    totalHits={1390}
+  >
+    <EuiPanel
+      paddingSize="s"
+    >
+      <div
+        className="euiPanel euiPanel--paddingSmall euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      >
+        <HitsCounter
+          hits={1390}
+          onResetQuery={[Function]}
+          showResetButton={false}
+        >
+          <I18nProvider>
+            <IntlProvider
+              defaultLocale="en"
+              formats={
+                Object {
+                  "date": Object {
+                    "full": Object {
+                      "day": "numeric",
+                      "month": "long",
+                      "weekday": "long",
+                      "year": "numeric",
+                    },
+                    "long": Object {
+                      "day": "numeric",
+                      "month": "long",
+                      "year": "numeric",
+                    },
+                    "medium": Object {
+                      "day": "numeric",
+                      "month": "short",
+                      "year": "numeric",
+                    },
+                    "short": Object {
+                      "day": "numeric",
+                      "month": "numeric",
+                      "year": "2-digit",
+                    },
+                  },
+                  "number": Object {
+                    "currency": Object {
+                      "style": "currency",
+                    },
+                    "percent": Object {
+                      "style": "percent",
+                    },
+                  },
+                  "relative": Object {
+                    "days": Object {
+                      "units": "day",
+                    },
+                    "hours": Object {
+                      "units": "hour",
+                    },
+                    "minutes": Object {
+                      "units": "minute",
+                    },
+                    "months": Object {
+                      "units": "month",
+                    },
+                    "seconds": Object {
+                      "units": "second",
+                    },
+                    "years": Object {
+                      "units": "year",
+                    },
+                  },
+                  "time": Object {
+                    "full": Object {
+                      "hour": "numeric",
+                      "minute": "numeric",
+                      "second": "numeric",
+                      "timeZoneName": "short",
+                    },
+                    "long": Object {
+                      "hour": "numeric",
+                      "minute": "numeric",
+                      "second": "numeric",
+                      "timeZoneName": "short",
+                    },
+                    "medium": Object {
+                      "hour": "numeric",
+                      "minute": "numeric",
+                      "second": "numeric",
+                    },
+                    "short": Object {
+                      "hour": "numeric",
+                      "minute": "numeric",
+                    },
+                  },
+                }
+              }
+              locale="en"
+              messages={Object {}}
+              textComponent={Symbol(react.fragment)}
+            >
+              <PseudoLocaleWrapper>
+                <EuiFlexGroup
+                  alignItems="center"
+                  className="dscResultCount"
+                  gutterSize="s"
+                  justifyContent="center"
+                  responsive={false}
+                >
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow dscResultCount"
+                  >
+                    <EuiFlexItem
+                      grow={false}
+                    >
+                      <div
+                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <strong
+                              data-test-subj="discoverQueryHits"
+                            >
+                              1,390
+                            </strong>
+                             
+                            <FormattedMessage
+                              defaultMessage="{hits, plural, one {hit} other {hits}}"
+                              id="discover.hitsPluralTitle"
+                              values={
+                                Object {
+                                  "hits": 1390,
+                                }
+                              }
+                            >
+                              hits
+                            </FormattedMessage>
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </PseudoLocaleWrapper>
+            </IntlProvider>
+          </I18nProvider>
+        </HitsCounter>
+        <EuiSpacer
+          size="s"
+        >
+          <div
+            className="euiSpacer euiSpacer--s"
+          />
+        </EuiSpacer>
+        <div
+          className="dscTable dscTableFixedScroll"
+        >
+          <EuiDataGrid
+            aria-labelledby="aria-labelledby"
+            columnVisibility={
+              Object {
+                "setVisibleColumns": [Function],
+                "visibleColumns": Array [
+                  "_source",
+                ],
+              }
+            }
+            columns={
+              Array [
+                Object {
+                  "display": "Source",
+                  "id": "_source",
+                  "isSortable": false,
+                  "schema": "_source",
+                },
+              ]
+            }
+            data-test-subj="docTable"
+            leadingControlColumns={
+              Array [
+                Object {
+                  "headerCellRender": [Function],
+                  "id": "inspectCollapseColumn",
+                  "rowCellRender": [Function],
+                  "width": 40,
+                },
+              ]
+            }
+            pagination={
+              Object {
+                "onChangeItemsPerPage": [Function],
+                "onChangePage": [Function],
+                "pageIndex": 0,
+                "pageSize": 100,
+                "pageSizeOptions": Array [
+                  25,
+                  50,
+                  100,
+                ],
+              }
+            }
+            renderCellValue={[Function]}
+            rowCount={1390}
+            rowHeightsOptions={
+              Object {
+                "defaultHeight": Object {
+                  "lineCount": 3,
+                },
+              }
+            }
+            sorting={
+              Object {
+                "columns": Array [],
+                "onSort": [Function],
+              }
+            }
+            toolbarVisibility={
+              Object {
+                "showColumnSelector": Object {
+                  "allowHide": false,
+                  "allowReorder": true,
+                },
+                "showFullScreenSelector": false,
+                "showStyleSelector": false,
+              }
+            }
+          >
+            <EuiFocusTrap
+              className="euiDataGrid__focusWrap"
+              clickOutsideDisables={false}
+              disabled={true}
+              noIsolation={true}
+              returnFocus={true}
+              scrollLock={false}
+            >
+              <ForwardRef
+                className="euiDataGrid__focusWrap"
+                enabled={false}
+                noIsolation={true}
+                onClickOutside={[Function]}
+                returnFocus={true}
+                scrollLock={false}
+              >
+                <ForwardRef
+                  className="euiDataGrid__focusWrap"
+                  enabled={false}
+                  noIsolation={true}
+                  onClickOutside={[Function]}
+                  returnFocus={true}
+                  scrollLock={false}
+                  sideCar={[Function]}
+                >
+                  <ForwardRef(FocusLockUI)
+                    as={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "classNames": Object {
+                          "fullWidth": "width-before-scroll-bar",
+                          "zeroRight": "right-scroll-bar-position",
+                        },
+                        "defaultProps": Object {
+                          "enabled": true,
+                          "inert": false,
+                          "removeScrollBar": true,
+                        },
+                        "render": [Function],
+                      }
+                    }
+                    autoFocus={true}
+                    className="euiDataGrid__focusWrap"
+                    crossFrame={true}
+                    disabled={true}
+                    lockProps={
+                      Object {
+                        "allowPinchZoom": undefined,
+                        "as": undefined,
+                        "enabled": false,
+                        "inert": undefined,
+                        "shards": undefined,
+                        "sideCar": [Function],
+                        "style": undefined,
+                      }
+                    }
+                    noFocusGuards={false}
+                    persistentFocus={false}
+                    returnFocus={true}
+                    sideCar={[Function]}
+                  >
+                    <div
+                      data-focus-guard={true}
+                      key="guard-first"
+                      style={
+                        Object {
+                          "height": "0px",
+                          "left": "1px",
+                          "overflow": "hidden",
+                          "padding": 0,
+                          "position": "fixed",
+                          "top": "1px",
+                          "width": "1px",
+                        }
+                      }
+                      tabIndex={-1}
+                    />
+                    <ForwardRef
+                      className="euiDataGrid__focusWrap"
+                      data-focus-lock-disabled="disabled"
+                      enabled={false}
+                      inert={false}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      removeScrollBar={true}
+                      sideCar={[Function]}
+                    >
+                      <div
+                        className="euiDataGrid__focusWrap"
+                        data-focus-lock-disabled="disabled"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onScrollCapture={[Function]}
+                        onTouchMoveCapture={[Function]}
+                        onWheelCapture={[Function]}
+                      >
+                        <div
+                          className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
+                          data-test-subj="docTable"
+                          onKeyDown={[Function]}
+                          style={
+                            Object {
+                              "height": undefined,
+                              "width": undefined,
+                            }
+                          }
+                        />
+                      </div>
+                    </ForwardRef>
+                    <div
+                      data-focus-guard={true}
+                      style={
+                        Object {
+                          "height": "0px",
+                          "left": "1px",
+                          "overflow": "hidden",
+                          "padding": 0,
+                          "position": "fixed",
+                          "top": "1px",
+                          "width": "1px",
+                        }
+                      }
+                      tabIndex={-1}
+                    />
+                  </ForwardRef(FocusLockUI)>
+                </ForwardRef>
+              </ForwardRef>
+            </EuiFocusTrap>
+          </EuiDataGrid>
+        </div>
+      </div>
+    </EuiPanel>
+  </DataGrid>
+</Provider>
+`;

--- a/public/components/event_analytics/explorer/__tests__/data_grid.test.tsx
+++ b/public/components/event_analytics/explorer/__tests__/data_grid.test.tsx
@@ -132,4 +132,53 @@ describe('Datagrid component', () => {
       expect(wrapper).toMatchSnapshot();
     });
   });
+
+  it('renders data grid with no timestamp', async () => {
+    const explorerFields = {
+      [SELECTED_FIELDS]: [],
+      [UNSELECTED_FIELDS]: [],
+      [AVAILABLE_FIELDS]: SIDEBAR_AVAILABLE_FIELDS,
+      [QUERIED_FIELDS]: QUERY_FIELDS,
+    };
+
+    coreStartMock.http.get = jest
+      .fn()
+      .mockResolvedValue((sampleEmptyPanel as unknown) as HttpResponse);
+
+    const tabId = 'explorer-tab-_fbef9141-48eb-11ee-a60a-af33302cfb3c';
+
+    const pplService = new PPLService(coreStartMock.http);
+    const preloadedState = {
+      queries: {
+        [tabId]: {
+          [SELECTED_TIMESTAMP]: '',
+        },
+      },
+    };
+    const store = configureStore({ reducer: queriesReducer, preloadedState });
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <DataGrid
+          http={coreStartMock.http}
+          pplService={pplService}
+          rows={DATA_GRID_ROWS}
+          explorerFields={explorerFields}
+          timeStampField={''}
+          rawQuery={EXPLORER_DATA_GRID_QUERY}
+          totalHits={1390}
+          requestParams={{ tabId }}
+          startTime={'now/y'}
+          endTime={'now'}
+          storedSelectedColumns={DEFAULT_EMPTY_EXPLORER_FIELDS}
+        />
+      </Provider>
+    );
+
+    wrapper.update();
+
+    await waitFor(() => {
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 });

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -68,9 +68,11 @@ export function DataGrid(props: DataGridProps) {
   });
 
   const selectedColumns =
-    explorerFields.selectedFields.length > 0
+    explorerFields.selectedFields.length > 0 // if any fields are selected use that, otherwise defaults
       ? explorerFields.selectedFields
-      : [{ name: timeStampField, type: 'timestamp' }, ...DEFAULT_EMPTY_EXPLORER_FIELDS];
+      : timeStampField && timeStampField !== '' // if theres a timestamp, include that, otherwise dont
+      ? [{ name: timeStampField, type: 'timestamp' }, ...DEFAULT_EMPTY_EXPLORER_FIELDS]
+      : DEFAULT_EMPTY_EXPLORER_FIELDS;
   // useRef instead of useState somehow solves the issue of user triggered sorting not
   // having any delays
   const sortingFields: MutableRefObject<EuiDataGridSorting['columns']> = useRef([]);

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -12,6 +12,7 @@ import {
   EuiDescriptionListTitle,
   EuiPanel,
   EuiDataGridProps,
+  EuiSpacer,
 } from '@elastic/eui';
 import moment from 'moment';
 import React, { Fragment, MutableRefObject, useEffect, useRef, useState } from 'react';
@@ -28,6 +29,7 @@ import PPLService from '../../../../services/requests/ppl';
 import { useFetchEvents } from '../../hooks';
 import { redoQuery } from '../../utils/utils';
 import { FlyoutButton } from './docViewRow';
+import { HitsCounter } from '../hits_counter/hits_counter';
 
 export interface DataGridProps {
   http: HttpSetup;
@@ -253,6 +255,12 @@ export function DataGrid(props: DataGridProps) {
 
   return (
     <EuiPanel paddingSize="s">
+      {timeStampField === '' && (
+        <>
+          <HitsCounter hits={totalHits} showResetButton={false} onResetQuery={() => {}} />
+          <EuiSpacer size="s" />
+        </>
+      )}
       <div className="dscTable dscTableFixedScroll">
         <EuiDataGrid
           aria-labelledby="aria-labelledby"

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -133,6 +133,7 @@ import { TimechartHeader } from './timechart_header';
 import { ExplorerVisualizations } from './visualizations';
 import { CountDistribution } from './visualizations/count_distribution';
 import { DirectQueryVisualization } from './visualizations/direct_query_vis';
+import { createBrowserHistory } from 'history';
 
 export const Explorer = ({
   pplService,

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -541,7 +541,7 @@ export const Explorer = ({
       <div className="dscWrapper">
         {explorerData && !isEmpty(explorerData.jsonData) ? (
           <EuiFlexGroup direction="column" gutterSize="none">
-            {((isDefaultDataSourceType && query[SELECTED_TIMESTAMP] !== '') || appLogEvents) && (
+            {(isDefaultDataSourceType || appLogEvents) && query[SELECTED_TIMESTAMP] !== '' && (
               <>
                 <EuiFlexItem grow={false}>
                   <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s" color="transparent">
@@ -590,7 +590,7 @@ export const Explorer = ({
                 </EuiFlexItem>
               </>
             )}
-            {((isDefaultDataSourceType && query[SELECTED_TIMESTAMP] !== '') || appLogEvents) && (
+            {(isDefaultDataSourceType || appLogEvents) && query[SELECTED_TIMESTAMP] !== '' && (
               <EuiFlexItem grow={false}>
                 <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s" color="transparent">
                   <EuiPanel paddingSize="s" style={{ height: '100%' }}>
@@ -632,7 +632,7 @@ export const Explorer = ({
                         <EuiSpacer size="m" />
                       </>
                     )}
-                    {(countDistribution.data?.['count()'] || explorerData?.datarows?.length) && (
+                    {(explorerData?.datarows?.length || countDistribution.data?.['count()']) && (
                       <DataGrid
                         http={http}
                         pplService={pplService}
@@ -642,7 +642,8 @@ export const Explorer = ({
                         timeStampField={queryRef.current![SELECTED_TIMESTAMP]}
                         rawQuery={appBasedRef.current || queryRef.current![RAW_QUERY]}
                         totalHits={
-                          isDefaultDataSourceType || appLogEvents
+                          (isDefaultDataSourceType || appLogEvents) &&
+                          query[SELECTED_TIMESTAMP] !== ''
                             ? _.sum(countDistribution.data?.['count()']) ||
                               explorerData.datarows.length
                             : explorerData.datarows.length

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -133,7 +133,6 @@ import { TimechartHeader } from './timechart_header';
 import { ExplorerVisualizations } from './visualizations';
 import { CountDistribution } from './visualizations/count_distribution';
 import { DirectQueryVisualization } from './visualizations/direct_query_vis';
-import { createBrowserHistory } from 'history';
 
 export const Explorer = ({
   pplService,
@@ -270,7 +269,6 @@ export const Explorer = ({
 
   const historyFromRedirection = createBrowserHistory();
   useEffect(() => {
-    console.log(historyFromRedirection.location.state);
     if (!historyFromRedirection.location.state) return;
     const {
       datasourceName,
@@ -299,6 +297,7 @@ export const Explorer = ({
           query: { [RAW_QUERY]: queryToRun },
         })
       );
+      setTempQuery(queryToRun);
     });
   }, []);
 

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -542,7 +542,7 @@ export const Explorer = ({
       <div className="dscWrapper">
         {explorerData && !isEmpty(explorerData.jsonData) ? (
           <EuiFlexGroup direction="column" gutterSize="none">
-            {(isDefaultDataSourceType || appLogEvents) && (
+            {((isDefaultDataSourceType && query[SELECTED_TIMESTAMP] !== '') || appLogEvents) && (
               <>
                 <EuiFlexItem grow={false}>
                   <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s" color="transparent">
@@ -591,7 +591,7 @@ export const Explorer = ({
                 </EuiFlexItem>
               </>
             )}
-            {(isDefaultDataSourceType || appLogEvents) && (
+            {((isDefaultDataSourceType && query[SELECTED_TIMESTAMP] !== '') || appLogEvents) && (
               <EuiFlexItem grow={false}>
                 <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s" color="transparent">
                   <EuiPanel paddingSize="s" style={{ height: '100%' }}>

--- a/public/components/event_analytics/explorer/no_results.tsx
+++ b/public/components/event_analytics/explorer/no_results.tsx
@@ -24,7 +24,7 @@ export const NoResults = ({ tabId }: any) => {
   // get the queries isLoaded, if it exists AND is true = show no res
   const queryInfo = useSelector(selectQueries)[tabId];
   const summaryData = useSelector(selectQueryAssistantSummarization)[tabId];
-  const queryAssistLoading = summaryData.loading;
+  const queryAssistLoading = summaryData?.loading;
 
   return (
     <EuiPage paddingSize="s">

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -304,7 +304,7 @@ export const DataConfigPanelItem = ({
           },
         });
       },
-      errorCallback: (err) => {},
+      errorCallback: () => {},
     });
   }, [configList, query, visualizations]);
 
@@ -316,11 +316,6 @@ export const DataConfigPanelItem = ({
   }: VisualizationState) => {
     fillVisDataInStore({ visData, queryState, visConfMetadata, visMeta });
   };
-
-  const isPositionButtonVisible = (sectionName: string) =>
-    sectionName === AGGREGATIONS &&
-    (visualizations.vis.name === VIS_CHART_TYPES.Line ||
-      visualizations.vis.name === VIS_CHART_TYPES.Scatter);
 
   const getTimeStampFilteredFields = (options: IField[]) =>
     filter(options, (i: IField) => i.type !== TIMESTAMP);

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -50,7 +50,10 @@ import {
 import { TabContext, useRenderVisualization } from '../../../../../hooks';
 import { DataConfigItemClickPanel } from '../config_controls/data_config_item_click_panel';
 import { DataConfigPanelFields } from '../config_controls/data_config_panel_fields';
-import { composeFinalQuery } from '../../../../../../../../common/utils';
+import {
+  composeFinalQuery,
+  composeFinalQueryWithoutTimestamp,
+} from '../../../../../../common/query_utils';
 
 const initialDimensionEntry = {
   label: '',
@@ -244,16 +247,18 @@ export const DataConfigPanelItem = ({
     return {
       ...prevQuery,
       [RAW_QUERY]: newQueryString,
-      [FINAL_QUERY]: composeFinalQuery(
-        newQueryString,
-        prevQuery[SELECTED_DATE_RANGE][0] || 'now',
-        prevQuery[SELECTED_DATE_RANGE][1] || 'now',
-        !isEmpty(visConfig.span?.time_field)
-          ? visConfig.span?.time_field[0].name
-          : prevQuery.selectedTimestamp,
-        false,
-        ''
-      ),
+      [FINAL_QUERY]: isEmpty(prevQuery.selectedTimestamp)
+        ? composeFinalQueryWithoutTimestamp(newQueryString, '')
+        : composeFinalQuery(
+            newQueryString,
+            prevQuery[SELECTED_DATE_RANGE][0] || 'now',
+            prevQuery[SELECTED_DATE_RANGE][1] || 'now',
+            !isEmpty(visConfig.span?.time_field)
+              ? visConfig.span?.time_field[0].name
+              : prevQuery.selectedTimestamp,
+            false,
+            ''
+          ),
     };
   };
 

--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -23,6 +23,7 @@ import {
   TAB_CHART_ID,
 } from '../../../../common/constants/explorer';
 import { PPL_STATS_REGEX } from '../../../../common/constants/shared';
+import { composeFinalQueryWithoutTimestamp } from '../../../components/common/query_utils';
 
 export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
   protected queryIndex: string;
@@ -85,13 +86,22 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
     const { dispatch, changeQuery } = this.storeContext;
 
     await this.processTimestamp(query);
-    if (isEmpty(this.timestamp)) return;
 
-    const curStartTime = startingTime || this.query[SELECTED_DATE_RANGE][0];
-    const curEndTime = endingTime || this.query[SELECTED_DATE_RANGE][1];
+    const noTimestamp = isEmpty(this.timestamp);
+
+    const curStartTime = noTimestamp ? undefined : startingTime || this.query[SELECTED_DATE_RANGE][0];
+    const curEndTime = noTimestamp ? undefined : endingTime || this.query[SELECTED_DATE_RANGE][1];
 
     // compose final query
-    const finalQuery = composeFinalQuery(
+    const finalQuery = noTimestamp ? 
+    composeFinalQueryWithoutTimestamp(
+      this.query[RAW_QUERY],
+      isLiveTailOn,
+      appBaseQuery,
+      this.query[SELECTED_PATTERN_FIELD],
+      this.query[PATTERN_REGEX],
+      this.query[FILTERED_PATTERN]
+    ) : composeFinalQuery(
       this.query[RAW_QUERY],
       curStartTime,
       curEndTime,
@@ -106,7 +116,7 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
     // update UI with new query state
     await this.updateQueryState(this.query[RAW_QUERY], finalQuery, this.timestamp);
     // calculate proper time interval for count distribution
-    if (!selectedInterval.current || selectedInterval.current.text === 'Auto') {
+    if (!noTimestamp && (!selectedInterval.current || selectedInterval.current.text === 'Auto')) {
       findAutoInterval(curStartTime, curEndTime);
     }
 

--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -89,28 +89,31 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
 
     const noTimestamp = isEmpty(this.timestamp);
 
-    const curStartTime = noTimestamp ? undefined : startingTime || this.query[SELECTED_DATE_RANGE][0];
+    const curStartTime = noTimestamp
+      ? undefined
+      : startingTime || this.query[SELECTED_DATE_RANGE][0];
     const curEndTime = noTimestamp ? undefined : endingTime || this.query[SELECTED_DATE_RANGE][1];
 
     // compose final query
-    const finalQuery = noTimestamp ? 
-    composeFinalQueryWithoutTimestamp(
-      this.query[RAW_QUERY],
-      appBaseQuery,
-      this.query[SELECTED_PATTERN_FIELD],
-      this.query[PATTERN_REGEX],
-      this.query[FILTERED_PATTERN]
-    ) : composeFinalQuery(
-      this.query[RAW_QUERY],
-      curStartTime,
-      curEndTime,
-      this.timestamp,
-      isLiveTailOn,
-      appBaseQuery,
-      this.query[SELECTED_PATTERN_FIELD],
-      this.query[PATTERN_REGEX],
-      this.query[FILTERED_PATTERN]
-    );
+    const finalQuery = noTimestamp
+      ? composeFinalQueryWithoutTimestamp(
+          this.query[RAW_QUERY],
+          appBaseQuery,
+          this.query[SELECTED_PATTERN_FIELD],
+          this.query[PATTERN_REGEX],
+          this.query[FILTERED_PATTERN]
+        )
+      : composeFinalQuery(
+          this.query[RAW_QUERY],
+          curStartTime,
+          curEndTime,
+          this.timestamp,
+          isLiveTailOn,
+          appBaseQuery,
+          this.query[SELECTED_PATTERN_FIELD],
+          this.query[PATTERN_REGEX],
+          this.query[FILTERED_PATTERN]
+        );
 
     // update UI with new query state
     await this.updateQueryState(this.query[RAW_QUERY], finalQuery, this.timestamp);

--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -96,7 +96,6 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
     const finalQuery = noTimestamp ? 
     composeFinalQueryWithoutTimestamp(
       this.query[RAW_QUERY],
-      isLiveTailOn,
       appBaseQuery,
       this.query[SELECTED_PATTERN_FIELD],
       this.query[PATTERN_REGEX],

--- a/public/services/saved_objects/saved_object_loaders/explorer_saved_object_loader.ts
+++ b/public/services/saved_objects/saved_object_loaders/explorer_saved_object_loader.ts
@@ -167,7 +167,7 @@ export class ExplorerSavedObjectLoader extends SavedObjectLoaderBase implements 
   }
 
   async processSavedData(savedObjectData: SavedObjectData) {
-    const savedType = isObjectSavedQuery(savedObjectData) ? SAVED_QUERY : SAVED_VISUALIZATION;
+        const savedType = isObjectSavedQuery(savedObjectData) ? SAVED_QUERY : SAVED_VISUALIZATION;
     const objectData = isObjectSavedQuery(savedObjectData)
       ? savedObjectData.savedQuery
       : savedObjectData.savedVisualization;
@@ -204,7 +204,7 @@ export class ExplorerSavedObjectLoader extends SavedObjectLoaderBase implements 
           tabId,
           query: {
             [RAW_QUERY]: currQuery,
-            [SELECTED_TIMESTAMP]: objectData?.selected_timestamp?.name || 'timestamp',
+            [SELECTED_TIMESTAMP]: objectData?.selected_timestamp?.name,
             [SAVED_OBJECT_ID]: objectId,
             [SAVED_OBJECT_TYPE]: savedType,
             [SELECTED_DATE_RANGE]:

--- a/public/services/saved_objects/saved_object_loaders/explorer_saved_object_loader.ts
+++ b/public/services/saved_objects/saved_object_loaders/explorer_saved_object_loader.ts
@@ -167,7 +167,7 @@ export class ExplorerSavedObjectLoader extends SavedObjectLoaderBase implements 
   }
 
   async processSavedData(savedObjectData: SavedObjectData) {
-        const savedType = isObjectSavedQuery(savedObjectData) ? SAVED_QUERY : SAVED_VISUALIZATION;
+    const savedType = isObjectSavedQuery(savedObjectData) ? SAVED_QUERY : SAVED_VISUALIZATION;
     const objectData = isObjectSavedQuery(savedObjectData)
       ? savedObjectData.savedQuery
       : savedObjectData.savedVisualization;


### PR DESCRIPTION
### Description
To allow for querying of flint materialized views and covering indices which may not have timestamps, Explorer is being extended to show results from queries with no timestamps
Changes:

- Check field mapping for no timestamp
- Send out query without timestamp and get results to Explorer
- Disable timepicker
- Get rid of time column in data grid
- Saved query: modify load
- Visualization changes
- Disable patterns
- Enable Hit Counter

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
