### PR TITLE
[Bug Fix] Flint datasource 2.13 bug bash fix

### DIFF
--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -728,7 +728,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                       Object {
                         "actions": Array [
                           Object {
-                            "description": "Discover this object",
+                            "description": "Query in Observability Logs",
                             "icon": "discoverApp",
                             "name": "Discover",
                             "onClick": [Function],
@@ -1286,7 +1286,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                           Object {
                             "actions": Array [
                               Object {
-                                "description": "Discover this object",
+                                "description": "Query in Observability Logs",
                                 "icon": "discoverApp",
                                 "name": "Discover",
                                 "onClick": [Function],
@@ -1991,7 +1991,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2017,7 +2017,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2040,7 +2040,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_0_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >
@@ -2256,7 +2256,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2282,7 +2282,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2305,7 +2305,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_1_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >
@@ -2521,7 +2521,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2555,7 +2555,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2578,7 +2578,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_2_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >
@@ -2890,7 +2890,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2924,7 +2924,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -2947,7 +2947,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_3_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >
@@ -3259,7 +3259,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -3293,7 +3293,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -3316,7 +3316,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_4_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >
@@ -3628,7 +3628,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -3662,7 +3662,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -3685,7 +3685,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_5_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >
@@ -3997,7 +3997,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               actions={
                                                 Array [
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -4031,7 +4031,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               <DefaultItemAction
                                                 action={
                                                   Object {
-                                                    "description": "Discover this object",
+                                                    "description": "Query in Observability Logs",
                                                     "icon": "discoverApp",
                                                     "name": "Discover",
                                                     "onClick": [Function],
@@ -4054,7 +4054,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 key="item_action_6_0"
                                               >
                                                 <EuiToolTip
-                                                  content="Discover this object"
+                                                  content="Query in Observability Logs"
                                                   delay="long"
                                                   position="top"
                                                 >

--- a/public/components/datasources/components/__tests__/__snapshots__/data_connection.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/data_connection.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`Data Connection Page test Renders S3 data connection page with data 1`]
                         <span
                           class="euiButtonEmpty__text"
                         >
-                          Query in Discover
+                          Query in Observability Logs
                         </span>
                       </span>
                     </button>

--- a/public/components/datasources/components/__tests__/acceleration_table.test.tsx
+++ b/public/components/datasources/components/__tests__/acceleration_table.test.tsx
@@ -159,7 +159,7 @@ describe('AccelerationTable Component', () => {
     });
 
     const activeStatusRows = wrapper!.find('tr.euiTableRow').filterWhere((node) => {
-      return node.find('.euiFlexItem').someWhere((subNode) => subNode.text() === 'active');
+      return node.find('.euiFlexItem').someWhere((subNode) => subNode.text() === 'Active');
     });
 
     expect(activeStatusRows.length).toBe(
@@ -177,7 +177,7 @@ describe('AccelerationTable Component', () => {
     });
     wrapper!.update();
 
-    const expectedLocalizedTime = 'Thu, 14 Mar 2024 04:05:53';
+    const expectedLocalizedTime = '3/14/2024, 4:05:53 AM';
 
     expect(wrapper!.text()).toContain(expectedLocalizedTime);
   });

--- a/public/components/datasources/components/manage/accelerations/acceleration_action_overlay.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_action_overlay.tsx
@@ -48,13 +48,13 @@ export const AccelerationActionOverlay: React.FC<AccelerationActionOverlayProps>
 
   switch (actionType) {
     case 'vacuum':
-      title = `Vacuum acceleration ${displayIndexName} on ${displayFullPath}?`;
+      title = `Vacuum acceleration ${displayIndexName} on ${displayFullPath} ?`;
       description = ACC_VACUUM_MSG;
       confirmButtonText = 'Vacuum';
       confirmEnabled = confirmationInput === displayIndexName;
       break;
     case 'delete':
-      title = `Delete acceleration ${displayIndexName} on ${displayFullPath}?`;
+      title = `Delete acceleration ${displayIndexName} on ${displayFullPath} ?`;
       description = ACC_DELETE_MSG;
       confirmButtonText = 'Delete';
       break;

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -150,14 +150,16 @@ export const AccelerationTable = ({
     );
   };
 
+  const displayUpdatedTime = updatedTime ? new Date(updatedTime).toLocaleString() : '';
+
   const AccelerationTableHeader = () => {
     return (
       <>
-        <EuiFlexGroup direction="row">
+        <EuiFlexGroup direction="row" alignItems="center">
           <EuiFlexItem>
             <EuiText>
-              <h3 className="panel-title">{ACC_PANEL_TITLE}</h3>
-              <p>{ACC_PANEL_DESC}</p>
+              <h2 className="panel-title">{ACC_PANEL_TITLE}</h2>
+              {ACC_PANEL_DESC}
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
@@ -174,10 +176,10 @@ export const AccelerationTable = ({
               {updatedTime && (
                 <EuiFlexItem>
                   <EuiText textAlign="right" size="xs" color="subdued">
-                    {'Last updated'}
+                    {'Last updated at:'}
                   </EuiText>
                   <EuiText textAlign="right" color="subdued" size="xs">
-                    {updatedTime}
+                    {displayUpdatedTime}
                   </EuiText>
                 </EuiFlexItem>
               )}
@@ -335,7 +337,6 @@ export const AccelerationTable = ({
       <EuiPanel>
         <AccelerationTableHeader />
         <EuiHorizontalRule />
-        <EuiSpacer />
         {isRefreshing ? (
           <AccelerationLoading />
         ) : (

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -203,7 +203,7 @@ export const AccelerationTable = ({
   const tableActions = [
     {
       name: 'Discover',
-      description: 'Open in Discover',
+      description: 'Query in Observability Logs',
       icon: 'discoverApp',
       type: 'icon',
       onClick: (acc: CachedAcceleration) => {

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -202,7 +202,7 @@ export const AccelerationTable = ({
 
   const tableActions = [
     {
-      name: 'Discover',
+      name: 'Query Data',
       description: 'Query in Observability Logs',
       icon: 'discoverApp',
       type: 'icon',

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -4,7 +4,6 @@
  */
 
 import {
-  EuiBasicTableColumn,
   EuiButton,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -15,6 +14,7 @@ import {
   EuiLoadingSpinner,
   EuiPanel,
   EuiSpacer,
+  EuiTableFieldDataColumnType,
   EuiText,
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -276,27 +276,27 @@ export const AccelerationTable = ({
           default:
             label = 'INVALID TYPE';
         }
-        return <EuiText>{label}</EuiText>;
+        return <EuiText size="s">{label}</EuiText>;
       },
     },
     {
       field: 'database',
       name: 'Database',
       sortable: true,
-      render: (database: string) => <EuiText>{database}</EuiText>,
+      render: (database: string) => <EuiText size="s">{database}</EuiText>,
     },
     {
       field: 'table',
       name: 'Table',
       sortable: true,
-      render: (table: string) => <EuiText>{table || '-'}</EuiText>,
+      render: (table: string) => <EuiText size="s">{table || '-'}</EuiText>,
     },
     {
       field: 'refreshType',
       name: 'Refresh Type',
       sortable: true,
       render: (autoRefresh: boolean, acceleration: CachedAcceleration) => {
-        return <EuiText>{acceleration.autoRefresh ? 'Auto refresh' : 'Manual'}</EuiText>;
+        return <EuiText size="s">{acceleration.autoRefresh ? 'Auto refresh' : 'Manual'}</EuiText>;
       },
     },
     {
@@ -314,7 +314,7 @@ export const AccelerationTable = ({
       name: 'Actions',
       actions: tableActions,
     },
-  ] as Array<EuiBasicTableColumn<any>>;
+  ] as Array<EuiTableFieldDataColumnType<any>>;
 
   const pagination = {
     initialPageSize: 10,

--- a/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
@@ -28,6 +28,14 @@ export const getAccelerationName = (acceleration: CachedAcceleration) => {
   return acceleration.indexName || 'skipping_index';
 };
 
+export const getCapitalizedStatusColumnContent = (status: string) => {
+  return status
+    .toLowerCase()
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
 export const getAccelerationFullPath = (acceleration: CachedAcceleration, dataSource: string) => {
   switch (acceleration.type) {
     case 'skipping':
@@ -94,24 +102,25 @@ export const CreateAccelerationFlyoutButton = ({
 };
 
 export const AccelerationStatus = ({ status }: { status: string }) => {
-  const label = status;
+  const capitalizedStatusColumn = getCapitalizedStatusColumnContent(status);
+
   let color;
 
-  switch (status) {
-    case 'active':
+  switch (capitalizedStatusColumn) {
+    case 'Active':
       color = 'success';
       break;
-    case 'refreshing':
+    case 'Refreshing':
       color = 'warning';
       break;
-    case 'deleted':
+    case 'Deleted':
       color = 'danger';
       break;
     default:
       color = 'subdued';
   }
 
-  return <EuiHealth color={color}>{label}</EuiHealth>;
+  return <EuiHealth color={color}>{capitalizedStatusColumn}</EuiHealth>;
 };
 
 export const AccelerationHealth = ({ health }: { health: string }) => {

--- a/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
+++ b/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
@@ -139,7 +139,7 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
           description: i18n.translate(
             'datasources.associatedObjectsTab.action.discover.description',
             {
-              defaultMessage: 'Discover this object',
+              defaultMessage: 'Query in Observability Logs',
             }
           ),
           type: 'icon',

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -162,7 +162,7 @@ export const DataConnection = (props: any) => {
             selectable={{
               onClick: onclickDiscoverCard,
               isDisabled: false,
-              children: 'Query in Discover',
+              children: 'Query in Observability Logs',
             }}
           />
         </EuiFlexItem>


### PR DESCRIPTION
### Description
Flint datasource 2.13 bug bash fix

### Issues Resolved
- Align the font with AO table
- Acceleration table's status column capitalization issue.
- Acceleration table header and buttons formatting.
- Acceleration table timestamp localization.
- "Query in Observability Logs" instead of "Query in Discover" for Get Started box in data connection.
- Fix the discover icons description in both acceleration table and associated table.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
