### PR TITLE
Allow browsing integrations in Flyout from Data Sources page

### DIFF
--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { coreRefs } from '../../public/framework/core_refs';
+
+/**
+ * TODO making this method type-safe is nontrivial: if you just define
+ * `Nested<T> = { [k: string]: Nested<T> | T }` then you can't accumulate because `T` is not `Nested<T>`
+ * There might be a way to define a recursive type that accumulates cleanly but it's probably not
+ * worth the effort.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function get<T = unknown>(obj: Record<string, any>, path: string, defaultValue?: T): T {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return path.split('.').reduce((acc: any, part: string) => acc && acc[part], obj) || defaultValue;
 }
 
@@ -33,3 +43,19 @@ export function combineSchemaAndDatarows(
 
   return combinedData;
 }
+
+/**
+ * Safely prepend the `basePath` from `coreRefs` to the given link.
+ * If `coreRefs.http.basePath` exists (always true in normal operation), prepend it to the link.
+ * If it doesn't exist (usually during unit testing), return the link as-is.
+ *
+ * @param link The link to prepend with `coreRefs.http.basePath`.
+ * @returns The link with the prepended `basePath` if it exists, otherwise the unmodified link.
+ */
+export const basePathLink = (link: string): string => {
+  if (coreRefs.http?.basePath) {
+    return coreRefs.http.basePath.prepend(link);
+  } else {
+    return link;
+  }
+};

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
     <div
       className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <NoInstalledIntegrations>
+      <NoInstalledIntegrations
+        toggleFlyout={[Function]}
+      >
         <EuiFlexGroup
           alignItems="center"
           direction="column"
@@ -104,27 +106,30 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
               <div
                 className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <AddIntegrationButton>
+                <AddIntegrationButton
+                  toggleFlyout={[Function]}
+                >
                   <EuiButton
-                    href="/app/integrations#available"
+                    onClick={[Function]}
                   >
                     <EuiButtonDisplay
                       baseClassName="euiButton"
-                      element="a"
-                      href="/app/integrations#available"
+                      disabled={false}
+                      element="button"
                       isDisabled={false}
-                      rel="noreferrer"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <a
+                      <button
                         className="euiButton euiButton--primary"
                         disabled={false}
-                        href="/app/integrations#available"
-                        rel="noreferrer"
+                        onClick={[Function]}
                         style={
                           Object {
                             "minWidth": undefined,
                           }
                         }
+                        type="button"
                       >
                         <EuiButtonContent
                           className="euiButton__content"
@@ -145,7 +150,7 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
                             </span>
                           </span>
                         </EuiButtonContent>
-                      </a>
+                      </button>
                     </EuiButtonDisplay>
                   </EuiButton>
                 </AddIntegrationButton>
@@ -319,29 +324,31 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
             >
               <AddIntegrationButton
                 fill={true}
+                toggleFlyout={[Function]}
               >
                 <EuiButton
                   fill={true}
-                  href="/app/integrations#available"
+                  onClick={[Function]}
                 >
                   <EuiButtonDisplay
                     baseClassName="euiButton"
-                    element="a"
+                    disabled={false}
+                    element="button"
                     fill={true}
-                    href="/app/integrations#available"
                     isDisabled={false}
-                    rel="noreferrer"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <a
+                    <button
                       className="euiButton euiButton--primary euiButton--fill"
                       disabled={false}
-                      href="/app/integrations#available"
-                      rel="noreferrer"
+                      onClick={[Function]}
                       style={
                         Object {
                           "minWidth": undefined,
                         }
                       }
+                      type="button"
                     >
                       <EuiButtonContent
                         className="euiButton__content"
@@ -362,7 +369,7 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
                           </span>
                         </span>
                       </EuiButtonContent>
-                    </a>
+                    </button>
                   </EuiButtonDisplay>
                 </EuiButton>
               </AddIntegrationButton>

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Installed Integrations Table test Renders the empty installed integrations table 1`] = `
 <InstalledIntegrationsTable
+  datasourceType="S3GLUE"
   integrations={Array []}
 >
   <EuiSpacer>
@@ -166,6 +167,7 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
 
 exports[`Installed Integrations Table test Renders the installed integrations table 1`] = `
 <InstalledIntegrationsTable
+  datasourceType="S3GLUE"
   integrations={
     Array [
       Object {

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -859,3 +859,3588 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
   </EuiPanel>
 </InstalledIntegrationsTable>
 `;
