### PR TITLE
Integrations: Update delete modal to support custom verify prompt

### DIFF
--- a/.cypress/integration/integrations_test/integrations.spec.js
+++ b/.cypress/integration/integrations_test/integrations.spec.js
@@ -107,7 +107,7 @@ describe('Add nginx integration instance flow', () => {
 
     cy.get('button[data-test-subj="popoverModal__deleteButton"]').should('be.disabled');
 
-    cy.get('input.euiFieldText[placeholder="delete"]').focus().type('delete', {
+    cy.get(`input.euiFieldText[placeholder="${testInstance}"]`).focus().type(testInstance, {
       delay: 50,
     });
     cy.get('button[data-test-subj="popoverModal__deleteButton"]').should('not.be.disabled');

--- a/public/components/common/helpers/delete_modal.tsx
+++ b/public/components/common/helpers/delete_modal.tsx
@@ -25,6 +25,7 @@ export const DeleteModal = ({
   onConfirm,
   title,
   message,
+  prompt,
 }: {
   onCancel: (
     event?: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -32,11 +33,13 @@ export const DeleteModal = ({
   onConfirm: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   title: string;
   message: string;
+  prompt?: string;
 }) => {
   const [value, setValue] = useState('');
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
   };
+  const deletePrompt = prompt ?? 'delete';
   return (
     <EuiOverlayMask>
       <EuiModal onClose={onCancel} initialFocus="[name=input]">
@@ -49,10 +52,10 @@ export const DeleteModal = ({
           <EuiText>The action cannot be undone.</EuiText>
           <EuiSpacer />
           <EuiForm>
-            <EuiFormRow label={'To confirm deletion, enter "delete" in the text field'}>
+            <EuiFormRow label={`To confirm deletion, enter "${deletePrompt}" in the text field`}>
               <EuiFieldText
                 name="input"
-                placeholder="delete"
+                placeholder={deletePrompt}
                 value={value}
                 onChange={(e) => onChange(e)}
                 data-test-subj="popoverModal__deleteTextInput"
@@ -67,7 +70,7 @@ export const DeleteModal = ({
             onClick={() => onConfirm()}
             color="danger"
             fill
-            disabled={value !== 'delete'}
+            disabled={value !== deletePrompt}
             data-test-subj="popoverModal__deleteButton"
           >
             Delete

--- a/public/components/integrations/components/added_integration.tsx
+++ b/public/components/integrations/components/added_integration.tsx
@@ -50,7 +50,9 @@ export function AddedIntegration(props: AddedIntegrationProps) {
 
   const { setToast } = useToast();
 
-  const [stateData, setData] = useState<any>({ data: {} });
+  const [stateData, setData] = useState<{ data: IntegrationInstanceResult | undefined }>({
+    data: undefined,
+  });
 
   useEffect(() => {
     chrome.setBreadcrumbs([
@@ -73,7 +75,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [modalLayout, setModalLayout] = useState(<EuiOverlayMask />);
 
-  const getModal = () => {
+  const activateDeleteModal = (integrationName?: string) => {
     setModalLayout(
       <DeleteModal
         onConfirm={() => {
@@ -83,8 +85,9 @@ export function AddedIntegration(props: AddedIntegrationProps) {
         onCancel={() => {
           setIsModalVisible(false);
         }}
-        title={`Delete Assets`}
-        message={`Are you sure you want to delete the selected asset(s)?`}
+        title={`Delete Integration`}
+        message={`Are you sure you want to delete the selected Integration?`}
+        prompt={integrationName}
       />
     );
     setIsModalVisible(true);
@@ -97,6 +100,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
         setToast(`${stateData.data?.name} integration successfully deleted!`, 'success');
       })
       .catch((err) => {
+        console.error(err);
         setToast(`Error deleting ${stateData.data?.name} or its assets`, 'danger');
       })
       .finally(() => {
@@ -110,7 +114,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
       .then((exists) => setData(exists));
   }
 
-  function AddedOverview(overviewProps: any) {
+  function AddedOverview(overviewProps: { data: { data?: IntegrationInstanceResult } }) {
     const { data } = overviewProps.data;
 
     return (
@@ -136,7 +140,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
                   aria-label="Delete"
                   color="danger"
                   onClick={() => {
-                    getModal();
+                    activateDeleteModal(data?.name);
                   }}
                   data-test-subj="deleteInstanceButton"
                 />
@@ -165,12 +169,12 @@ export function AddedIntegration(props: AddedIntegrationProps) {
     );
   }
 
-  function AddedAssets(assetProps: any) {
+  function AddedAssets(assetProps: { data: { data?: { assets: AssetReference[] } } }) {
     const { data } = assetProps.data;
 
     const assets = data?.assets || [];
 
-    const renderAsset = (record: any) => {
+    const renderAsset = (record: AssetReference) => {
       switch (record.assetType) {
         case 'dashboard':
           return (
@@ -259,13 +263,13 @@ export function AddedIntegration(props: AddedIntegrationProps) {
         name: 'Type',
         sortable: true,
         truncateText: true,
-        render: (value, record) => (
-          <EuiText data-test-subj={`${record.type}IntegrationDescription`}>
+        render: (_value, record) => (
+          <EuiText data-test-subj={`${record.assetType}AssetTypeDescription`}>
             {_.truncate(record.assetType, { length: 100 })}
           </EuiText>
         ),
       },
-    ] as Array<EuiTableFieldDataColumnType<any>>;
+    ] as Array<EuiTableFieldDataColumnType<AssetReference>>;
 
     return (
       <EuiPanel>

--- a/public/components/integrations/components/added_integration_table.tsx
+++ b/public/components/integrations/components/added_integration_table.tsx
@@ -79,7 +79,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
         <EuiIcon
           type={'trash'}
           onClick={() => {
-            getModal(record.id, record.templateName);
+            activateDeleteModal(record.id, record.name);
           }}
         />
       ),
@@ -103,7 +103,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
       });
   }
 
-  const getModal = (integrationInstanceId: string, name: string) => {
+  const activateDeleteModal = (integrationInstanceId: string, name: string) => {
     setModalLayout(
       <DeleteModal
         onConfirm={() => {
@@ -113,8 +113,9 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
         onCancel={() => {
           setIsModalVisible(false);
         }}
-        title={`Delete Assets`}
-        message={`Are you sure you want to delete the selected asset(s)?`}
+        title={`Delete Integration`}
+        message={`Are you sure you want to delete the selected integration?`}
+        prompt={name}
       />
     );
     setIsModalVisible(true);


### PR DESCRIPTION
### Description
Per UX: the delete modal uses in general should be using some variable text instead of a fixed "delete". This PR updates the DeleteModal component with an optional prompt that's used for deletion (defaulting back to "delete"), and activates this prompt within Integrations.

<img width="511" alt="image" src="https://github.com/opensearch-project/dashboards-observability/assets/31739405/8f333a78-371a-4561-9799-67ade23701c6">

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
