### PR TITLE
Update loading state for tables fields in create acceleration flyout

### DIFF
--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -117,9 +117,20 @@ export const CreateAcceleration = ({
   };
 
   const initiateColumnLoad = (dataSource: string, database: string, dataTable: string) => {
+    // All components related to table fields
     setAccelerationFormData({
       ...accelerationFormData,
       dataTableFields: [],
+      skippingIndexQueryData: [],
+      coveringIndexQueryData: [],
+      materializedViewQueryData: {
+        columnsValues: [],
+        groupByTumbleValue: {
+          timeField: '',
+          tumbleWindow: 0,
+          tumbleInterval: ACCELERATION_TIME_INTERVAL[2].value, // minutes
+        },
+      },
     });
     stopLoadingTableFields();
     if (dataTable !== '') {
@@ -163,6 +174,12 @@ export const CreateAcceleration = ({
     }
   }, [loadStatus]);
 
+  useEffect(() => {
+    return () => {
+      stopLoadingTableFields();
+    };
+  }, []);
+
   const dataSourcesPreselected = databaseName !== undefined && tableName !== undefined;
 
   return (
@@ -191,7 +208,6 @@ export const CreateAcceleration = ({
               accelerationFormData={accelerationFormData}
               setAccelerationFormData={setAccelerationFormData}
               initiateColumnLoad={initiateColumnLoad}
-              loading={tableFieldsLoading}
             />
             <EuiSpacer size="xxl" />
             <IndexSettingOptions
@@ -202,6 +218,7 @@ export const CreateAcceleration = ({
             <QueryVisualEditor
               accelerationFormData={accelerationFormData}
               setAccelerationFormData={setAccelerationFormData}
+              tableFieldsLoading={tableFieldsLoading}
             />
             <EuiSpacer size="xxl" />
             <IndexAdvancedSettings

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
@@ -244,7 +244,7 @@ Array [
                     aria-describedby="random_html_id-help-0"
                     aria-haspopup="true"
                     aria-labelledby="random_html_id random_html_id"
-                    className="euiSuperSelectControl euiSuperSelectControl-isLoading"
+                    className="euiSuperSelectControl"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
@@ -256,9 +256,6 @@ Array [
                   <div
                     className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
                   >
-                    <span
-                      className="euiLoadingSpinner euiLoadingSpinner--medium"
-                    />
                     <span
                       className="euiFormControlLayoutCustomIcon"
                     >

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
@@ -18,14 +18,12 @@ interface IndexTypeSelectorProps {
   accelerationFormData: CreateAccelerationForm;
   setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
   initiateColumnLoad: (dataSource: string, database: string, dataTable: string) => void;
-  loading: boolean;
 }
 
 export const IndexTypeSelector = ({
   accelerationFormData,
   setAccelerationFormData,
   initiateColumnLoad,
-  loading,
 }: IndexTypeSelectorProps) => {
   const [value, setValue] = useState('skipping');
 
@@ -116,7 +114,6 @@ export const IndexTypeSelector = ({
           onChange={onChangeSupeSelect}
           itemLayoutAlign="top"
           hasDividers
-          isLoading={loading}
         />
       </EuiFormRow>
     </>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_databases.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_databases.tsx
@@ -37,7 +37,7 @@ export const SelectorLoadDatabases = ({
   const {
     loadStatus: loadDatabasesStatus,
     startLoading: startDatabasesLoading,
-    stopLoading: _stopDatabasesLoading,
+    stopLoading: stopDatabasesLoading,
   } = useLoadDatabasesToCache();
 
   const onClickRefreshDatabases = () => {
@@ -61,6 +61,12 @@ export const SelectorLoadDatabases = ({
   useEffect(() => {
     setLoadingComboBoxes({ ...loadingComboBoxes, database: isLoading });
   }, [isLoading]);
+
+  useEffect(() => {
+    return () => {
+      stopDatabasesLoading();
+    };
+  }, []);
 
   return (
     <>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
@@ -48,12 +48,12 @@ export const SelectorLoadObjects = ({
   const {
     loadStatus: loadTablesStatus,
     startLoading: startLoadingTables,
-    stopLoading: _stopLoadingTables,
+    stopLoading: stopLoadingTables,
   } = useLoadTablesToCache();
   const {
     loadStatus: loadAccelerationsStatus,
     startLoading: startLoadingAccelerations,
-    stopLoading: _stopLoadingAccelerations,
+    stopLoading: stopLoadingAccelerations,
   } = useLoadAccelerationsToCache();
 
   const onClickRefreshDatabases = () => {
@@ -97,6 +97,12 @@ export const SelectorLoadObjects = ({
     setLoadingComboBoxes({ ...loadingComboBoxes, dataTable: isEitherLoading });
   }, [isEitherLoading]);
 
+  useEffect(() => {
+    return () => {
+      stopLoadingTables();
+      stopLoadingAccelerations();
+    };
+  }, []);
   return (
     <>
       {isEitherLoading ? (

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/query_visual_editor.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/query_visual_editor.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
 import React from 'react';
 import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
 import { CoveringIndexBuilder } from './covering_index/covering_index_builder';
@@ -13,13 +13,25 @@ import { SkippingIndexBuilder } from './skipping_index/skipping_index_builder';
 interface QueryVisualEditorProps {
   accelerationFormData: CreateAccelerationForm;
   setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
+  tableFieldsLoading: boolean;
 }
 
 export const QueryVisualEditor = ({
   accelerationFormData,
   setAccelerationFormData,
+  tableFieldsLoading,
 }: QueryVisualEditorProps) => {
-  return (
+  return tableFieldsLoading ? (
+    <>
+      <EuiFlexGroup alignItems="center" gutterSize="s" direction="column">
+        <EuiSpacer />
+        <EuiFlexItem>
+          <EuiLoadingSpinner size="l" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>Loading tables fields</EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  ) : (
     <>
       <EuiSpacer size="l" />
       {accelerationFormData.accelerationIndexType === 'skipping' && (


### PR DESCRIPTION
### Description
Update loading state for tables fields in create acceleration flyout

### Issues Resolved
1. Reset fields in acceleration create workflow when fields change
2. Update loading state to be in definitions instead of flyout
3. On unmount stop loaders

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