+
+exports[`Installed Integrations Table test Renders the installed integrations table flyout 1`] = `
+<InstallIntegrationFlyout
+  availableIntegrations={
+    Object {
+      "hits": Array [
+        Object {
+          "assets": Array [
+            Object {
+              "extension": "ndjson",
+              "name": "sample",
+              "type": "savedObjectBundle",
+              "version": "1.0.1",
+            },
+          ],
+          "components": Array [
+            Object {
+              "name": "logs",
+              "version": "1.0.0",
+            },
+          ],
+          "license": "Apache-2.0",
+          "name": "sample",
+          "type": "logs",
+          "version": "2.0.0",
+          "workflows": Array [
+            Object {
+              "description": "This is a test workflow.",
+              "enabled_by_default": true,
+              "label": "Workflow 1",
+              "name": "workflow1",
+            },
+          ],
+        },
+        Object {
+          "assets": Array [
+            Object {
+              "extension": "ndjson",
+              "name": "sample",
+              "type": "savedObjectBundle",
+              "version": "1.0.1",
+            },
+          ],
+          "components": Array [
+            Object {
+              "name": "logs",
+              "version": "1.0.0",
+            },
+          ],
+          "labels": Array [
+            "Flint S3",
+          ],
+          "license": "Apache-2.0",
+          "name": "sample2",
+          "type": "logs",
+          "version": "2.0.0",
+          "workflows": Array [
+            Object {
+              "description": "This is a test workflow.",
+              "enabled_by_default": true,
+              "label": "Workflow 1",
+              "name": "workflow1",
+            },
+          ],
+        },
+      ],
+    }
+  }
+  closeFlyout={[Function]}
+  datasourceType="S3GLUE"
+  setAvailableIntegrations={[Function]}
+>
+  <EuiFlyout
+    onClose={[Function]}
+  >
+    <OuiWindowEvent
+      event="keydown"
+      handler={[Function]}
+    />
+    <EuiOverlayMask
+      headerZindexLocation="below"
+      onClick={[Function]}
+    >
+      <Portal
+        containerInfo={
+          <div
+            class="euiOverlayMask euiOverlayMask--belowHeader"
+          >
+            <div
+              aria-hidden="true"
+              data-aria-hidden="true"
+              data-focus-guard="true"
+              style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+              tabindex="0"
+            />
+            <div
+              data-focus-lock-disabled="false"
+            >
+              <div
+                class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+                role="dialog"
+                tabindex="-1"
+              >
+                <button
+                  aria-label="Close this dialog"
+                  class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+                  data-test-subj="euiFlyoutCloseButton"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                </button>
+                <div
+                  class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+                  id="availableIntegrationsArea"
+                  role="main"
+                >
+                  <div
+                    class="euiSpacer euiSpacer--l"
+                  />
+                  <div>
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                    >
+                      <div
+                        class="euiFlexItem euiSearchBar__searchHolder"
+                      >
+                        <div
+                          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                              class="euiFieldSearch euiFieldSearch--fullWidth"
+                              placeholder="Search..."
+                              type="search"
+                              value=""
+                            />
+                            <div
+                              class="euiFormControlLayoutIcons"
+                            >
+                              <span
+                                class="euiFormControlLayoutCustomIcon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                  />
+                                </svg>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--l"
+                    />
+                    <div
+                      class="euiBasicTable"
+                    >
+                      <div>
+                        <div
+                          class="euiTableHeaderMobile"
+                        >
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                          </div>
+                        </div>
+                        <table
+                          class="euiTable euiTable--responsive euiTable--auto"
+                          id="random_html_id"
+                          tabindex="-1"
+                        >
+                          <caption
+                            class="euiScreenReaderOnly euiTableCaption"
+                          />
+                          <thead>
+                            <tr>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_name_0"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Name"
+                                  >
+                                    Name
+                                  </span>
+                                </span>
+                              </th>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_description_1"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Description"
+                                  >
+                                    Description
+                                  </span>
+                                </span>
+                              </th>
+                              <th
+                                class="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_categories_2"
+                                role="columnheader"
+                                scope="col"
+                              >
+                                <span
+                                  class="euiTableCellContent"
+                                >
+                                  <span
+                                    class="euiTableCellContent__text"
+                                    title="Categories"
+                                  >
+                                    Categories
+                                  </span>
+                                </span>
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr
+                              class="euiTableRow euiTableRow-isSelectable"
+                            >
+                              <td
+                                class="euiTableRowCell"
+                              >
+                                <div
+                                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Name
+                                </div>
+                                <div
+                                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <a
+                                    class="euiLink euiLink--primary"
+                                    data-test-subj="sample2IntegrationLink"
+                                    href="/app/integrations#/available/sample2"
+                                    rel="noreferrer"
+                                  >
+                                    sample2
+                                  </a>
+                                </div>
+                              </td>
+                              <td
+                                class="euiTableRowCell"
+                              >
+                                <div
+                                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Description
+                                </div>
+                                <div
+                                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                    data-test-subj="sample2IntegrationDescription"
+                                  />
+                                </div>
+                              </td>
+                              <td
+                                class="euiTableRowCell"
+                              >
+                                <div
+                                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Categories
+                                </div>
+                                <div
+                                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <div
+                                    class="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
+                                  >
+                                    <span
+                                      class="euiBadgeGroup__item"
+                                    >
+                                      <span
+                                        class="euiBadge euiBadge--iconLeft"
+                                        style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+                                        title="Flint S3"
+                                      >
+                                        <span
+                                          class="euiBadge__content"
+                                        >
+                                          <span
+                                            class="euiBadge__text"
+                                          >
+                                            Flint S3
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiPopover euiPopover--anchorUpRight"
+                            >
+                              <div
+                                class="euiPopover__anchor"
+                              >
+                                <button
+                                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                  data-test-subj="tablePaginationPopoverButton"
+                                  type="button"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                    <span
+                                      class="euiButtonEmpty__text"
+                                    >
+                                      Rows per page
+                                      : 
+                                      10
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <nav
+                              class="euiPagination"
+                            >
+                              <button
+                                aria-label="Previous page"
+                                class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                data-test-subj="pagination-button-previous"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </button>
+                              <ul
+                                class="euiPagination__list"
+                              >
+                                <li
+                                  class="euiPagination__item"
+                                >
+                                  <button
+                                    aria-controls="random_html_id"
+                                    aria-current="true"
+                                    aria-label="Page 1 of 1"
+                                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                    data-test-subj="pagination-button-0"
+                                    disabled=""
+                                    type="button"
+                                  >
+                                    <span
+                                      class="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        class="euiButtonEmpty__text"
+                                      >
+                                        1
+                                      </span>
+                                    </span>
+                                  </button>
+                                </li>
+                              </ul>
+                              <button
+                                aria-label="Next page"
+                                class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                data-test-subj="pagination-button-next"
+                                disabled=""
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </button>
+                            </nav>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-hidden="true"
+              data-aria-hidden="true"
+              data-focus-guard="true"
+              style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+              tabindex="0"
+            />
+          </div>
+        }
+      >
+        <EuiFocusTrap
+          clickOutsideDisables={false}
+          disabled={false}
+          noIsolation={true}
+          returnFocus={true}
+          scrollLock={false}
+        >
+          <ForwardRef
+            enabled={true}
+            noIsolation={true}
+            onClickOutside={[Function]}
+            returnFocus={true}
+            scrollLock={false}
+          >
+            <ForwardRef
+              enabled={true}
+              noIsolation={true}
+              onClickOutside={[Function]}
+              returnFocus={true}
+              scrollLock={false}
+              sideCar={[Function]}
+            >
+              <ForwardRef(FocusLockUI)
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "classNames": Object {
+                      "fullWidth": "width-before-scroll-bar",
+                      "zeroRight": "right-scroll-bar-position",
+                    },
+                    "defaultProps": Object {
+                      "enabled": true,
+                      "inert": false,
+                      "removeScrollBar": true,
+                    },
+                    "render": [Function],
+                  }
+                }
+                autoFocus={true}
+                crossFrame={true}
+                disabled={false}
+                lockProps={
+                  Object {
+                    "allowPinchZoom": undefined,
+                    "as": undefined,
+                    "enabled": false,
+                    "inert": undefined,
+                    "onMouseDown": [Function],
+                    "onTouchStart": [Function],
+                    "shards": undefined,
+                    "sideCar": [Function],
+                    "style": undefined,
+                  }
+                }
+                noFocusGuards={false}
+                onActivation={[Function]}
+                onDeactivation={[Function]}
+                persistentFocus={false}
+                returnFocus={true}
+                sideCar={[Function]}
+              >
+                <div
+                  data-focus-guard={true}
+                  key="guard-first"
+                  style={
+                    Object {
+                      "height": "0px",
+                      "left": "1px",
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "fixed",
+                      "top": "1px",
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex={0}
+                />
+                <RequireSideCar
+                  autoFocus={true}
+                  crossFrame={true}
+                  disabled={false}
+                  id={Object {}}
+                  observed={
+                    <div
+                      data-focus-lock-disabled="false"
+                    >
+                      <div
+                        class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+                        role="dialog"
+                        tabindex="-1"
+                      >
+                        <button
+                          aria-label="Close this dialog"
+                          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+                          data-test-subj="euiFlyoutCloseButton"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </button>
+                        <div
+                          class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+                          id="availableIntegrationsArea"
+                          role="main"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div>
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                            >
+                              <div
+                                class="euiFlexItem euiSearchBar__searchHolder"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                                      class="euiFieldSearch euiFieldSearch--fullWidth"
+                                      placeholder="Search..."
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                >
+                                  <div
+                                    class="euiFlexItem"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              class="euiBasicTable"
+                            >
+                              <div>
+                                <div
+                                  class="euiTableHeaderMobile"
+                                >
+                                  <div
+                                    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                  >
+                                    <div
+                                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                                    />
+                                    <div
+                                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                                    />
+                                  </div>
+                                </div>
+                                <table
+                                  class="euiTable euiTable--responsive euiTable--auto"
+                                  id="random_html_id"
+                                  tabindex="-1"
+                                >
+                                  <caption
+                                    class="euiScreenReaderOnly euiTableCaption"
+                                  />
+                                  <thead>
+                                    <tr>
+                                      <th
+                                        class="euiTableHeaderCell"
+                                        data-test-subj="tableHeaderCell_name_0"
+                                        role="columnheader"
+                                        scope="col"
+                                      >
+                                        <span
+                                          class="euiTableCellContent"
+                                        >
+                                          <span
+                                            class="euiTableCellContent__text"
+                                            title="Name"
+                                          >
+                                            Name
+                                          </span>
+                                        </span>
+                                      </th>
+                                      <th
+                                        class="euiTableHeaderCell"
+                                        data-test-subj="tableHeaderCell_description_1"
+                                        role="columnheader"
+                                        scope="col"
+                                      >
+                                        <span
+                                          class="euiTableCellContent"
+                                        >
+                                          <span
+                                            class="euiTableCellContent__text"
+                                            title="Description"
+                                          >
+                                            Description
+                                          </span>
+                                        </span>
+                                      </th>
+                                      <th
+                                        class="euiTableHeaderCell"
+                                        data-test-subj="tableHeaderCell_categories_2"
+                                        role="columnheader"
+                                        scope="col"
+                                      >
+                                        <span
+                                          class="euiTableCellContent"
+                                        >
+                                          <span
+                                            class="euiTableCellContent__text"
+                                            title="Categories"
+                                          >
+                                            Categories
+                                          </span>
+                                        </span>
+                                      </th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    <tr
+                                      class="euiTableRow euiTableRow-isSelectable"
+                                    >
+                                      <td
+                                        class="euiTableRowCell"
+                                      >
+                                        <div
+                                          class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                        >
+                                          Name
+                                        </div>
+                                        <div
+                                          class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                        >
+                                          <a
+                                            class="euiLink euiLink--primary"
+                                            data-test-subj="sample2IntegrationLink"
+                                            href="/app/integrations#/available/sample2"
+                                            rel="noreferrer"
+                                          >
+                                            sample2
+                                          </a>
+                                        </div>
+                                      </td>
+                                      <td
+                                        class="euiTableRowCell"
+                                      >
+                                        <div
+                                          class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                        >
+                                          Description
+                                        </div>
+                                        <div
+                                          class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                        >
+                                          <div
+                                            class="euiText euiText--medium"
+                                            data-test-subj="sample2IntegrationDescription"
+                                          />
+                                        </div>
+                                      </td>
+                                      <td
+                                        class="euiTableRowCell"
+                                      >
+                                        <div
+                                          class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                        >
+                                          Categories
+                                        </div>
+                                        <div
+                                          class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                        >
+                                          <div
+                                            class="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
+                                          >
+                                            <span
+                                              class="euiBadgeGroup__item"
+                                            >
+                                              <span
+                                                class="euiBadge euiBadge--iconLeft"
+                                                style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+                                                title="Flint S3"
+                                              >
+                                                <span
+                                                  class="euiBadge__content"
+                                                >
+                                                  <span
+                                                    class="euiBadge__text"
+                                                  >
+                                                    Flint S3
+                                                  </span>
+                                                </span>
+                                              </span>
+                                            </span>
+                                          </div>
+                                        </div>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </div>
+                              <div>
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                >
+                                  <div
+                                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                                  >
+                                    <div
+                                      class="euiPopover euiPopover--anchorUpRight"
+                                    >
+                                      <div
+                                        class="euiPopover__anchor"
+                                      >
+                                        <button
+                                          class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                          data-test-subj="tablePaginationPopoverButton"
+                                          type="button"
+                                        >
+                                          <span
+                                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              focusable="false"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                            <span
+                                              class="euiButtonEmpty__text"
+                                            >
+                                              Rows per page
+                                              : 
+                                              10
+                                            </span>
+                                          </span>
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                                  >
+                                    <nav
+                                      class="euiPagination"
+                                    >
+                                      <button
+                                        aria-label="Previous page"
+                                        class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled=""
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </button>
+                                      <ul
+                                        class="euiPagination__list"
+                                      >
+                                        <li
+                                          class="euiPagination__item"
+                                        >
+                                          <button
+                                            aria-controls="random_html_id"
+                                            aria-current="true"
+                                            aria-label="Page 1 of 1"
+                                            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                            data-test-subj="pagination-button-0"
+                                            disabled=""
+                                            type="button"
+                                          >
+                                            <span
+                                              class="euiButtonContent euiButtonEmpty__content"
+                                            >
+                                              <span
+                                                class="euiButtonEmpty__text"
+                                              >
+                                                1
+                                              </span>
+                                            </span>
+                                          </button>
+                                        </li>
+                                      </ul>
+                                      <button
+                                        aria-label="Next page"
+                                        class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-next"
+                                        disabled=""
+                                        type="button"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </button>
+                                    </nav>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  }
+                  onActivation={[Function]}
+                  onDeactivation={[Function]}
+                  persistentFocus={false}
+                  returnFocus={[Function]}
+                  shards={Array []}
+                  sideCar={
+                    Object {
+                      "assignMedium": [Function],
+                      "assignSyncMedium": [Function],
+                      "options": Object {
+                        "async": true,
+                        "ssr": false,
+                      },
+                      "read": [Function],
+                      "useMedium": [Function],
+                    }
+                  }
+                >
+                  <SideCar
+                    autoFocus={true}
+                    crossFrame={true}
+                    disabled={false}
+                    id={Object {}}
+                    observed={
+                      <div
+                        data-focus-lock-disabled="false"
+                      >
+                        <div
+                          class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+                          role="dialog"
+                          tabindex="-1"
+                        >
+                          <button
+                            aria-label="Close this dialog"
+                            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+                            data-test-subj="euiFlyoutCloseButton"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                          </button>
+                          <div
+                            class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+                            id="availableIntegrationsArea"
+                            role="main"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div>
+                              <div
+                                class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                              >
+                                <div
+                                  class="euiFlexItem euiSearchBar__searchHolder"
+                                >
+                                  <div
+                                    class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                  >
+                                    <div
+                                      class="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <input
+                                        aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                                        class="euiFieldSearch euiFieldSearch--fullWidth"
+                                        placeholder="Search..."
+                                        type="search"
+                                        value=""
+                                      />
+                                      <div
+                                        class="euiFormControlLayoutIcons"
+                                      >
+                                        <span
+                                          class="euiFormControlLayoutCustomIcon"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height="16"
+                                            role="img"
+                                            viewBox="0 0 16 16"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <div
+                                    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  >
+                                    <div
+                                      class="euiFlexItem"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--l"
+                              />
+                              <div
+                                class="euiBasicTable"
+                              >
+                                <div>
+                                  <div
+                                    class="euiTableHeaderMobile"
+                                  >
+                                    <div
+                                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                    >
+                                      <div
+                                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                                      />
+                                      <div
+                                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                                      />
+                                    </div>
+                                  </div>
+                                  <table
+                                    class="euiTable euiTable--responsive euiTable--auto"
+                                    id="random_html_id"
+                                    tabindex="-1"
+                                  >
+                                    <caption
+                                      class="euiScreenReaderOnly euiTableCaption"
+                                    />
+                                    <thead>
+                                      <tr>
+                                        <th
+                                          class="euiTableHeaderCell"
+                                          data-test-subj="tableHeaderCell_name_0"
+                                          role="columnheader"
+                                          scope="col"
+                                        >
+                                          <span
+                                            class="euiTableCellContent"
+                                          >
+                                            <span
+                                              class="euiTableCellContent__text"
+                                              title="Name"
+                                            >
+                                              Name
+                                            </span>
+                                          </span>
+                                        </th>
+                                        <th
+                                          class="euiTableHeaderCell"
+                                          data-test-subj="tableHeaderCell_description_1"
+                                          role="columnheader"
+                                          scope="col"
+                                        >
+                                          <span
+                                            class="euiTableCellContent"
+                                          >
+                                            <span
+                                              class="euiTableCellContent__text"
+                                              title="Description"
+                                            >
+                                              Description
+                                            </span>
+                                          </span>
+                                        </th>
+                                        <th
+                                          class="euiTableHeaderCell"
+                                          data-test-subj="tableHeaderCell_categories_2"
+                                          role="columnheader"
+                                          scope="col"
+                                        >
+                                          <span
+                                            class="euiTableCellContent"
+                                          >
+                                            <span
+                                              class="euiTableCellContent__text"
+                                              title="Categories"
+                                            >
+                                              Categories
+                                            </span>
+                                          </span>
+                                        </th>
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      <tr
+                                        class="euiTableRow euiTableRow-isSelectable"
+                                      >
+                                        <td
+                                          class="euiTableRowCell"
+                                        >
+                                          <div
+                                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                          >
+                                            Name
+                                          </div>
+                                          <div
+                                            class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                          >
+                                            <a
+                                              class="euiLink euiLink--primary"
+                                              data-test-subj="sample2IntegrationLink"
+                                              href="/app/integrations#/available/sample2"
+                                              rel="noreferrer"
+                                            >
+                                              sample2
+                                            </a>
+                                          </div>
+                                        </td>
+                                        <td
+                                          class="euiTableRowCell"
+                                        >
+                                          <div
+                                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                          >
+                                            Description
+                                          </div>
+                                          <div
+                                            class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                          >
+                                            <div
+                                              class="euiText euiText--medium"
+                                              data-test-subj="sample2IntegrationDescription"
+                                            />
+                                          </div>
+                                        </td>
+                                        <td
+                                          class="euiTableRowCell"
+                                        >
+                                          <div
+                                            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                          >
+                                            Categories
+                                          </div>
+                                          <div
+                                            class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                          >
+                                            <div
+                                              class="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
+                                            >
+                                              <span
+                                                class="euiBadgeGroup__item"
+                                              >
+                                                <span
+                                                  class="euiBadge euiBadge--iconLeft"
+                                                  style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+                                                  title="Flint S3"
+                                                >
+                                                  <span
+                                                    class="euiBadge__content"
+                                                  >
+                                                    <span
+                                                      class="euiBadge__text"
+                                                    >
+                                                      Flint S3
+                                                    </span>
+                                                  </span>
+                                                </span>
+                                              </span>
+                                            </div>
+                                          </div>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </div>
+                                <div>
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                  >
+                                    <div
+                                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                                    >
+                                      <div
+                                        class="euiPopover euiPopover--anchorUpRight"
+                                      >
+                                        <div
+                                          class="euiPopover__anchor"
+                                        >
+                                          <button
+                                            class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                            data-test-subj="tablePaginationPopoverButton"
+                                            type="button"
+                                          >
+                                            <span
+                                              class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                focusable="false"
+                                                height="16"
+                                                role="img"
+                                                viewBox="0 0 16 16"
+                                                width="16"
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                              <span
+                                                class="euiButtonEmpty__text"
+                                              >
+                                                Rows per page
+                                                : 
+                                                10
+                                              </span>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                                    >
+                                      <nav
+                                        class="euiPagination"
+                                      >
+                                        <button
+                                          aria-label="Previous page"
+                                          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled=""
+                                          type="button"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            height="16"
+                                            role="img"
+                                            viewBox="0 0 16 16"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </button>
+                                        <ul
+                                          class="euiPagination__list"
+                                        >
+                                          <li
+                                            class="euiPagination__item"
+                                          >
+                                            <button
+                                              aria-controls="random_html_id"
+                                              aria-current="true"
+                                              aria-label="Page 1 of 1"
+                                              class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              data-test-subj="pagination-button-0"
+                                              disabled=""
+                                              type="button"
+                                            >
+                                              <span
+                                                class="euiButtonContent euiButtonEmpty__content"
+                                              >
+                                                <span
+                                                  class="euiButtonEmpty__text"
+                                                >
+                                                  1
+                                                </span>
+                                              </span>
+                                            </button>
+                                          </li>
+                                        </ul>
+                                        <button
+                                          aria-label="Next page"
+                                          class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled=""
+                                          type="button"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            height="16"
+                                            role="img"
+                                            viewBox="0 0 16 16"
+                                            width="16"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </button>
+                                      </nav>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    }
+                    onActivation={[Function]}
+                    onDeactivation={[Function]}
+                    persistentFocus={false}
+                    returnFocus={[Function]}
+                    shards={Array []}
+                    sideCar={
+                      Object {
+                        "assignMedium": [Function],
+                        "assignSyncMedium": [Function],
+                        "options": Object {
+                          "async": true,
+                          "ssr": false,
+                        },
+                        "read": [Function],
+                        "useMedium": [Function],
+                      }
+                    }
+                  >
+                    <SideEffect(FocusWatcher)
+                      autoFocus={true}
+                      crossFrame={true}
+                      disabled={false}
+                      id={Object {}}
+                      observed={
+                        <div
+                          data-focus-lock-disabled="false"
+                        >
+                          <div
+                            class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+                            role="dialog"
+                            tabindex="-1"
+                          >
+                            <button
+                              aria-label="Close this dialog"
+                              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+                              data-test-subj="euiFlyoutCloseButton"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </button>
+                            <div
+                              class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+                              id="availableIntegrationsArea"
+                              role="main"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--l"
+                              />
+                              <div>
+                                <div
+                                  class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                                >
+                                  <div
+                                    class="euiFlexItem euiSearchBar__searchHolder"
+                                  >
+                                    <div
+                                      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                    >
+                                      <div
+                                        class="euiFormControlLayout__childrenWrapper"
+                                      >
+                                        <input
+                                          aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                                          class="euiFieldSearch euiFieldSearch--fullWidth"
+                                          placeholder="Search..."
+                                          type="search"
+                                          value=""
+                                        />
+                                        <div
+                                          class="euiFormControlLayoutIcons"
+                                        >
+                                          <span
+                                            class="euiFormControlLayoutCustomIcon"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                                  >
+                                    <div
+                                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <div
+                                        class="euiFlexItem"
+                                      />
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="euiSpacer euiSpacer--l"
+                                />
+                                <div
+                                  class="euiBasicTable"
+                                >
+                                  <div>
+                                    <div
+                                      class="euiTableHeaderMobile"
+                                    >
+                                      <div
+                                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                      >
+                                        <div
+                                          class="euiFlexItem euiFlexItem--flexGrowZero"
+                                        />
+                                        <div
+                                          class="euiFlexItem euiFlexItem--flexGrowZero"
+                                        />
+                                      </div>
+                                    </div>
+                                    <table
+                                      class="euiTable euiTable--responsive euiTable--auto"
+                                      id="random_html_id"
+                                      tabindex="-1"
+                                    >
+                                      <caption
+                                        class="euiScreenReaderOnly euiTableCaption"
+                                      />
+                                      <thead>
+                                        <tr>
+                                          <th
+                                            class="euiTableHeaderCell"
+                                            data-test-subj="tableHeaderCell_name_0"
+                                            role="columnheader"
+                                            scope="col"
+                                          >
+                                            <span
+                                              class="euiTableCellContent"
+                                            >
+                                              <span
+                                                class="euiTableCellContent__text"
+                                                title="Name"
+                                              >
+                                                Name
+                                              </span>
+                                            </span>
+                                          </th>
+                                          <th
+                                            class="euiTableHeaderCell"
+                                            data-test-subj="tableHeaderCell_description_1"
+                                            role="columnheader"
+                                            scope="col"
+                                          >
+                                            <span
+                                              class="euiTableCellContent"
+                                            >
+                                              <span
+                                                class="euiTableCellContent__text"
+                                                title="Description"
+                                              >
+                                                Description
+                                              </span>
+                                            </span>
+                                          </th>
+                                          <th
+                                            class="euiTableHeaderCell"
+                                            data-test-subj="tableHeaderCell_categories_2"
+                                            role="columnheader"
+                                            scope="col"
+                                          >
+                                            <span
+                                              class="euiTableCellContent"
+                                            >
+                                              <span
+                                                class="euiTableCellContent__text"
+                                                title="Categories"
+                                              >
+                                                Categories
+                                              </span>
+                                            </span>
+                                          </th>
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        <tr
+                                          class="euiTableRow euiTableRow-isSelectable"
+                                        >
+                                          <td
+                                            class="euiTableRowCell"
+                                          >
+                                            <div
+                                              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                            >
+                                              Name
+                                            </div>
+                                            <div
+                                              class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                            >
+                                              <a
+                                                class="euiLink euiLink--primary"
+                                                data-test-subj="sample2IntegrationLink"
+                                                href="/app/integrations#/available/sample2"
+                                                rel="noreferrer"
+                                              >
+                                                sample2
+                                              </a>
+                                            </div>
+                                          </td>
+                                          <td
+                                            class="euiTableRowCell"
+                                          >
+                                            <div
+                                              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                            >
+                                              Description
+                                            </div>
+                                            <div
+                                              class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                            >
+                                              <div
+                                                class="euiText euiText--medium"
+                                                data-test-subj="sample2IntegrationDescription"
+                                              />
+                                            </div>
+                                          </td>
+                                          <td
+                                            class="euiTableRowCell"
+                                          >
+                                            <div
+                                              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                            >
+                                              Categories
+                                            </div>
+                                            <div
+                                              class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                            >
+                                              <div
+                                                class="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
+                                              >
+                                                <span
+                                                  class="euiBadgeGroup__item"
+                                                >
+                                                  <span
+                                                    class="euiBadge euiBadge--iconLeft"
+                                                    style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+                                                    title="Flint S3"
+                                                  >
+                                                    <span
+                                                      class="euiBadge__content"
+                                                    >
+                                                      <span
+                                                        class="euiBadge__text"
+                                                      >
+                                                        Flint S3
+                                                      </span>
+                                                    </span>
+                                                  </span>
+                                                </span>
+                                              </div>
+                                            </div>
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                  </div>
+                                  <div>
+                                    <div
+                                      class="euiSpacer euiSpacer--m"
+                                    />
+                                    <div
+                                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                    >
+                                      <div
+                                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                                      >
+                                        <div
+                                          class="euiPopover euiPopover--anchorUpRight"
+                                        >
+                                          <div
+                                            class="euiPopover__anchor"
+                                          >
+                                            <button
+                                              class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                              data-test-subj="tablePaginationPopoverButton"
+                                              type="button"
+                                            >
+                                              <span
+                                                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <svg
+                                                  aria-hidden="true"
+                                                  class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                  focusable="false"
+                                                  height="16"
+                                                  role="img"
+                                                  viewBox="0 0 16 16"
+                                                  width="16"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
+                                                <span
+                                                  class="euiButtonEmpty__text"
+                                                >
+                                                  Rows per page
+                                                  : 
+                                                  10
+                                                </span>
+                                              </span>
+                                            </button>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                                      >
+                                        <nav
+                                          class="euiPagination"
+                                        >
+                                          <button
+                                            aria-label="Previous page"
+                                            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                            data-test-subj="pagination-button-previous"
+                                            disabled=""
+                                            type="button"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </button>
+                                          <ul
+                                            class="euiPagination__list"
+                                          >
+                                            <li
+                                              class="euiPagination__item"
+                                            >
+                                              <button
+                                                aria-controls="random_html_id"
+                                                aria-current="true"
+                                                aria-label="Page 1 of 1"
+                                                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                data-test-subj="pagination-button-0"
+                                                disabled=""
+                                                type="button"
+                                              >
+                                                <span
+                                                  class="euiButtonContent euiButtonEmpty__content"
+                                                >
+                                                  <span
+                                                    class="euiButtonEmpty__text"
+                                                  >
+                                                    1
+                                                  </span>
+                                                </span>
+                                              </button>
+                                            </li>
+                                          </ul>
+                                          <button
+                                            aria-label="Next page"
+                                            class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                            data-test-subj="pagination-button-next"
+                                            disabled=""
+                                            type="button"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </button>
+                                        </nav>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      }
+                      onActivation={[Function]}
+                      onDeactivation={[Function]}
+                      persistentFocus={false}
+                      returnFocus={[Function]}
+                      shards={Array []}
+                    >
+                      <FocusWatcher
+                        autoFocus={true}
+                        crossFrame={true}
+                        disabled={false}
+                        id={Object {}}
+                        observed={
+                          <div
+                            data-focus-lock-disabled="false"
+                          >
+                            <div
+                              class="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+                              role="dialog"
+                              tabindex="-1"
+                            >
+                              <button
+                                aria-label="Close this dialog"
+                                class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+                                data-test-subj="euiFlyoutCloseButton"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </button>
+                              <div
+                                class="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+                                id="availableIntegrationsArea"
+                                role="main"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--l"
+                                />
+                                <div>
+                                  <div
+                                    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                                  >
+                                    <div
+                                      class="euiFlexItem euiSearchBar__searchHolder"
+                                    >
+                                      <div
+                                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                      >
+                                        <div
+                                          class="euiFormControlLayout__childrenWrapper"
+                                        >
+                                          <input
+                                            aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                                            class="euiFieldSearch euiFieldSearch--fullWidth"
+                                            placeholder="Search..."
+                                            type="search"
+                                            value=""
+                                          />
+                                          <div
+                                            class="euiFormControlLayoutIcons"
+                                          >
+                                            <span
+                                              class="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                                focusable="false"
+                                                height="16"
+                                                role="img"
+                                                viewBox="0 0 16 16"
+                                                width="16"
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                />
+                                              </svg>
+                                            </span>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                                    >
+                                      <div
+                                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <div
+                                          class="euiFlexItem"
+                                        />
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="euiSpacer euiSpacer--l"
+                                  />
+                                  <div
+                                    class="euiBasicTable"
+                                  >
+                                    <div>
+                                      <div
+                                        class="euiTableHeaderMobile"
+                                      >
+                                        <div
+                                          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                        >
+                                          <div
+                                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                                          />
+                                          <div
+                                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                                          />
+                                        </div>
+                                      </div>
+                                      <table
+                                        class="euiTable euiTable--responsive euiTable--auto"
+                                        id="random_html_id"
+                                        tabindex="-1"
+                                      >
+                                        <caption
+                                          class="euiScreenReaderOnly euiTableCaption"
+                                        />
+                                        <thead>
+                                          <tr>
+                                            <th
+                                              class="euiTableHeaderCell"
+                                              data-test-subj="tableHeaderCell_name_0"
+                                              role="columnheader"
+                                              scope="col"
+                                            >
+                                              <span
+                                                class="euiTableCellContent"
+                                              >
+                                                <span
+                                                  class="euiTableCellContent__text"
+                                                  title="Name"
+                                                >
+                                                  Name
+                                                </span>
+                                              </span>
+                                            </th>
+                                            <th
+                                              class="euiTableHeaderCell"
+                                              data-test-subj="tableHeaderCell_description_1"
+                                              role="columnheader"
+                                              scope="col"
+                                            >
+                                              <span
+                                                class="euiTableCellContent"
+                                              >
+                                                <span
+                                                  class="euiTableCellContent__text"
+                                                  title="Description"
+                                                >
+                                                  Description
+                                                </span>
+                                              </span>
+                                            </th>
+                                            <th
+                                              class="euiTableHeaderCell"
+                                              data-test-subj="tableHeaderCell_categories_2"
+                                              role="columnheader"
+                                              scope="col"
+                                            >
+                                              <span
+                                                class="euiTableCellContent"
+                                              >
+                                                <span
+                                                  class="euiTableCellContent__text"
+                                                  title="Categories"
+                                                >
+                                                  Categories
+                                                </span>
+                                              </span>
+                                            </th>
+                                          </tr>
+                                        </thead>
+                                        <tbody>
+                                          <tr
+                                            class="euiTableRow euiTableRow-isSelectable"
+                                          >
+                                            <td
+                                              class="euiTableRowCell"
+                                            >
+                                              <div
+                                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                              >
+                                                Name
+                                              </div>
+                                              <div
+                                                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                              >
+                                                <a
+                                                  class="euiLink euiLink--primary"
+                                                  data-test-subj="sample2IntegrationLink"
+                                                  href="/app/integrations#/available/sample2"
+                                                  rel="noreferrer"
+                                                >
+                                                  sample2
+                                                </a>
+                                              </div>
+                                            </td>
+                                            <td
+                                              class="euiTableRowCell"
+                                            >
+                                              <div
+                                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                              >
+                                                Description
+                                              </div>
+                                              <div
+                                                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                              >
+                                                <div
+                                                  class="euiText euiText--medium"
+                                                  data-test-subj="sample2IntegrationDescription"
+                                                />
+                                              </div>
+                                            </td>
+                                            <td
+                                              class="euiTableRowCell"
+                                            >
+                                              <div
+                                                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                              >
+                                                Categories
+                                              </div>
+                                              <div
+                                                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                              >
+                                                <div
+                                                  class="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
+                                                >
+                                                  <span
+                                                    class="euiBadgeGroup__item"
+                                                  >
+                                                    <span
+                                                      class="euiBadge euiBadge--iconLeft"
+                                                      style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0);"
+                                                      title="Flint S3"
+                                                    >
+                                                      <span
+                                                        class="euiBadge__content"
+                                                      >
+                                                        <span
+                                                          class="euiBadge__text"
+                                                        >
+                                                          Flint S3
+                                                        </span>
+                                                      </span>
+                                                    </span>
+                                                  </span>
+                                                </div>
+                                              </div>
+                                            </td>
+                                          </tr>
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                    <div>
+                                      <div
+                                        class="euiSpacer euiSpacer--m"
+                                      />
+                                      <div
+                                        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                      >
+                                        <div
+                                          class="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <div
+                                            class="euiPopover euiPopover--anchorUpRight"
+                                          >
+                                            <div
+                                              class="euiPopover__anchor"
+                                            >
+                                              <button
+                                                class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                                data-test-subj="tablePaginationPopoverButton"
+                                                type="button"
+                                              >
+                                                <span
+                                                  class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                >
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height="16"
+                                                    role="img"
+                                                    viewBox="0 0 16 16"
+                                                    width="16"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                  <span
+                                                    class="euiButtonEmpty__text"
+                                                  >
+                                                    Rows per page
+                                                    : 
+                                                    10
+                                                  </span>
+                                                </span>
+                                              </button>
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <nav
+                                            class="euiPagination"
+                                          >
+                                            <button
+                                              aria-label="Previous page"
+                                              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                              data-test-subj="pagination-button-previous"
+                                              disabled=""
+                                              type="button"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height="16"
+                                                role="img"
+                                                viewBox="0 0 16 16"
+                                                width="16"
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </button>
+                                            <ul
+                                              class="euiPagination__list"
+                                            >
+                                              <li
+                                                class="euiPagination__item"
+                                              >
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current="true"
+                                                  aria-label="Page 1 of 1"
+                                                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled=""
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="euiButtonContent euiButtonEmpty__content"
+                                                  >
+                                                    <span
+                                                      class="euiButtonEmpty__text"
+                                                    >
+                                                      1
+                                                    </span>
+                                                  </span>
+                                                </button>
+                                              </li>
+                                            </ul>
+                                            <button
+                                              aria-label="Next page"
+                                              class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                              data-test-subj="pagination-button-next"
+                                              disabled=""
+                                              type="button"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height="16"
+                                                role="img"
+                                                viewBox="0 0 16 16"
+                                                width="16"
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </button>
+                                          </nav>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        }
+                        onActivation={[Function]}
+                        onDeactivation={[Function]}
+                        persistentFocus={false}
+                        returnFocus={[Function]}
+                        shards={Array []}
+                      />
+                    </SideEffect(FocusWatcher)>
+                  </SideCar>
+                </RequireSideCar>
+                <ForwardRef
+                  data-focus-lock-disabled={false}
+                  enabled={false}
+                  inert={false}
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchStart={[Function]}
+                  removeScrollBar={true}
+                  sideCar={[Function]}
+                >
+                  <div
+                    data-focus-lock-disabled={false}
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onMouseDown={[Function]}
+                    onScrollCapture={[Function]}
+                    onTouchMoveCapture={[Function]}
+                    onTouchStart={[Function]}
+                    onWheelCapture={[Function]}
+                  >
+                    <EuiOutsideClickDetector
+                      isDisabled={true}
+                      onOutsideClick={[Function]}
+                    >
+                      <div
+                        className="euiFlyout euiFlyout--medium euiFlyout--paddingLarge"
+                        onMouseDown={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        role="dialog"
+                        tabIndex={-1}
+                      >
+                        <EuiI18n
+                          default="Close this dialog"
+                          token="euiFlyout.closeAriaLabel"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Close this dialog"
+                            className="euiFlyout__closeButton euiFlyout__closeButton--inside"
+                            color="text"
+                            data-test-subj="euiFlyoutCloseButton"
+                            display="empty"
+                            iconType="cross"
+                            onClick={[Function]}
+                          >
+                            <button
+                              aria-label="Close this dialog"
+                              className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall euiFlyout__closeButton euiFlyout__closeButton--inside"
+                              data-test-subj="euiFlyoutCloseButton"
+                              disabled={false}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                color="inherit"
+                                size="m"
+                                type="cross"
+                              >
+                                <EuiIconBeaker
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </EuiIconBeaker>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiI18n>
+                        <AvailableIntegrationsTable
+                          data={
+                            Object {
+                              "hits": Array [
+                                Object {
+                                  "assets": Array [
+                                    Object {
+                                      "extension": "ndjson",
+                                      "name": "sample",
+                                      "type": "savedObjectBundle",
+                                      "version": "1.0.1",
+                                    },
+                                  ],
+                                  "components": Array [
+                                    Object {
+                                      "name": "logs",
+                                      "version": "1.0.0",
+                                    },
+                                  ],
+                                  "labels": Array [
+                                    "Flint S3",
+                                  ],
+                                  "license": "Apache-2.0",
+                                  "name": "sample2",
+                                  "type": "logs",
+                                  "version": "2.0.0",
+                                  "workflows": Array [
+                                    Object {
+                                      "description": "This is a test workflow.",
+                                      "enabled_by_default": true,
+                                      "label": "Workflow 1",
+                                      "name": "workflow1",
+                                    },
+                                  ],
+                                },
+                              ],
+                            }
+                          }
+                          isCardView={true}
+                          loading={false}
+                        >
+                          <EuiPageContent
+                            id="availableIntegrationsArea"
+                          >
+                            <EuiPanel
+                              className="euiPageContent"
+                              id="availableIntegrationsArea"
+                              paddingSize="l"
+                              role="main"
+                            >
+                              <div
+                                className="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+                                id="availableIntegrationsArea"
+                                role="main"
+                              >
+                                <EuiSpacer>
+                                  <div
+                                    className="euiSpacer euiSpacer--l"
+                                  />
+                                </EuiSpacer>
+                                <EuiInMemoryTable
+                                  allowNeutralSort={false}
+                                  columns={
+                                    Array [
+                                      Object {
+                                        "field": "name",
+                                        "name": "Name",
+                                        "render": [Function],
+                                        "sortable": true,
+                                        "truncateText": true,
+                                      },
+                                      Object {
+                                        "field": "description",
+                                        "name": "Description",
+                                        "render": [Function],
+                                        "sortable": true,
+                                        "truncateText": true,
+                                      },
+                                      Object {
+                                        "field": "categories",
+                                        "name": "Categories",
+                                        "render": [Function],
+                                        "sortable": true,
+                                        "truncateText": true,
+                                      },
+                                    ]
+                                  }
+                                  isSelectable={true}
+                                  itemId="id"
+                                  items={
+                                    Array [
+                                      Object {
+                                        "assets": Array [
+                                          Object {
+                                            "extension": "ndjson",
+                                            "name": "sample",
+                                            "type": "savedObjectBundle",
+                                            "version": "1.0.1",
+                                          },
+                                        ],
+                                        "components": Array [
+                                          Object {
+                                            "name": "logs",
+                                            "version": "1.0.0",
+                                          },
+                                        ],
+                                        "labels": Array [
+                                          "Flint S3",
+                                        ],
+                                        "license": "Apache-2.0",
+                                        "name": "sample2",
+                                        "type": "logs",
+                                        "version": "2.0.0",
+                                        "workflows": Array [
+                                          Object {
+                                            "description": "This is a test workflow.",
+                                            "enabled_by_default": true,
+                                            "label": "Workflow 1",
+                                            "name": "workflow1",
+                                          },
+                                        ],
+                                      },
+                                    ]
+                                  }
+                                  loading={false}
+                                  pagination={
+                                    Object {
+                                      "initialPageSize": 10,
+                                      "pageSizeOptions": Array [
+                                        5,
+                                        10,
+                                        15,
+                                      ],
+                                    }
+                                  }
+                                  responsive={true}
+                                  search={
+                                    Object {
+                                      "box": Object {
+                                        "incremental": true,
+                                      },
+                                      "toolsRight": <EuiFlexGroup>
+                                        <EuiFlexItem />
+                                      </EuiFlexGroup>,
+                                    }
+                                  }
+                                  tableLayout="auto"
+                                >
+                                  <div>
+                                    <EuiSearchBar
+                                      box={
+                                        Object {
+                                          "incremental": true,
+                                        }
+                                      }
+                                      onChange={[Function]}
+                                      toolsRight={
+                                        <EuiFlexGroup>
+                                          <EuiFlexItem />
+                                        </EuiFlexGroup>
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        alignItems="center"
+                                        gutterSize="m"
+                                        wrap={true}
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                                        >
+                                          <EuiFlexItem
+                                            className="euiSearchBar__searchHolder"
+                                            grow={true}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiSearchBar__searchHolder"
+                                            >
+                                              <EuiSearchBox
+                                                incremental={true}
+                                                isInvalid={false}
+                                                onSearch={[Function]}
+                                                placeholder="Search..."
+                                                query=""
+                                              >
+                                                <EuiFieldSearch
+                                                  aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                                                  compressed={false}
+                                                  defaultValue=""
+                                                  fullWidth={true}
+                                                  incremental={true}
+                                                  inputRef={[Function]}
+                                                  isClearable={true}
+                                                  isInvalid={false}
+                                                  isLoading={false}
+                                                  onSearch={[Function]}
+                                                  placeholder="Search..."
+                                                >
+                                                  <EuiFormControlLayout
+                                                    compressed={false}
+                                                    fullWidth={true}
+                                                    icon="search"
+                                                    isLoading={false}
+                                                  >
+                                                    <div
+                                                      className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                                    >
+                                                      <div
+                                                        className="euiFormControlLayout__childrenWrapper"
+                                                      >
+                                                        <EuiValidatableControl
+                                                          isInvalid={false}
+                                                        >
+                                                          <input
+                                                            aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                                                            className="euiFieldSearch euiFieldSearch--fullWidth"
+                                                            defaultValue=""
+                                                            onKeyUp={[Function]}
+                                                            placeholder="Search..."
+                                                            type="search"
+                                                          />
+                                                        </EuiValidatableControl>
+                                                        <EuiFormControlLayoutIcons
+                                                          compressed={false}
+                                                          icon="search"
+                                                          isLoading={false}
+                                                        >
+                                                          <div
+                                                            className="euiFormControlLayoutIcons"
+                                                          >
+                                                            <EuiFormControlLayoutCustomIcon
+                                                              size="m"
+                                                              type="search"
+                                                            >
+                                                              <span
+                                                                className="euiFormControlLayoutCustomIcon"
+                                                              >
+                                                                <EuiIcon
+                                                                  aria-hidden="true"
+                                                                  className="euiFormControlLayoutCustomIcon__icon"
+                                                                  size="m"
+                                                                  type="search"
+                                                                >
+                                                                  <EuiIconSearch
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                                                    focusable="false"
+                                                                    role="img"
+                                                                    style={null}
+                                                                  >
+                                                                    <svg
+                                                                      aria-hidden={true}
+                                                                      className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                                                      focusable="false"
+                                                                      height={16}
+                                                                      role="img"
+                                                                      style={null}
+                                                                      viewBox="0 0 16 16"
+                                                                      width={16}
+                                                                      xmlns="http://www.w3.org/2000/svg"
+                                                                    >
+                                                                      <path
+                                                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                                      />
+                                                                    </svg>
+                                                                  </EuiIconSearch>
+                                                                </EuiIcon>
+                                                              </span>
+                                                            </EuiFormControlLayoutCustomIcon>
+                                                          </div>
+                                                        </EuiFormControlLayoutIcons>
+                                                      </div>
+                                                    </div>
+                                                  </EuiFormControlLayout>
+                                                </EuiFieldSearch>
+                                              </EuiSearchBox>
+                                            </div>
+                                          </EuiFlexItem>
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiFlexGroup>
+                                                <div
+                                                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                                >
+                                                  <EuiFlexItem>
+                                                    <div
+                                                      className="euiFlexItem"
+                                                    />
+                                                  </EuiFlexItem>
+                                                </div>
+                                              </EuiFlexGroup>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </EuiSearchBar>
+                                    <EuiSpacer
+                                      size="l"
+                                    >
+                                      <div
+                                        className="euiSpacer euiSpacer--l"
+                                      />
+                                    </EuiSpacer>
+                                    <EuiBasicTable
+                                      columns={
+                                        Array [
+                                          Object {
+                                            "field": "name",
+                                            "name": "Name",
+                                            "render": [Function],
+                                            "sortable": true,
+                                            "truncateText": true,
+                                          },
+                                          Object {
+                                            "field": "description",
+                                            "name": "Description",
+                                            "render": [Function],
+                                            "sortable": true,
+                                            "truncateText": true,
+                                          },
+                                          Object {
+                                            "field": "categories",
+                                            "name": "Categories",
+                                            "render": [Function],
+                                            "sortable": true,
+                                            "truncateText": true,
+                                          },
+                                        ]
+                                      }
+                                      isSelectable={true}
+                                      itemId="id"
+                                      items={
+                                        Array [
+                                          Object {
+                                            "assets": Array [
+                                              Object {
+                                                "extension": "ndjson",
+                                                "name": "sample",
+                                                "type": "savedObjectBundle",
+                                                "version": "1.0.1",
+                                              },
+                                            ],
+                                            "components": Array [
+                                              Object {
+                                                "name": "logs",
+                                                "version": "1.0.0",
+                                              },
+                                            ],
+                                            "labels": Array [
+                                              "Flint S3",
+                                            ],
+                                            "license": "Apache-2.0",
+                                            "name": "sample2",
+                                            "type": "logs",
+                                            "version": "2.0.0",
+                                            "workflows": Array [
+                                              Object {
+                                                "description": "This is a test workflow.",
+                                                "enabled_by_default": true,
+                                                "label": "Workflow 1",
+                                                "name": "workflow1",
+                                              },
+                                            ],
+                                          },
+                                        ]
+                                      }
+                                      loading={false}
+                                      noItemsMessage="No items found"
+                                      onChange={[Function]}
+                                      pagination={
+                                        Object {
+                                          "hidePerPageOptions": undefined,
+                                          "pageIndex": 0,
+                                          "pageSize": 10,
+                                          "pageSizeOptions": Array [
+                                            5,
+                                            10,
+                                            15,
+                                          ],
+                                          "totalItemCount": 1,
+                                        }
+                                      }
+                                      responsive={true}
+                                      tableLayout="auto"
+                                    >
+                                      <div
+                                        className="euiBasicTable"
+                                      >
+                                        <div>
+                                          <EuiTableHeaderMobile>
+                                            <div
+                                              className="euiTableHeaderMobile"
+                                            >
+                                              <EuiFlexGroup
+                                                alignItems="baseline"
+                                                justifyContent="spaceBetween"
+                                                responsive={false}
+                                              >
+                                                <div
+                                                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                                >
+                                                  <EuiFlexItem
+                                                    grow={false}
+                                                  >
+                                                    <div
+                                                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                                                    />
+                                                  </EuiFlexItem>
+                                                  <EuiFlexItem
+                                                    grow={false}
+                                                  >
+                                                    <div
+                                                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                                                    />
+                                                  </EuiFlexItem>
+                                                </div>
+                                              </EuiFlexGroup>
+                                            </div>
+                                          </EuiTableHeaderMobile>
+                                          <EuiTable
+                                            id="random_html_id"
+                                            responsive={true}
+                                            tableLayout="auto"
+                                          >
+                                            <table
+                                              className="euiTable euiTable--responsive euiTable--auto"
+                                              id="random_html_id"
+                                              tabIndex={-1}
+                                            >
+                                              <EuiScreenReaderOnly>
+                                                <caption
+                                                  className="euiScreenReaderOnly euiTableCaption"
+                                                >
+                                                  <EuiDelayRender
+                                                    delay={500}
+                                                  />
+                                                </caption>
+                                              </EuiScreenReaderOnly>
+                                              <EuiTableHeader>
+                                                <thead>
+                                                  <tr>
+                                                    <EuiTableHeaderCell
+                                                      align="left"
+                                                      data-test-subj="tableHeaderCell_name_0"
+                                                      key="_data_h_name_0"
+                                                    >
+                                                      <th
+                                                        className="euiTableHeaderCell"
+                                                        data-test-subj="tableHeaderCell_name_0"
+                                                        role="columnheader"
+                                                        scope="col"
+                                                        style={
+                                                          Object {
+                                                            "width": undefined,
+                                                          }
+                                                        }
+                                                      >
+                                                        <CellContents
+                                                          className="euiTableCellContent"
+                                                          showSortMsg={false}
+                                                        >
+                                                          <span
+                                                            className="euiTableCellContent"
+                                                          >
+                                                            <EuiInnerText>
+                                                              <EuiI18n
+                                                                default="{innerText}; {description}"
+                                                                token="euiTableHeaderCell.titleTextWithDesc"
+                                                                values={
+                                                                  Object {
+                                                                    "description": undefined,
+                                                                    "innerText": "Name",
+                                                                  }
+                                                                }
+                                                              >
+                                                                <span
+                                                                  className="euiTableCellContent__text"
+                                                                  title="Name"
+                                                                >
+                                                                  Name
+                                                                </span>
+                                                              </EuiI18n>
+                                                            </EuiInnerText>
+                                                          </span>
+                                                        </CellContents>
+                                                      </th>
+                                                    </EuiTableHeaderCell>
+                                                    <EuiTableHeaderCell
+                                                      align="left"
+                                                      data-test-subj="tableHeaderCell_description_1"
+                                                      key="_data_h_description_1"
+                                                    >
+                                                      <th
+                                                        className="euiTableHeaderCell"
+                                                        data-test-subj="tableHeaderCell_description_1"
+                                                        role="columnheader"
+                                                        scope="col"
+                                                        style={
+                                                          Object {
+                                                            "width": undefined,
+                                                          }
+                                                        }
+                                                      >
+                                                        <CellContents
+                                                          className="euiTableCellContent"
+                                                          showSortMsg={false}
+                                                        >
+                                                          <span
+                                                            className="euiTableCellContent"
+                                                          >
+                                                            <EuiInnerText>
+                                                              <EuiI18n
+                                                                default="{innerText}; {description}"
+                                                                token="euiTableHeaderCell.titleTextWithDesc"
+                                                                values={
+                                                                  Object {
+                                                                    "description": undefined,
+                                                                    "innerText": "Description",
+                                                                  }
+                                                                }
+                                                              >
+                                                                <span
+                                                                  className="euiTableCellContent__text"
+                                                                  title="Description"
+                                                                >
+                                                                  Description
+                                                                </span>
+                                                              </EuiI18n>
+                                                            </EuiInnerText>
+                                                          </span>
+                                                        </CellContents>
+                                                      </th>
+                                                    </EuiTableHeaderCell>
+                                                    <EuiTableHeaderCell
+                                                      align="left"
+                                                      data-test-subj="tableHeaderCell_categories_2"
+                                                      key="_data_h_categories_2"
+                                                    >
+                                                      <th
+                                                        className="euiTableHeaderCell"
+                                                        data-test-subj="tableHeaderCell_categories_2"
+                                                        role="columnheader"
+                                                        scope="col"
+                                                        style={
+                                                          Object {
+                                                            "width": undefined,
+                                                          }
+                                                        }
+                                                      >
+                                                        <CellContents
+                                                          className="euiTableCellContent"
+                                                          showSortMsg={false}
+                                                        >
+                                                          <span
+                                                            className="euiTableCellContent"
+                                                          >
+                                                            <EuiInnerText>
+                                                              <EuiI18n
+                                                                default="{innerText}; {description}"
+                                                                token="euiTableHeaderCell.titleTextWithDesc"
+                                                                values={
+                                                                  Object {
+                                                                    "description": undefined,
+                                                                    "innerText": "Categories",
+                                                                  }
+                                                                }
+                                                              >
+                                                                <span
+                                                                  className="euiTableCellContent__text"
+                                                                  title="Categories"
+                                                                >
+                                                                  Categories
+                                                                </span>
+                                                              </EuiI18n>
+                                                            </EuiInnerText>
+                                                          </span>
+                                                        </CellContents>
+                                                      </th>
+                                                    </EuiTableHeaderCell>
+                                                  </tr>
+                                                </thead>
+                                              </EuiTableHeader>
+                                              <EuiTableBody
+                                                bodyRef={[Function]}
+                                              >
+                                                <tbody>
+                                                  <EuiTableRow
+                                                    isSelectable={true}
+                                                    isSelected={false}
+                                                  >
+                                                    <tr
+                                                      className="euiTableRow euiTableRow-isSelectable"
+                                                    >
+                                                      <EuiTableRowCell
+                                                        align="left"
+                                                        key="_data_column_name_0_0"
+                                                        mobileOptions={
+                                                          Object {
+                                                            "header": "Name",
+                                                            "render": undefined,
+                                                          }
+                                                        }
+                                                        setScopeRow={false}
+                                                        textOnly={false}
+                                                        truncateText={true}
+                                                      >
+                                                        <td
+                                                          className="euiTableRowCell"
+                                                          style={
+                                                            Object {
+                                                              "width": undefined,
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                                          >
+                                                            Name
+                                                          </div>
+                                                          <div
+                                                            className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                                          >
+                                                            <EuiLink
+                                                              className=""
+                                                              data-test-subj="sample2IntegrationLink"
+                                                              href="/app/integrations#/available/sample2"
+                                                              key=".0"
+                                                            >
+                                                              <a
+                                                                className="euiLink euiLink--primary"
+                                                                data-test-subj="sample2IntegrationLink"
+                                                                href="/app/integrations#/available/sample2"
+                                                                rel="noreferrer"
+                                                              >
+                                                                sample2
+                                                              </a>
+                                                            </EuiLink>
+                                                          </div>
+                                                        </td>
+                                                      </EuiTableRowCell>
+                                                      <EuiTableRowCell
+                                                        align="left"
+                                                        key="_data_column_description_0_1"
+                                                        mobileOptions={
+                                                          Object {
+                                                            "header": "Description",
+                                                            "render": undefined,
+                                                          }
+                                                        }
+                                                        setScopeRow={false}
+                                                        textOnly={false}
+                                                        truncateText={true}
+                                                      >
+                                                        <td
+                                                          className="euiTableRowCell"
+                                                          style={
+                                                            Object {
+                                                              "width": undefined,
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                                          >
+                                                            Description
+                                                          </div>
+                                                          <div
+                                                            className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                                          >
+                                                            <EuiText
+                                                              className=""
+                                                              data-test-subj="sample2IntegrationDescription"
+                                                              key=".0"
+                                                            >
+                                                              <div
+                                                                className="euiText euiText--medium"
+                                                                data-test-subj="sample2IntegrationDescription"
+                                                              />
+                                                            </EuiText>
+                                                          </div>
+                                                        </td>
+                                                      </EuiTableRowCell>
+                                                      <EuiTableRowCell
+                                                        align="left"
+                                                        key="_data_column_categories_0_2"
+                                                        mobileOptions={
+                                                          Object {
+                                                            "header": "Categories",
+                                                            "render": undefined,
+                                                          }
+                                                        }
+                                                        setScopeRow={false}
+                                                        textOnly={false}
+                                                        truncateText={true}
+                                                      >
+                                                        <td
+                                                          className="euiTableRowCell"
+                                                          style={
+                                                            Object {
+                                                              "width": undefined,
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                                          >
+                                                            Categories
+                                                          </div>
+                                                          <div
+                                                            className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                                          >
+                                                            <EuiBadgeGroup
+                                                              className=""
+                                                              key=".0"
+                                                            >
+                                                              <div
+                                                                className="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
+                                                              >
+                                                                <span
+                                                                  className="euiBadgeGroup__item"
+                                                                  key=".0"
+                                                                >
+                                                                  <EuiBadge>
+                                                                    <EuiInnerText>
+                                                                      <span
+                                                                        className="euiBadge euiBadge--iconLeft"
+                                                                        style={
+                                                                          Object {
+                                                                            "backgroundColor": "#d3dae6",
+                                                                            "color": "#000",
+                                                                          }
+                                                                        }
+                                                                        title="Flint S3"
+                                                                      >
+                                                                        <span
+                                                                          className="euiBadge__content"
+                                                                        >
+                                                                          <span
+                                                                            className="euiBadge__text"
+                                                                          >
+                                                                            Flint S3
+                                                                          </span>
+                                                                        </span>
+                                                                      </span>
+                                                                    </EuiInnerText>
+                                                                  </EuiBadge>
+                                                                </span>
+                                                              </div>
+                                                            </EuiBadgeGroup>
+                                                          </div>
+                                                        </td>
+                                                      </EuiTableRowCell>
+                                                    </tr>
+                                                  </EuiTableRow>
+                                                </tbody>
+                                              </EuiTableBody>
+                                            </table>
+                                          </EuiTable>
+                                        </div>
+                                        <PaginationBar
+                                          aria-controls="random_html_id"
+                                          onPageChange={[Function]}
+                                          onPageSizeChange={[Function]}
+                                          pagination={
+                                            Object {
+                                              "hidePerPageOptions": undefined,
+                                              "pageIndex": 0,
+                                              "pageSize": 10,
+                                              "pageSizeOptions": Array [
+                                                5,
+                                                10,
+                                                15,
+                                              ],
+                                              "totalItemCount": 1,
+                                            }
+                                          }
+                                        >
+                                          <div>
+                                            <EuiSpacer
+                                              size="m"
+                                            >
+                                              <div
+                                                className="euiSpacer euiSpacer--m"
+                                              />
+                                            </EuiSpacer>
+                                            <EuiTablePagination
+                                              activePage={0}
+                                              aria-controls="random_html_id"
+                                              itemsPerPage={10}
+                                              itemsPerPageOptions={
+                                                Array [
+                                                  5,
+                                                  10,
+                                                  15,
+                                                ]
+                                              }
+                                              onChangeItemsPerPage={[Function]}
+                                              onChangePage={[Function]}
+                                              pageCount={1}
+                                            >
+                                              <EuiFlexGroup
+                                                alignItems="center"
+                                                justifyContent="spaceBetween"
+                                                responsive={false}
+                                              >
+                                                <div
+                                                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                                                >
+                                                  <EuiFlexItem
+                                                    grow={false}
+                                                  >
+                                                    <div
+                                                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                                                    >
+                                                      <EuiPopover
+                                                        anchorPosition="upRight"
+                                                        button={
+                                                          <EuiButtonEmpty
+                                                            color="text"
+                                                            data-test-subj="tablePaginationPopoverButton"
+                                                            iconSide="right"
+                                                            iconType="arrowDown"
+                                                            onClick={[Function]}
+                                                            size="xs"
+                                                          >
+                                                            <EuiI18n
+                                                              default="Rows per page"
+                                                              token="euiTablePagination.rowsPerPage"
+                                                            />
+                                                            : 
+                                                            10
+                                                          </EuiButtonEmpty>
+                                                        }
+                                                        closePopover={[Function]}
+                                                        display="inlineBlock"
+                                                        hasArrow={true}
+                                                        isOpen={false}
+                                                        ownFocus={true}
+                                                        panelPaddingSize="none"
+                                                      >
+                                                        <div
+                                                          className="euiPopover euiPopover--anchorUpRight"
+                                                        >
+                                                          <div
+                                                            className="euiPopover__anchor"
+                                                          >
+                                                            <EuiButtonEmpty
+                                                              color="text"
+                                                              data-test-subj="tablePaginationPopoverButton"
+                                                              iconSide="right"
+                                                              iconType="arrowDown"
+                                                              onClick={[Function]}
+                                                              size="xs"
+                                                            >
+                                                              <button
+                                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                                                data-test-subj="tablePaginationPopoverButton"
+                                                                disabled={false}
+                                                                onClick={[Function]}
+                                                                type="button"
+                                                              >
+                                                                <EuiButtonContent
+                                                                  className="euiButtonEmpty__content"
+                                                                  iconSide="right"
+                                                                  iconSize="s"
+                                                                  iconType="arrowDown"
+                                                                  textProps={
+                                                                    Object {
+                                                                      "className": "euiButtonEmpty__text",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <span
+                                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                                  >
+                                                                    <EuiIcon
+                                                                      className="euiButtonContent__icon"
+                                                                      color="inherit"
+                                                                      size="s"
+                                                                      type="arrowDown"
+                                                                    >
+                                                                      <EuiIconBeaker
+                                                                        aria-hidden={true}
+                                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                        focusable="false"
+                                                                        role="img"
+                                                                        style={null}
+                                                                      >
+                                                                        <svg
+                                                                          aria-hidden={true}
+                                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                          focusable="false"
+                                                                          height={16}
+                                                                          role="img"
+                                                                          style={null}
+                                                                          viewBox="0 0 16 16"
+                                                                          width={16}
+                                                                          xmlns="http://www.w3.org/2000/svg"
+                                                                        >
+                                                                          <path
+                                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                          />
+                                                                        </svg>
+                                                                      </EuiIconBeaker>
+                                                                    </EuiIcon>
+                                                                    <span
+                                                                      className="euiButtonEmpty__text"
+                                                                    >
+                                                                      <EuiI18n
+                                                                        default="Rows per page"
+                                                                        token="euiTablePagination.rowsPerPage"
+                                                                      >
+                                                                        Rows per page
+                                                                      </EuiI18n>
+                                                                      : 
+                                                                      10
+                                                                    </span>
+                                                                  </span>
+                                                                </EuiButtonContent>
+                                                              </button>
+                                                            </EuiButtonEmpty>
+                                                          </div>
+                                                        </div>
+                                                      </EuiPopover>
+                                                    </div>
+                                                  </EuiFlexItem>
+                                                  <EuiFlexItem
+                                                    grow={false}
+                                                  >
+                                                    <div
+                                                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                                                    >
+                                                      <EuiPagination
+                                                        activePage={0}
+                                                        aria-controls="random_html_id"
+                                                        onPageClick={[Function]}
+                                                        pageCount={1}
+                                                      >
+                                                        <nav
+                                                          className="euiPagination"
+                                                        >
+                                                          <EuiI18n
+                                                            default="Previous page, {page}"
+                                                            token="euiPagination.previousPage"
+                                                            values={
+                                                              Object {
+                                                                "page": 0,
+                                                              }
+                                                            }
+                                                          >
+                                                            <EuiI18n
+                                                              default="Previous page"
+                                                              token="euiPagination.disabledPreviousPage"
+                                                            >
+                                                              <EuiButtonIcon
+                                                                aria-label="Previous page"
+                                                                color="text"
+                                                                data-test-subj="pagination-button-previous"
+                                                                disabled={true}
+                                                                iconType="arrowLeft"
+                                                                onClick={[Function]}
+                                                              >
+                                                                <button
+                                                                  aria-label="Previous page"
+                                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                                                  data-test-subj="pagination-button-previous"
+                                                                  disabled={true}
+                                                                  onClick={[Function]}
+                                                                  type="button"
+                                                                >
+                                                                  <EuiIcon
+                                                                    aria-hidden="true"
+                                                                    className="euiButtonIcon__icon"
+                                                                    color="inherit"
+                                                                    size="m"
+                                                                    type="arrowLeft"
+                                                                  >
+                                                                    <EuiIconBeaker
+                                                                      aria-hidden={true}
+                                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                                      focusable="false"
+                                                                      role="img"
+                                                                      style={null}
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                                        focusable="false"
+                                                                        height={16}
+                                                                        role="img"
+                                                                        style={null}
+                                                                        viewBox="0 0 16 16"
+                                                                        width={16}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                        />
+                                                                      </svg>
+                                                                    </EuiIconBeaker>
+                                                                  </EuiIcon>
+                                                                </button>
+                                                              </EuiButtonIcon>
+                                                            </EuiI18n>
+                                                          </EuiI18n>
+                                                          <ul
+                                                            className="euiPagination__list"
+                                                          >
+                                                            <PaginationButton
+                                                              key="0"
+                                                              pageIndex={0}
+                                                            >
+                                                              <li
+                                                                className="euiPagination__item"
+                                                              >
+                                                                <EuiPaginationButton
+                                                                  aria-controls="random_html_id"
+                                                                  hideOnMobile={true}
+                                                                  isActive={true}
+                                                                  onClick={[Function]}
+                                                                  pageIndex={0}
+                                                                  totalPages={1}
+                                                                >
+                                                                  <EuiI18n
+                                                                    default="Page {page} of {totalPages}"
+                                                                    token="euiPaginationButton.longPageString"
+                                                                    values={
+                                                                      Object {
+                                                                        "page": 1,
+                                                                        "totalPages": 1,
+                                                                      }
+                                                                    }
+                                                                  >
+                                                                    <EuiI18n
+                                                                      default="Page {page}"
+                                                                      token="euiPaginationButton.shortPageString"
+                                                                      values={
+                                                                        Object {
+                                                                          "page": 1,
+                                                                        }
+                                                                      }
+                                                                    >
+                                                                      <EuiButtonEmpty
+                                                                        aria-controls="random_html_id"
+                                                                        aria-current={true}
+                                                                        aria-label="Page 1 of 1"
+                                                                        className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                                        color="text"
+                                                                        data-test-subj="pagination-button-0"
+                                                                        href="#random_html_id"
+                                                                        isDisabled={true}
+                                                                        onClick={[Function]}
+                                                                        size="s"
+                                                                      >
+                                                                        <button
+                                                                          aria-controls="random_html_id"
+                                                                          aria-current={true}
+                                                                          aria-label="Page 1 of 1"
+                                                                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                                          data-test-subj="pagination-button-0"
+                                                                          disabled={true}
+                                                                          onClick={[Function]}
+                                                                          type="button"
+                                                                        >
+                                                                          <EuiButtonContent
+                                                                            className="euiButtonEmpty__content"
+                                                                            iconSide="left"
+                                                                            iconSize="m"
+                                                                            textProps={
+                                                                              Object {
+                                                                                "className": "euiButtonEmpty__text",
+                                                                              }
+                                                                            }
+                                                                          >
+                                                                            <span
+                                                                              className="euiButtonContent euiButtonEmpty__content"
+                                                                            >
+                                                                              <span
+                                                                                className="euiButtonEmpty__text"
+                                                                              >
+                                                                                1
+                                                                              </span>
+                                                                            </span>
+                                                                          </EuiButtonContent>
+                                                                        </button>
+                                                                      </EuiButtonEmpty>
+                                                                    </EuiI18n>
+                                                                  </EuiI18n>
+                                                                </EuiPaginationButton>
+                                                              </li>
+                                                            </PaginationButton>
+                                                          </ul>
+                                                          <EuiI18n
+                                                            default="Next page, {page}"
+                                                            token="euiPagination.nextPage"
+                                                            values={
+                                                              Object {
+                                                                "page": 2,
+                                                              }
+                                                            }
+                                                          >
+                                                            <EuiI18n
+                                                              default="Next page"
+                                                              token="euiPagination.disabledNextPage"
+                                                            >
+                                                              <EuiButtonIcon
+                                                                aria-label="Next page"
+                                                                color="text"
+                                                                data-test-subj="pagination-button-next"
+                                                                disabled={true}
+                                                                iconType="arrowRight"
+                                                                onClick={[Function]}
+                                                              >
+                                                                <button
+                                                                  aria-label="Next page"
+                                                                  className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                                                  data-test-subj="pagination-button-next"
+                                                                  disabled={true}
+                                                                  onClick={[Function]}
+                                                                  type="button"
+                                                                >
+                                                                  <EuiIcon
+                                                                    aria-hidden="true"
+                                                                    className="euiButtonIcon__icon"
+                                                                    color="inherit"
+                                                                    size="m"
+                                                                    type="arrowRight"
+                                                                  >
+                                                                    <EuiIconBeaker
+                                                                      aria-hidden={true}
+                                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                                      focusable="false"
+                                                                      role="img"
+                                                                      style={null}
+                                                                    >
+                                                                      <svg
+                                                                        aria-hidden={true}
+                                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                                        focusable="false"
+                                                                        height={16}
+                                                                        role="img"
+                                                                        style={null}
+                                                                        viewBox="0 0 16 16"
+                                                                        width={16}
+                                                                        xmlns="http://www.w3.org/2000/svg"
+                                                                      >
+                                                                        <path
+                                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                        />
+                                                                      </svg>
+                                                                    </EuiIconBeaker>
+                                                                  </EuiIcon>
+                                                                </button>
+                                                              </EuiButtonIcon>
+                                                            </EuiI18n>
+                                                          </EuiI18n>
+                                                        </nav>
+                                                      </EuiPagination>
+                                                    </div>
+                                                  </EuiFlexItem>
+                                                </div>
+                                              </EuiFlexGroup>
+                                            </EuiTablePagination>
+                                          </div>
+                                        </PaginationBar>
+                                      </div>
+                                    </EuiBasicTable>
+                                  </div>
+                                </EuiInMemoryTable>
+                              </div>
+                            </EuiPanel>
+                          </EuiPageContent>
+                        </AvailableIntegrationsTable>
+                      </div>
+                    </EuiOutsideClickDetector>
+                  </div>
+                </ForwardRef>
+                <div
+                  data-focus-guard={true}
+                  style={
+                    Object {
+                      "height": "0px",
+                      "left": "1px",
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "fixed",
+                      "top": "1px",
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex={0}
+                />
+              </ForwardRef(FocusLockUI)>
+              <RequireSideCar
+                noIsolation={true}
+                onClickOutside={[Function]}
+                setLockProps={[Function]}
+                sideCar={
+                  Object {
+                    "assignMedium": [Function],
+                    "assignSyncMedium": [Function],
+                    "options": Object {
+                      "async": true,
+                      "ssr": false,
+                    },
+                    "read": [Function],
+                    "useMedium": [Function],
+                  }
+                }
+              >
+                <SideCar
+                  noIsolation={true}
+                  onClickOutside={[Function]}
+                  setLockProps={[Function]}
+                  sideCar={
+                    Object {
+                      "assignMedium": [Function],
+                      "assignSyncMedium": [Function],
+                      "options": Object {
+                        "async": true,
+                        "ssr": false,
+                      },
+                      "read": [Function],
+                      "useMedium": [Function],
+                    }
+                  }
+                >
+                  <Effect
+                    noIsolation={true}
+                    onClickOutside={[Function]}
+                    setLockProps={[Function]}
+                  >
+                    <Component>
+                      <Sheet
+                        styles="
+ [data-focus-on-hidden] {
+   pointer-events: none !important;
+ }
+"
+                      />
+                    </Component>
+                  </Effect>
+                </SideCar>
+              </RequireSideCar>
+            </ForwardRef>
+          </ForwardRef>
+        </EuiFocusTrap>
+      </Portal>
+    </EuiOverlayMask>
+  </EuiFlyout>
+</InstallIntegrationFlyout>
+`;

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -104,49 +104,51 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
               <div
                 className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiButton
