### PR TITLE
Fixed small bugs in explorer

### DIFF
--- a/public/components/common/search/direct_search.tsx
+++ b/public/components/common/search/direct_search.tsx
@@ -21,6 +21,7 @@ import {
 import { isEmpty, isEqual } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
+import { i18n } from '@osd/i18n';
 import { ASYNC_POLLING_INTERVAL, QUERY_LANGUAGE } from '../../../../common/constants/data_sources';
 import {
   APP_ANALYTICS_TAB_ID_REGEX,
@@ -54,7 +55,6 @@ import { formatError } from '../../event_analytics/utils';
 import { usePolling } from '../../hooks/use_polling';
 import { PPLReferenceFlyout } from '../helpers';
 import { Autocomplete } from './autocomplete';
-import { i18n } from '@osd/i18n';
 export interface IQueryBarProps {
   query: string;
   tempQuery: string;

--- a/public/components/common/search/direct_search.tsx
+++ b/public/components/common/search/direct_search.tsx
@@ -384,7 +384,7 @@ export const DirectSearch = (props: any) => {
             getSuggestions={getSuggestions}
             onItemSelect={onItemSelect}
             tabId={tabId}
-            isSuggestionDisabled={queryLang === 'SQL'}
+            isSuggestionDisabled={true}
             isDisabled={explorerSearchMetadata.isPolling}
           />
           {queryLang === QUERY_LANGUAGE.PPL && (

--- a/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
+++ b/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
@@ -293,7 +293,7 @@ exports[`Datagrid component Renders data grid component 1`] = `
                   "display": "Time (timestamp)",
                   "id": "timestamp",
                   "initialWidth": 200,
-                  "isSortable": true,
+                  "isSortable": undefined,
                   "schema": "datetime",
                 },
                 Object {
@@ -783,7 +783,7 @@ exports[`Datagrid component renders data grid with different timestamp 1`] = `
                   "display": "Time (utc_time)",
                   "id": "utc_time",
                   "initialWidth": 200,
-                  "isSortable": true,
+                  "isSortable": undefined,
                   "schema": "datetime",
                 },
                 Object {

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -180,7 +180,7 @@ export function DataGrid(props: DataGridProps) {
               http={http}
               key={null}
               docId={'undefined'}
-              doc={rows[rowIndex % pageFields.current[1]]}
+              doc={data[rowIndex % pageFields.current[1]]}
               selectedCols={explorerFields.queriedFields}
               timeStampField={timeStampField}
               explorerFields={explorerFields}
@@ -192,7 +192,7 @@ export function DataGrid(props: DataGridProps) {
               selectedIndex={rowIndex}
               sortingFields={sortingFields}
               rowHeightsOptions={rowHeightsOptions}
-              rows={rows}
+              rows={data}
             />
           );
         },

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -40,6 +40,7 @@ export interface DataGridProps {
   requestParams: any;
   startTime: string;
   endTime: string;
+  isNotDefaultDatasource: boolean;
   storedSelectedColumns: IField[];
   formatGridColumn?: (columns: EuiDataGridColumn[]) => EuiDataGridColumn[];
   OuiDataGridProps?: Partial<EuiDataGridProps>;
@@ -59,6 +60,7 @@ export function DataGrid(props: DataGridProps) {
     requestParams,
     startTime,
     endTime,
+    isNotDefaultDatasource,
     formatGridColumn = defaultFormatGrid,
     OuiDataGridProps,
   } = props;
@@ -127,6 +129,7 @@ export function DataGrid(props: DataGridProps) {
           ...DEFAULT_TIMESTAMP_COLUMN,
           display: `${columnNameTranslate('Time')} (${timeStampField})`,
           id: timeStampField,
+          isSortable: !isNotDefaultDatasource, // allow sorting for default ds, dont otherwise
         });
       } else if (name === '_source') {
         columns.push({
@@ -137,7 +140,7 @@ export function DataGrid(props: DataGridProps) {
         columns.push({
           id: name,
           display: name,
-          isSortable: true, // TODO: add functionality here based on type
+          isSortable: !isNotDefaultDatasource,
         });
       }
     });

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -102,6 +102,8 @@ export function DataGrid(props: DataGridProps) {
 
   const setPage = (page: number[]) => {
     pageFields.current = page;
+    if (isNotDefaultDatasource) return; // avoid adjusting query if using s3
+
     redoQuery(
       startTime,
       endTime,
@@ -201,7 +203,13 @@ export function DataGrid(props: DataGridProps) {
 
   // renders what is shown in each cell, i.e. the content of each row
   const dataGridCellRender = ({ rowIndex, columnId }: { rowIndex: number; columnId: string }) => {
-    const trueIndex = rowIndex % pageFields.current[1]; // modulo of row length, i.e. pos on current page
+    let trueIndex = rowIndex;
+    // if using default ds, data given to dg will be per page, need to adjust dg expected index and actual data index
+    if (!isNotDefaultDatasource) {
+      // modulo of row length, i.e. pos on current page
+      trueIndex = trueIndex % pageFields.current[1];
+    }
+
     if (trueIndex < data.length) {
       if (columnId === '_source') {
         return (

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -116,6 +116,15 @@ export function DataGrid(props: DataGridProps) {
     );
   };
 
+  const findTrueIndex = (rowIndex: number) => {
+    // if using default ds, data given to dg will be per page, need to adjust dg expected index and actual data index
+    if (!isNotDefaultDatasource) {
+      // modulo of row length, i.e. pos on current page
+      rowIndex = rowIndex % pageFields.current[1];
+    }
+    return rowIndex;
+  };
+
   const columnNameTranslate = (name: string) => {
     return i18n.translate(`discover.events.dataGrid.${name.toLowerCase()}Column`, {
       defaultMessage: name,
@@ -180,7 +189,7 @@ export function DataGrid(props: DataGridProps) {
               http={http}
               key={null}
               docId={'undefined'}
-              doc={data[rowIndex % pageFields.current[1]]}
+              doc={data[findTrueIndex(rowIndex)]}
               selectedCols={explorerFields.queriedFields}
               timeStampField={timeStampField}
               explorerFields={explorerFields}
@@ -203,12 +212,7 @@ export function DataGrid(props: DataGridProps) {
 
   // renders what is shown in each cell, i.e. the content of each row
   const dataGridCellRender = ({ rowIndex, columnId }: { rowIndex: number; columnId: string }) => {
-    let trueIndex = rowIndex;
-    // if using default ds, data given to dg will be per page, need to adjust dg expected index and actual data index
-    if (!isNotDefaultDatasource) {
-      // modulo of row length, i.e. pos on current page
-      trueIndex = trueIndex % pageFields.current[1];
-    }
+    let trueIndex = findTrueIndex(rowIndex);
 
     if (trueIndex < data.length) {
       if (columnId === '_source') {

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -212,7 +212,7 @@ export function DataGrid(props: DataGridProps) {
 
   // renders what is shown in each cell, i.e. the content of each row
   const dataGridCellRender = ({ rowIndex, columnId }: { rowIndex: number; columnId: string }) => {
-    let trueIndex = findTrueIndex(rowIndex);
+    const trueIndex = findTrueIndex(rowIndex);
 
     if (trueIndex < data.length) {
       if (columnId === '_source') {

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -187,11 +187,11 @@ export function DataGrid(props: DataGridProps) {
               pplService={pplService}
               rawQuery={rawQuery}
               onFlyoutOpen={() => {}}
-              dataGridColumns={dataGridColumns}
-              dataGridColumnVisibility={dataGridColumnVisibility}
+              dataGridColumns={dataGridColumns()}
+              dataGridColumnVisibility={dataGridColumnVisibility()}
               selectedIndex={rowIndex}
               sortingFields={sortingFields}
-              rowHeightsOptions={rowHeightsOptions}
+              rowHeightsOptions={rowHeightsOptions()}
               rows={data}
             />
           );

--- a/public/components/event_analytics/explorer/events_views/data_grid.tsx
+++ b/public/components/event_analytics/explorer/events_views/data_grid.tsx
@@ -40,7 +40,7 @@ export interface DataGridProps {
   requestParams: any;
   startTime: string;
   endTime: string;
-  isNotDefaultDatasource: boolean;
+  isDefaultDataSource: boolean;
   storedSelectedColumns: IField[];
   formatGridColumn?: (columns: EuiDataGridColumn[]) => EuiDataGridColumn[];
   OuiDataGridProps?: Partial<EuiDataGridProps>;
@@ -60,7 +60,7 @@ export function DataGrid(props: DataGridProps) {
     requestParams,
     startTime,
     endTime,
-    isNotDefaultDatasource,
+    isDefaultDataSource,
     formatGridColumn = defaultFormatGrid,
     OuiDataGridProps,
   } = props;
@@ -102,7 +102,7 @@ export function DataGrid(props: DataGridProps) {
 
   const setPage = (page: number[]) => {
     pageFields.current = page;
-    if (isNotDefaultDatasource) return; // avoid adjusting query if using s3
+    if (!isDefaultDataSource) return; // avoid adjusting query if using s3
 
     redoQuery(
       startTime,
@@ -118,7 +118,7 @@ export function DataGrid(props: DataGridProps) {
 
   const findTrueIndex = (rowIndex: number) => {
     // if using default ds, data given to dg will be per page, need to adjust dg expected index and actual data index
-    if (!isNotDefaultDatasource) {
+    if (isDefaultDataSource) {
       // modulo of row length, i.e. pos on current page
       rowIndex = rowIndex % pageFields.current[1];
     }
@@ -140,7 +140,7 @@ export function DataGrid(props: DataGridProps) {
           ...DEFAULT_TIMESTAMP_COLUMN,
           display: `${columnNameTranslate('Time')} (${timeStampField})`,
           id: timeStampField,
-          isSortable: !isNotDefaultDatasource, // allow sorting for default ds, dont otherwise
+          isSortable: isDefaultDataSource, // allow sorting for default ds, dont otherwise
         });
       } else if (name === '_source') {
         columns.push({
@@ -151,7 +151,7 @@ export function DataGrid(props: DataGridProps) {
         columns.push({
           id: name,
           display: name,
-          isSortable: !isNotDefaultDatasource,
+          isSortable: isDefaultDataSource,
         });
       }
     });

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -650,8 +650,8 @@ export const Explorer = ({
                         requestParams={requestParams}
                         startTime={startTime}
                         endTime={endTime}
-                        isNotDefaultDatasource={
-                          explorerSearchMeta.datasources[0].type !== DEFAULT_DATA_SOURCE_TYPE
+                        isDefaultDataSource={
+                          explorerSearchMeta.datasources[0].type === DEFAULT_DATA_SOURCE_TYPE
                         }
                       />
                     )}

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -650,6 +650,9 @@ export const Explorer = ({
                         requestParams={requestParams}
                         startTime={startTime}
                         endTime={endTime}
+                        isNotDefaultDatasource={
+                          explorerSearchMeta.datasources[0].type !== DEFAULT_DATA_SOURCE_TYPE
+                        }
                       />
                     )}
                     <a tabIndex={0} id="discoverBottomMarker">


### PR DESCRIPTION
### Description
- For s3 data sources, disabled sorting
- Disabled autocomplete for s3 ppl
- For s3, implemented basic working pagination
- In default data sources: Explorer data grid fix flyout after sort correspond to correct row
- Fix/reenable surrounding events
- Create ability for surrounding events to work on s3

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