-                  href="/app/integrations#available"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    element="a"
+                <AddIntegrationButton>
+                  <EuiButton
                     href="/app/integrations#available"
-                    isDisabled={false}
-                    rel="noreferrer"
                   >
-                    <a
-                      className="euiButton euiButton--primary"
-                      disabled={false}
+                    <EuiButtonDisplay
+                      baseClassName="euiButton"
+                      element="a"
                       href="/app/integrations#available"
+                      isDisabled={false}
                       rel="noreferrer"
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
+                      <a
+                        className="euiButton euiButton--primary"
+                        disabled={false}
+                        href="/app/integrations#available"
+                        rel="noreferrer"
+                        style={
                           Object {
-                            "className": "euiButton__text",
+                            "minWidth": undefined,
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text",
+                            }
+                          }
                         >
                           <span
-                            className="euiButton__text"
+                            className="euiButtonContent euiButton__content"
                           >
-                            Add Integrations
+                            <span
+                              className="euiButton__text"
+                            >
+                              Add Integrations
+                            </span>
                           </span>
-                        </span>
-                      </EuiButtonContent>
-                    </a>
-                  </EuiButtonDisplay>
-                </EuiButton>
+                        </EuiButtonContent>
+                      </a>
+                    </EuiButtonDisplay>
+                  </EuiButton>
+                </AddIntegrationButton>
               </div>
             </EuiFlexItem>
           </div>
@@ -315,51 +317,55 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
             <div
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <EuiButton
+              <AddIntegrationButton
                 fill={true}
-                href="/app/integrations#available"
               >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  element="a"
+                <EuiButton
                   fill={true}
                   href="/app/integrations#available"
-                  isDisabled={false}
-                  rel="noreferrer"
                 >
-                  <a
-                    className="euiButton euiButton--primary euiButton--fill"
-                    disabled={false}
+                  <EuiButtonDisplay
+                    baseClassName="euiButton"
+                    element="a"
+                    fill={true}
                     href="/app/integrations#available"
+                    isDisabled={false}
                     rel="noreferrer"
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
                   >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      textProps={
+                    <a
+                      className="euiButton euiButton--primary euiButton--fill"
+                      disabled={false}
+                      href="/app/integrations#available"
+                      rel="noreferrer"
+                      style={
                         Object {
-                          "className": "euiButton__text",
+                          "minWidth": undefined,
                         }
                       }
                     >
-                      <span
-                        className="euiButtonContent euiButton__content"
+                      <EuiButtonContent
+                        className="euiButton__content"
+                        iconSide="left"
+                        textProps={
+                          Object {
+                            "className": "euiButton__text",
+                          }
+                        }
                       >
                         <span
-                          className="euiButton__text"
+                          className="euiButtonContent euiButton__content"
                         >
-                          Add Integration
+                          <span
+                            className="euiButton__text"
+                          >
+                            Add Integrations
+                          </span>
                         </span>
-                      </span>
-                    </EuiButtonContent>
-                  </a>
-                </EuiButtonDisplay>
-              </EuiButton>
+                      </EuiButtonContent>
+                    </a>
+                  </EuiButtonDisplay>
+                </EuiButton>
+              </AddIntegrationButton>
             </div>
           </EuiFlexItem>
         </div>

--- a/public/components/datasources/components/__tests__/installed_integrations_table.test.tsx
+++ b/public/components/datasources/components/__tests__/installed_integrations_table.test.tsx
@@ -6,8 +6,14 @@
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
-import { InstalledIntegrationsTable } from '../manage/integrations/installed_integrations_table';
-import { TEST_INTEGRATION_SEARCH_RESULTS } from '../../../../../test/constants';
+import {
+  InstallIntegrationFlyout,
+  InstalledIntegrationsTable,
+} from '../manage/integrations/installed_integrations_table';
+import {
+  TEST_AVAILABLE_INTEGRATIONS,
+  TEST_INTEGRATION_SEARCH_RESULTS,
+} from '../../../../../test/constants';
 
 describe('Installed Integrations Table test', () => {
   configure({ adapter: new Adapter() });
@@ -25,6 +31,19 @@ describe('Installed Integrations Table test', () => {
 
   it('Renders the empty installed integrations table', async () => {
     const wrapper = mount(<InstalledIntegrationsTable integrations={[]} datasourceType="S3GLUE" />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('Renders the installed integrations table flyout', async () => {
+    const wrapper = mount(
+      <InstallIntegrationFlyout
+        availableIntegrations={TEST_AVAILABLE_INTEGRATIONS}
+        setAvailableIntegrations={() => {}}
+        closeFlyout={() => {}}
+        datasourceType="S3GLUE"
+      />
+    );
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/public/components/datasources/components/__tests__/installed_integrations_table.test.tsx
+++ b/public/components/datasources/components/__tests__/installed_integrations_table.test.tsx
@@ -14,14 +14,17 @@ describe('Installed Integrations Table test', () => {
 
   it('Renders the installed integrations table', async () => {
     const wrapper = mount(
-      <InstalledIntegrationsTable integrations={TEST_INTEGRATION_SEARCH_RESULTS} />
+      <InstalledIntegrationsTable
+        integrations={TEST_INTEGRATION_SEARCH_RESULTS}
+        datasourceType="S3GLUE"
+      />
     );
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('Renders the empty installed integrations table', async () => {
-    const wrapper = mount(<InstalledIntegrationsTable integrations={[]} />);
+    const wrapper = mount(<InstalledIntegrationsTable integrations={[]} datasourceType="S3GLUE" />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -228,7 +228,12 @@ export const DataConnection = (props: any) => {
       id: 'installed_integrations',
       name: 'Installed Integrations',
       disabled: false,
-      content: <InstalledIntegrationsTable integrations={dataSourceIntegrations} />,
+      content: (
+        <InstalledIntegrationsTable
+          integrations={dataSourceIntegrations}
+          datasourceType={datasourceDetails.connector}
+        />
+      ),
     },
     {
       id: 'access_control',

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -121,7 +121,7 @@ const NoInstalledIntegrations = ({ toggleFlyout }: { toggleFlyout: () => void })
   );
 };
 
-const InstallIntegrationFlyout = ({
+export const InstallIntegrationFlyout = ({
   availableIntegrations,
   setAvailableIntegrations,
   closeFlyout,

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -75,6 +75,14 @@ const instanceToTableEntry = (
   };
 };
 
+const AddIntegrationButton = ({ fill }: { fill?: boolean }) => {
+  return (
+    <EuiButton href={safeBasePathLink('/app/integrations#available')} fill={fill}>
+      Add Integrations
+    </EuiButton>
+  );
+};
+
 const NoInstalledIntegrations = () => {
   return (
     <EuiFlexGroup direction="column" alignItems="center" gutterSize="xs">
@@ -92,9 +100,7 @@ const NoInstalledIntegrations = () => {
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton href={safeBasePathLink('/app/integrations#available')}>
-          Add Integrations
-        </EuiButton>
+        <AddIntegrationButton />
       </EuiFlexItem>
     </EuiFlexGroup>
   );
@@ -127,9 +133,7 @@ export const InstalledIntegrationsTable = ({
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton fill={true} href={safeBasePathLink('/app/integrations#available')}>
-            Add Integration
-          </EuiButton>
+          <AddIntegrationButton fill={true} />
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer />

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -20,7 +20,8 @@ import {
 } from '@elastic/eui';
 import _ from 'lodash';
 import { IntegrationHealthBadge } from '../../../../integrations/components/added_integration';
-import { coreRefs, basePathLink } from '../../../../../framework/core_refs';
+import { coreRefs } from '../../../../../framework/core_refs';
+import { basePathLink } from '../../../../../../common/utils/shared';
 import { AvailableIntegrationsTable } from '../../../../integrations/components/available_integration_table';
 import { INTEGRATIONS_BASE } from '../../../../../../common/constants/shared';
 import { AvailableIntegrationsList } from '../../../../integrations/components/available_integration_overview_page';

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -59,7 +59,6 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
   http={[MockFunction]}
   isCardView={false}
   query=""
-  renderCategoryFilters={[Function]}
   setCardView={[Function]}
   setQuery={[Function]}
 >

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
   http={[MockFunction]}
   isCardView={false}
   query=""
-  renderCateogryFilters={[Function]}
+  renderCategoryFilters={[Function]}
   setCardView={[Function]}
   setQuery={[Function]}
 >

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -1013,13 +1013,13 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                     <EuiLink
                                       className=""
                                       data-test-subj="nginxIntegrationLink"
-                                      href="#/available/nginx"
+                                      href="/app/integrations#/available/nginx"
                                       key=".0"
                                     >
                                       <a
                                         className="euiLink euiLink--primary"
                                         data-test-subj="nginxIntegrationLink"
-                                        href="#/available/nginx"
+                                        href="/app/integrations#/available/nginx"
                                         rel="noreferrer"
                                       >
                                         NginX Dashboard

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
   }
   isCardView={false}
   loading={false}
-  renderCateogryFilters={[Function]}
+  renderCategoryFilters={[Function]}
   setCardView={[Function]}
 >
   <EuiPageContent

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -58,7 +58,6 @@ exports[`Available Integration Table View Test Renders nginx integration table v
   }
   isCardView={false}
   loading={false}
-  renderCategoryFilters={[Function]}
   setCardView={[Function]}
 >
   <EuiPageContent

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -1061,11 +1061,13 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
 <SetupIntegrationForm
   config={
     Object {
+      "checkpointLocation": "",
       "connectionDataSource": "ss4o_logs-nginx-test",
       "connectionLocation": "",
       "connectionTableName": "",
       "connectionType": "s3",
       "displayName": "Test Instance Name",
+      "enabledWorkflows": Array [],
     }
   }
   integration={
@@ -2016,6 +2018,7 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
               onChange={[Function]}
               onFocus={[Function]}
               placeholder="s3://"
+              value=""
             >
               <EuiFormControlLayout
                 fullWidth={false}
@@ -2039,6 +2042,7 @@ exports[`Integration Setup Page Renders the S3 connector form as expected 1`] = 
                         onFocus={[Function]}
                         placeholder="s3://"
                         type="text"
+                        value=""
                       />
                     </EuiValidatableControl>
                     <EuiFormControlLayoutIcons />
@@ -2310,11 +2314,13 @@ exports[`Integration Setup Page Renders the S3 connector form without workflows 
 <SetupIntegrationForm
   config={
     Object {
+      "checkpointLocation": "",
       "connectionDataSource": "ss4o_logs-nginx-test",
       "connectionLocation": "",
       "connectionTableName": "",
       "connectionType": "s3",
       "displayName": "Test Instance Name",
+      "enabledWorkflows": Array [],
     }
   }
   integration={
@@ -3258,6 +3264,7 @@ exports[`Integration Setup Page Renders the S3 connector form without workflows 
               onChange={[Function]}
               onFocus={[Function]}
               placeholder="s3://"
+              value=""
             >
               <EuiFormControlLayout
                 fullWidth={false}
@@ -3281,6 +3288,7 @@ exports[`Integration Setup Page Renders the S3 connector form without workflows 
                         onFocus={[Function]}
                         placeholder="s3://"
                         type="text"
+                        value=""
                       />
                     </EuiValidatableControl>
                     <EuiFormControlLayoutIcons />
@@ -3322,11 +3330,13 @@ exports[`Integration Setup Page Renders the index form as expected 1`] = `
 <SetupIntegrationForm
   config={
     Object {
+      "checkpointLocation": "",
       "connectionDataSource": "ss4o_logs-nginx-test",
       "connectionLocation": "",
       "connectionTableName": "",
       "connectionType": "index",
       "displayName": "Test Instance Name",
+      "enabledWorkflows": Array [],
     }
   }
   integration={

--- a/public/components/integrations/components/__tests__/testing_constants.ts
+++ b/public/components/integrations/components/__tests__/testing_constants.ts
@@ -88,7 +88,7 @@ export const availableTableViewData: AvailableIntegrationsTableProps = {
     ],
   },
   loading: false,
-  renderCateogryFilters: () => {
+  renderCategoryFilters: () => {
     return (null as unknown) as { type: string; props: object; key: string };
   },
   isCardView: false,

--- a/public/components/integrations/components/__tests__/testing_constants.ts
+++ b/public/components/integrations/components/__tests__/testing_constants.ts
@@ -41,7 +41,7 @@ export const availableCardViewData: AvailableIntegrationsCardViewProps = {
       },
     ],
   },
-  renderCateogryFilters: () => (null as unknown) as { type: string; props: object; key: string },
+  renderCategoryFilters: () => (null as unknown) as { type: string; props: object; key: string },
   isCardView: false,
   setCardView: () => {},
   query: '',

--- a/public/components/integrations/components/__tests__/testing_constants.ts
+++ b/public/components/integrations/components/__tests__/testing_constants.ts
@@ -41,7 +41,6 @@ export const availableCardViewData: AvailableIntegrationsCardViewProps = {
       },
     ],
   },
-  renderCategoryFilters: () => (null as unknown) as { type: string; props: object; key: string },
   isCardView: false,
   setCardView: () => {},
   query: '',
@@ -88,9 +87,6 @@ export const availableTableViewData: AvailableIntegrationsTableProps = {
     ],
   },
   loading: false,
-  renderCategoryFilters: () => {
-    return (null as unknown) as { type: string; props: object; key: string };
-  },
   isCardView: false,
   setCardView: () => {},
 };

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -75,7 +75,11 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
                   description={i.description}
                   data-test-subj={`integration_card_${i.name.toLowerCase()}`}
                   titleElement="span"
-                  onClick={() => (window.location.hash = `#/available/${i.name}`)}
+                  onClick={() =>
+                    (window.location.hash = http.basePath.prepend(
+                      `/app/integrations#/available/${i.name}`
+                    ))
+                  }
                   footer={badges(i.labels ?? [])}
                 />
               </EuiFlexItem>

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -101,7 +101,7 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
             }}
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>{props.renderCateogryFilters()}</EuiFlexItem>
+        <EuiFlexItem grow={false}>{props.renderCategoryFilters()}</EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonGroup
             legend="Text align"

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -101,7 +101,7 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
             }}
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>{props.renderCategoryFilters()}</EuiFlexItem>
+        <EuiFlexItem grow={false}>{props.filters}</EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonGroup
             legend="Text align"

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -30,7 +30,7 @@ export interface AvailableIntegrationsTableProps {
   data: AvailableIntegrationsList;
   isCardView: boolean;
   setCardView?: (input: boolean) => void;
-  filters: React.JSX.Element;
+  filters?: React.JSX.Element;
 }
 
 export interface AvailableIntegrationsList {
@@ -44,7 +44,7 @@ export interface AvailableIntegrationsCardViewProps {
   query: string;
   setQuery: (input: string) => void;
   http: HttpStart;
-  filters: React.JSX.Element;
+  filters?: React.JSX.Element;
 }
 
 export interface CategoryFiltersProps {

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -27,8 +27,8 @@ export interface AvailableIntegrationsTableProps {
   loading: boolean;
   data: AvailableIntegrationsList;
   isCardView: boolean;
-  setCardView: (input: boolean) => void;
-  renderCateogryFilters: () => React.JSX.Element;
+  setCardView?: (input: boolean) => void;
+  renderCategoryFilters: () => React.JSX.Element;
 }
 
 export interface AvailableIntegrationsList {
@@ -167,7 +167,7 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
               },
               isCardView,
               setCardView,
-              renderCateogryFilters,
+              renderCategoryFilters: renderCateogryFilters,
             })}
       </EuiPageBody>
     </EuiPage>

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -23,12 +23,14 @@ import { INTEGRATIONS_BASE } from '../../../../common/constants/shared';
 import { AvailableIntegrationOverviewPageProps } from './integration_types';
 import { HttpStart } from '../../../../../../src/core/public';
 
+type CategoryItems = Array<{ name: string; checked: boolean }>;
+
 export interface AvailableIntegrationsTableProps {
   loading: boolean;
   data: AvailableIntegrationsList;
   isCardView: boolean;
   setCardView?: (input: boolean) => void;
-  renderCategoryFilters: () => React.JSX.Element;
+  filters: React.JSX.Element;
 }
 
 export interface AvailableIntegrationsList {
@@ -41,17 +43,16 @@ export interface AvailableIntegrationsCardViewProps {
   setCardView: (input: boolean) => void;
   query: string;
   setQuery: (input: string) => void;
-  renderCategoryFilters: () => React.JSX.Element;
   http: HttpStart;
+  filters: React.JSX.Element;
 }
 
-export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOverviewPageProps) {
-  const { chrome, http } = props;
+export interface CategoryFiltersProps {
+  items: CategoryItems;
+  setItems: React.Dispatch<CategoryItems>;
+}
 
-  const [query, setQuery] = useState('');
-  const [isCardView, setCardView] = useState(true);
-  const [data, setData] = useState<AvailableIntegrationsList>({ hits: [] });
-
+export const CategoryFilters = ({ items, setItems }: CategoryFiltersProps) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const onButtonClick = () => {
@@ -62,18 +63,14 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
     setIsPopoverOpen(false);
   };
 
-  const [items, setItems] = useState([] as Array<{ name: string; checked: boolean }>);
-
-  function updateItem(index: number) {
+  const updateItem = (index: number) => {
     if (!items[index]) {
       return;
     }
     const newItems = [...items];
     newItems[index].checked = !items[index].checked;
     setItems(newItems);
-  }
-
-  const helper = items.filter((item) => item.checked).map((x) => x.name);
+  };
 
   const button = (
     <EuiFilterButton
@@ -87,6 +84,45 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
       Categories
     </EuiFilterButton>
   );
+
+  return (
+    <EuiFilterGroup>
+      <EuiPopover
+        id="popoverExampleMultiSelect"
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        panelPaddingSize="none"
+      >
+        <EuiPopoverTitle paddingSize="s">
+          <EuiFieldSearch compressed />
+        </EuiPopoverTitle>
+        <div className="ouiFilterSelect__items">
+          {items.map((item, index) => (
+            <EuiFilterSelectItem
+              checked={item.checked ? 'on' : undefined}
+              key={index}
+              onClick={() => updateItem(index)}
+            >
+              {item.name}
+            </EuiFilterSelectItem>
+          ))}
+        </div>
+      </EuiPopover>
+    </EuiFilterGroup>
+  );
+};
+
+export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOverviewPageProps) {
+  const { chrome, http } = props;
+
+  const [query, setQuery] = useState('');
+  const [isCardView, setCardView] = useState(true);
+  const [data, setData] = useState<AvailableIntegrationsList>({ hits: [] });
+
+  const [items, setItems] = useState([] as Array<{ name: string; checked: boolean }>);
+
+  const helper = items.filter((item) => item.checked).map((x) => x.name);
 
   useEffect(() => {
     chrome.setBreadcrumbs([
@@ -115,60 +151,36 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
     });
   }
 
-  const renderCategoryFilters = () => {
-    return (
-      <EuiFilterGroup>
-        <EuiPopover
-          id="popoverExampleMultiSelect"
-          button={button}
-          isOpen={isPopoverOpen}
-          closePopover={closePopover}
-          panelPaddingSize="none"
-        >
-          <EuiPopoverTitle paddingSize="s">
-            <EuiFieldSearch compressed />
-          </EuiPopoverTitle>
-          <div className="ouiFilterSelect__items">
-            {items.map((item, index) => (
-              <EuiFilterSelectItem
-                checked={item.checked ? 'on' : undefined}
-                key={index}
-                onClick={() => updateItem(index)}
-              >
-                {item.name}
-              </EuiFilterSelectItem>
-            ))}
-          </div>
-        </EuiPopover>
-      </EuiFilterGroup>
-    );
-  };
+  const filteredHits = data.hits.filter((hit) => helper.every((tag) => hit.labels?.includes(tag)));
+  const filters = <CategoryFilters items={items} setItems={setItems} />;
 
   return (
     <EuiPage>
       <EuiPageBody>
-        {IntegrationHeader()}
-        {isCardView
-          ? AvailableIntegrationsCardView({
-              data: {
-                hits: data.hits.filter((hit) => helper.every((tag) => hit.labels?.includes(tag))),
-              },
-              isCardView,
-              setCardView,
-              query,
-              setQuery,
-              renderCategoryFilters,
-              http,
-            })
-          : AvailableIntegrationsTable({
-              loading: false,
-              data: {
-                hits: data.hits.filter((hit) => helper.every((tag) => hit.labels?.includes(tag))),
-              },
-              isCardView,
-              setCardView,
-              renderCategoryFilters,
-            })}
+        <IntegrationHeader />
+        {isCardView ? (
+          <AvailableIntegrationsCardView
+            data={{
+              hits: filteredHits,
+            }}
+            isCardView={isCardView}
+            setCardView={setCardView}
+            query={query}
+            setQuery={setQuery}
+            http={http}
+            filters={filters}
+          />
+        ) : (
+          <AvailableIntegrationsTable
+            loading={false}
+            data={{
+              hits: filteredHits,
+            }}
+            isCardView={isCardView}
+            setCardView={setCardView}
+            filters={filters}
+          />
+        )}
       </EuiPageBody>
     </EuiPage>
   );

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -41,7 +41,7 @@ export interface AvailableIntegrationsCardViewProps {
   setCardView: (input: boolean) => void;
   query: string;
   setQuery: (input: string) => void;
-  renderCateogryFilters: () => React.JSX.Element;
+  renderCategoryFilters: () => React.JSX.Element;
   http: HttpStart;
 }
 
@@ -115,7 +115,7 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
     });
   }
 
-  const renderCateogryFilters = () => {
+  const renderCategoryFilters = () => {
     return (
       <EuiFilterGroup>
         <EuiPopover
@@ -157,7 +157,7 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
               setCardView,
               query,
               setQuery,
-              renderCateogryFilters,
+              renderCategoryFilters,
               http,
             })
           : AvailableIntegrationsTable({
@@ -167,7 +167,7 @@ export function AvailableIntegrationOverviewPage(props: AvailableIntegrationOver
               },
               isCardView,
               setCardView,
-              renderCategoryFilters: renderCateogryFilters,
+              renderCategoryFilters,
             })}
       </EuiPageBody>
     </EuiPage>

--- a/public/components/integrations/components/available_integration_table.tsx
+++ b/public/components/integrations/components/available_integration_table.tsx
@@ -16,6 +16,7 @@ import {
 } from '@elastic/eui';
 import _ from 'lodash';
 import React, { useState } from 'react';
+import { basePathLink } from '../../../../public/framework/core_refs';
 import { AvailableIntegrationsTableProps } from './available_integration_overview_page';
 import { badges } from './integration_category_badge_group';
 
@@ -58,7 +59,7 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
       render: (value, record) => (
         <EuiLink
           data-test-subj={`${record.name}IntegrationLink`}
-          href={`#/available/${record.name}`}
+          href={basePathLink(`/app/integrations#/available/${record.name}`)}
         >
           {_.truncate(record.displayName || record.name, { length: 100 })}
         </EuiLink>

--- a/public/components/integrations/components/available_integration_table.tsx
+++ b/public/components/integrations/components/available_integration_table.tsx
@@ -38,6 +38,9 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
   const [toggleIconIdSelected, setToggleIconIdSelected] = useState('0');
 
   const onChangeIcons = (optionId: string) => {
+    if (!props.setCardView) {
+      return;
+    }
     setToggleIconIdSelected(optionId);
     if (optionId === '0') {
       props.setCardView(false);
@@ -84,16 +87,18 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
   const renderToggle = () => {
     return (
       <EuiFlexGroup>
-        <EuiFlexItem>{props.renderCateogryFilters()}</EuiFlexItem>
-        <EuiFlexItem>
-          <EuiButtonGroup
-            legend="Text align"
-            options={toggleButtonsIcons}
-            idSelected={toggleIconIdSelected}
-            onChange={(id) => onChangeIcons(id)}
-            isIconOnly
-          />
-        </EuiFlexItem>
+        <EuiFlexItem>{props.renderCategoryFilters()}</EuiFlexItem>
+        {props.setCardView ? (
+          <EuiFlexItem>
+            <EuiButtonGroup
+              legend="Text align"
+              options={toggleButtonsIcons}
+              idSelected={toggleIconIdSelected}
+              onChange={(id) => onChangeIcons(id)}
+              isIconOnly
+            />
+          </EuiFlexItem>
+        ) : null}
       </EuiFlexGroup>
     );
   };

--- a/public/components/integrations/components/available_integration_table.tsx
+++ b/public/components/integrations/components/available_integration_table.tsx
@@ -87,7 +87,7 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
   const renderToggle = () => {
     return (
       <EuiFlexGroup>
-        <EuiFlexItem>{props.renderCategoryFilters()}</EuiFlexItem>
+        <EuiFlexItem>{props.filters}</EuiFlexItem>
         {props.setCardView ? (
           <EuiFlexItem>
             <EuiButtonGroup

--- a/public/components/integrations/components/available_integration_table.tsx
+++ b/public/components/integrations/components/available_integration_table.tsx
@@ -16,7 +16,7 @@ import {
 } from '@elastic/eui';
 import _ from 'lodash';
 import React, { useState } from 'react';
-import { basePathLink } from '../../../../public/framework/core_refs';
+import { basePathLink } from '../../../../common/utils/shared';
 import { AvailableIntegrationsTableProps } from './available_integration_overview_page';
 import { badges } from './integration_category_badge_group';
 

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -14,7 +14,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import _ from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { OPENSEARCH_DOCUMENTATION_URL } from '../../../../common/constants/integrations';
 
 export function IntegrationHeader() {

--- a/public/framework/core_refs.ts
+++ b/public/framework/core_refs.ts
@@ -41,19 +41,3 @@ class CoreRefs {
 }
 
 export const coreRefs = CoreRefs.Instance;
-
-/**
- * Safely prepend the `basePath` from `coreRefs` to the given link.
- * If `coreRefs.http.basePath` exists (always true in normal operation), prepend it to the link.
- * If it doesn't exist (usually during unit testing), return the link as-is.
- *
- * @param link The link to prepend with `coreRefs.http.basePath`.
- * @returns The link with the prepended `basePath` if it exists, otherwise the unmodified link.
- */
-export const basePathLink = (link: string): string => {
-  if (coreRefs.http?.basePath) {
-    return coreRefs.http.basePath.prepend(link);
-  } else {
-    return link;
-  }
-};

--- a/public/framework/core_refs.ts
+++ b/public/framework/core_refs.ts
@@ -41,3 +41,19 @@ class CoreRefs {
 }
 
 export const coreRefs = CoreRefs.Instance;
+
+/**
+ * Safely prepend the `basePath` from `coreRefs` to the given link.
+ * If `coreRefs.http.basePath` exists (always true in normal operation), prepend it to the link.
+ * If it doesn't exist (usually during unit testing), return the link as-is.
+ *
+ * @param link The link to prepend with `coreRefs.http.basePath`.
+ * @returns The link with the prepended `basePath` if it exists, otherwise the unmodified link.
+ */
+export const basePathLink = (link: string): string => {
+  if (coreRefs.http?.basePath) {
+    return coreRefs.http.basePath.prepend(link);
+  } else {
+    return link;
+  }
+};

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AvailableIntegrationsList } from 'public/components/integrations/components/available_integration_overview_page';
 import { IntegrationSetupInputs } from 'public/components/integrations/components/setup_integration';
 
 export const TEST_SPAN_RESPONSE = {
@@ -566,6 +567,8 @@ export const TEST_INTEGRATION_SETUP_INPUTS: IntegrationSetupInputs = {
   connectionDataSource: 'ss4o_logs-nginx-test',
   connectionTableName: '',
   connectionLocation: '',
+  checkpointLocation: '',
+  enabledWorkflows: [],
 };
 
 // TODO fill in the rest of the fields
@@ -595,6 +598,13 @@ export const TEST_INTEGRATION_CONFIG: IntegrationConfig = {
       extension: 'ndjson',
       type: 'savedObjectBundle',
     },
+  ],
+};
+
+export const TEST_AVAILABLE_INTEGRATIONS: AvailableIntegrationsList = {
+  hits: [
+    TEST_INTEGRATION_CONFIG,
+    { ...TEST_INTEGRATION_CONFIG, name: 'sample2', labels: ['Flint S3'] },
   ],
 };
 


### PR DESCRIPTION
### Description
As part of in-progress work for allowing integration installation in a Flyout, this PR does the first step of copying the integration browsing component to the Flyout, with some additional refactoring for the changes (mostly around how category filters are rendered).

<img width="1453" alt="image" src="https://github.com/opensearch-project/dashboards-observability/assets/31739405/ae08bc9a-98ec-46d7-9848-8da0196e7c51">

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
