### PR TITLE
Lifting useLoadTableColumnsToCache out of Flyouts

### DIFF
--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -5046,34 +5046,10 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                   Add databases and tables to your data source or use Query Workbench
                 </p>
               </EuiText>
-              <EuiLink
-                external={true}
-                onClick={[Function]}
-              >
-                Learn more
-              </EuiLink>
             </React.Fragment>
-          }
-          button={
-            <EuiButton
-              iconSide="right"
-              iconType="popout"
-              onClick={[Function]}
-            >
-              Query Workbench
-            </EuiButton>
           }
         >
           <div
-            button={
-              <EuiButton
-                iconSide="right"
-                iconType="popout"
-                onClick={[Function]}
-              >
-                Query Workbench
-              </EuiButton>
-            }
             className="euiEmptyPrompt"
           >
             <EuiTextColor
@@ -5098,19 +5074,6 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                         </p>
                       </div>
                     </EuiText>
-                    <EuiLink
-                      external={true}
-                      onClick={[Function]}
-                    >
-                      <button
-                        className="euiLink euiLink--primary"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        Learn more
-                      </button>
-                    </EuiLink>
                   </div>
                 </EuiText>
               </span>

--- a/public/components/datasources/components/__tests__/acceleration_table.test.tsx
+++ b/public/components/datasources/components/__tests__/acceleration_table.test.tsx
@@ -76,6 +76,7 @@ jest.mock('../../../../framework/catalog_cache/cache_loader', () => ({
     loadStatus: 'success',
     startLoading: jest.fn(),
   })),
+  useLoadTableColumnsToCache: jest.fn(() => jest.fn()),
 }));
 
 jest.mock('../../../../plugin', () => ({
@@ -91,6 +92,9 @@ describe('AccelerationTable Component', () => {
     tablesLoadStatus: DirectQueryLoadingStatus.INITIAL,
     accelerationsLoadStatus: DirectQueryLoadingStatus.INITIAL,
     startLoadingAccelerations: jest.fn(),
+    tableColumnsLoadStatus: DirectQueryLoadingStatus.INITIAL,
+    startLoadingTableColumns: jest.fn(),
+    stopLoadingTableColumns: jest.fn(),
   };
 
   it('renders without crashing', () => {

--- a/public/components/datasources/components/__tests__/associated_objects_flyout.test.tsx
+++ b/public/components/datasources/components/__tests__/associated_objects_flyout.test.tsx
@@ -11,6 +11,7 @@ import * as plugin from '../../../../plugin';
 import { act } from '@testing-library/react';
 import { mockAssociatedObjects } from '../../../../../test/datasources';
 import { getAccelerationName } from '../manage/accelerations/utils/acceleration_utils';
+import { DirectQueryLoadingStatus } from '../../../../../common/types/explorer';
 
 configure({ adapter: new Adapter() });
 
@@ -22,6 +23,9 @@ jest.mock('../../../../plugin', () => ({
 
 describe('AssociatedObjectsDetailsFlyout Integration Tests', () => {
   const mockTableDetail = mockAssociatedObjects[0];
+  const loadStatus = DirectQueryLoadingStatus.INITIAL;
+  const startLoading = jest.fn();
+  const stopLoading = jest.fn();
 
   beforeEach(() => {
     plugin.getRenderAccelerationDetailsFlyout.mockClear();
@@ -29,7 +33,13 @@ describe('AssociatedObjectsDetailsFlyout Integration Tests', () => {
 
   it('renders acceleration details correctly and triggers flyout on click', () => {
     const wrapper = mount(
-      <AssociatedObjectsDetailsFlyout tableDetail={mockTableDetail} datasourceName="flint_s3" />
+      <AssociatedObjectsDetailsFlyout
+        tableDetail={mockTableDetail}
+        datasourceName="flint_s3"
+        loadStatus={loadStatus}
+        startLoading={startLoading}
+        stopLoading={stopLoading}
+      />
     );
     expect(wrapper.find('EuiInMemoryTable').at(0).find('EuiLink').length).toBeGreaterThan(0);
 
@@ -51,6 +61,9 @@ describe('AssociatedObjectsDetailsFlyout Integration Tests', () => {
       <AssociatedObjectsDetailsFlyout
         tableDetail={mockDetailNoAccelerations}
         datasourceName="flint_s3"
+        loadStatus={loadStatus}
+        startLoading={startLoading}
+        stopLoading={stopLoading}
       />
     );
 
@@ -62,7 +75,13 @@ describe('AssociatedObjectsDetailsFlyout Integration Tests', () => {
 
   it('renders schema table correctly with column data', () => {
     const wrapper = mount(
-      <AssociatedObjectsDetailsFlyout tableDetail={mockTableDetail} datasourceName="flint_s3" />
+      <AssociatedObjectsDetailsFlyout
+        tableDetail={mockTableDetail}
+        datasourceName="flint_s3"
+        loadStatus={loadStatus}
+        startLoading={startLoading}
+        stopLoading={stopLoading}
+      />
     );
 
     expect(wrapper.find('EuiInMemoryTable').at(1).exists()).toBe(true);
@@ -73,7 +92,13 @@ describe('AssociatedObjectsDetailsFlyout Integration Tests', () => {
 
   it('triggers details flyout on acceleration link click', async () => {
     const wrapper = mount(
-      <AssociatedObjectsDetailsFlyout tableDetail={mockTableDetail} datasourceName="flint_s3" />
+      <AssociatedObjectsDetailsFlyout
+        tableDetail={mockTableDetail}
+        datasourceName="flint_s3"
+        loadStatus={loadStatus}
+        startLoading={startLoading}
+        stopLoading={stopLoading}
+      />
     );
 
     await act(async () => {

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -39,6 +39,7 @@ import { AccelerationActionOverlay } from './acceleration_action_overlay';
 import { isCatalogCacheFetching } from '../associated_objects/utils/associated_objects_tab_utils';
 import { getRenderCreateAccelerationFlyout } from '../../../../../plugin';
 import { useAccelerationOperation } from './acceleration_operation';
+import { useLoadTableColumnsToCache } from '../../../../../framework/catalog_cache/cache_loader';
 
 interface AccelerationTableProps {
   dataSourceName: string;
@@ -68,6 +69,7 @@ export const AccelerationTable = ({
     actionType: null,
     selectedItem: null,
   });
+  const { loadStatus, startLoading, stopLoading } = useLoadTableColumnsToCache();
 
   useEffect(() => {
     if (operationSuccess) {
@@ -166,6 +168,9 @@ export const AccelerationTable = ({
                 <CreateAccelerationFlyoutButton
                   dataSourceName={dataSourceName}
                   renderCreateAccelerationFlyout={renderCreateAccelerationFlyout}
+                  loadStatus={loadStatus}
+                  startLoading={startLoading}
+                  stopLoading={stopLoading}
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/create_acceleration.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/create_acceleration.test.tsx
@@ -12,6 +12,7 @@ import { coreMock } from '../../../../../../../../../../../src/core/public/mocks
 import { queryWorkbenchPluginCheck } from '../../../../../../../../../common/constants/shared';
 import { mockDatasourcesQuery } from '../../../../../../../../../test/accelerations';
 import { CreateAcceleration } from '../create_acceleration';
+import { DirectQueryLoadingStatus } from '../../../../../../../../../common/types/explorer';
 
 const coreStartMock = coreMock.createStart();
 
@@ -36,7 +37,13 @@ describe('Create acceleration flyout components', () => {
     coreStartMock.http.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
 
     const wrapper = mount(
-      <CreateAcceleration selectedDatasource={selectedDatasource} resetFlyout={resetFlyout} />
+      <CreateAcceleration
+        selectedDatasource={selectedDatasource}
+        loadStatus={DirectQueryLoadingStatus.INITIAL}
+        startLoading={jest.fn()}
+        stopLoading={jest.fn()}
+        resetFlyout={resetFlyout}
+      />
     );
     wrapper.update();
     await waitFor(() => {

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -25,7 +25,6 @@ import {
   CreateAccelerationForm,
 } from '../../../../../../../../common/types/data_connections';
 import { DirectQueryLoadingStatus } from '../../../../../../../../common/types/explorer';
-import { useLoadTableColumnsToCache } from '../../../../../../../framework/catalog_cache/cache_loader';
 import { CatalogCacheManager } from '../../../../../../../framework/catalog_cache/cache_manager';
 import { coreRefs } from '../../../../../../../framework/core_refs';
 import { IndexAdvancedSettings } from '../selectors/index_advanced_settings';
@@ -41,6 +40,9 @@ import { hasError } from './utils';
 export interface CreateAccelerationProps {
   selectedDatasource: string;
   resetFlyout: () => void;
+  loadStatus: DirectQueryLoadingStatus;
+  startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void;
+  stopLoading: () => void;
   databaseName?: string;
   tableName?: string;
 }
@@ -48,9 +50,13 @@ export interface CreateAccelerationProps {
 export const CreateAcceleration = ({
   selectedDatasource,
   resetFlyout,
+  loadStatus,
+  startLoading,
+  stopLoading,
   databaseName,
   tableName,
 }: CreateAccelerationProps) => {
+  console.log(loadStatus);
   const http = coreRefs!.http;
   const [accelerationFormData, setAccelerationFormData] = useState<CreateAccelerationForm>({
     dataSource: selectedDatasource,
@@ -97,11 +103,6 @@ export const CreateAcceleration = ({
     },
   });
   const [tableFieldsLoading, setTableFieldsLoading] = useState(false);
-  const {
-    loadStatus,
-    startLoading,
-    stopLoading: stopLoadingTableFields,
-  } = useLoadTableColumnsToCache();
 
   const loadColumnsToAccelerationForm = (cachedTable: CachedTable) => {
     const idPrefix = htmlIdGenerator()();
@@ -132,7 +133,7 @@ export const CreateAcceleration = ({
         },
       },
     });
-    stopLoadingTableFields();
+    stopLoading();
     if (dataTable !== '') {
       setTableFieldsLoading(true);
       const cachedTable = CatalogCacheManager.getTable(dataSource, database, dataTable);
@@ -176,7 +177,7 @@ export const CreateAcceleration = ({
 
   useEffect(() => {
     return () => {
-      stopLoadingTableFields();
+      stopLoading();
     };
   }, []);
 

--- a/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
@@ -11,6 +11,7 @@ import {
   redirectToExplorerWithDataSrc,
 } from '../../associated_objects/utils/associated_objects_tab_utils';
 import { DATA_SOURCE_TYPES } from '../../../../../../../common/constants/data_sources';
+import { DirectQueryLoadingStatus } from '../../../../../../../common/types/explorer';
 
 export const ACC_PANEL_TITLE = 'Accelerations';
 export const ACC_PANEL_DESC =
@@ -80,13 +81,29 @@ export const generateAccelerationOperationQuery = (
 export const CreateAccelerationFlyoutButton = ({
   dataSourceName,
   renderCreateAccelerationFlyout,
+  loadStatus,
+  startLoading,
+  stopLoading,
 }: {
   dataSourceName: string;
-  renderCreateAccelerationFlyout: (dataSourceName: string) => void;
+  renderCreateAccelerationFlyout: (
+    dataSourceName: string,
+    loadStatus: DirectQueryLoadingStatus,
+    startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+    stopLoading: () => void
+  ) => void;
+  loadStatus: DirectQueryLoadingStatus;
+  startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void;
+  stopLoading: () => void;
 }) => {
   return (
     <>
-      <EuiButton onClick={() => renderCreateAccelerationFlyout(dataSourceName)} fill>
+      <EuiButton
+        onClick={() =>
+          renderCreateAccelerationFlyout(dataSourceName, loadStatus, startLoading, stopLoading)
+        }
+        fill
+      >
         Create acceleration
       </EuiButton>
     </>

--- a/public/components/datasources/components/manage/associated_objects/associated_objects_tab.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_tab.tsx
@@ -172,7 +172,8 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
     if (datasource.name) {
       const datasourceCache = CatalogCacheManager.getOrCreateDataSource(datasource.name);
       if (
-        datasourceCache.status === CachedDataSourceStatus.Empty &&
+        (datasourceCache.status === CachedDataSourceStatus.Empty ||
+          datasourceCache.status === CachedDataSourceStatus.Failed) &&
         !isCatalogCacheFetching(databasesLoadStatus)
       ) {
         startLoadingDatabases(datasource.name);
@@ -221,7 +222,8 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
         datasource.name
       );
       if (
-        databaseCache.status === CachedDataSourceStatus.Empty &&
+        (databaseCache.status === CachedDataSourceStatus.Empty ||
+          databaseCache.status === CachedDataSourceStatus.Failed) &&
         !isCatalogCacheFetching(tablesLoadStatus)
       ) {
         startLoadingTables(datasource.name, selectedDatabase);
@@ -230,7 +232,9 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
         setCachedTables(databaseCache.tables);
       }
       if (
-        (accelerationsCache.status === CachedDataSourceStatus.Empty || isRefreshing) &&
+        (accelerationsCache.status === CachedDataSourceStatus.Empty ||
+          accelerationsCache.status === CachedDataSourceStatus.Failed ||
+          isRefreshing) &&
         !isCatalogCacheFetching(accelerationsLoadStatus)
       ) {
         startLoadingAccelerations(datasource.name);
@@ -375,7 +379,11 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
                       <AssociatedObjectsTabFailure type="objects" />
                     ) : (
                       <>
-                        {cachedTables.length > 0 || cachedAccelerations.length > 0 ? (
+                        {cachedTables.length > 0 ||
+                        cachedAccelerations.filter(
+                          (acceleration: CachedAcceleration) =>
+                            acceleration.database === selectedDatabase
+                        ).length > 0 ? (
                           <AssociatedObjectsTable
                             datasourceName={datasource.name}
                             associatedObjects={associatedObjects}

--- a/public/components/datasources/components/manage/associated_objects/associated_objects_tab.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_tab.tsx
@@ -72,7 +72,16 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
     startLoadingTables,
     accelerationsLoadStatus,
     startLoadingAccelerations,
+    tableColumnsLoadStatus,
+    startLoadingTableColumns,
+    stopLoadingTableColumns,
   } = cacheLoadingHooks;
+
+  // const {
+  //   loadStatus: tableColumnsLoadStatus,
+  //   startLoading: startLoadingTableColumns,
+  //   stopLoading: stopLoadingTableColumns,
+  // } = useLoadTableColumnsToCache();
 
   let lastChecked: boolean;
   if (selectedDatabase !== '') {
@@ -149,6 +158,9 @@ export const AssociatedObjectsTab: React.FC<AssociatedObjectsTabProps> = (props)
           <CreateAccelerationFlyoutButton
             dataSourceName={datasource.name}
             renderCreateAccelerationFlyout={renderCreateAccelerationFlyout}
+            loadStatus={tableColumnsLoadStatus}
+            startLoading={startLoadingTableColumns}
+            stopLoading={stopLoadingTableColumns}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
+++ b/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
@@ -34,6 +34,7 @@ import {
   ACCELERATION_INDEX_TYPES,
   DATA_SOURCE_TYPES,
 } from '../../../../../../../common/constants/data_sources';
+import { useLoadTableColumnsToCache } from '../../../../../../../public/framework/catalog_cache/cache_loader';
 
 interface AssociatedObjectsTableProps {
   datasourceName: string;
@@ -58,6 +59,8 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
   const [accelerationFilterOptions, setAccelerationFilterOptions] = useState<FilterOption[]>([]);
   const [filteredObjects, setFilteredObjects] = useState<AssociatedObject[]>([]);
 
+  const { loadStatus, startLoading, stopLoading } = useLoadTableColumnsToCache();
+
   const columns = [
     {
       field: 'name',
@@ -70,7 +73,13 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
         <EuiLink
           onClick={() => {
             if (item.type === 'table') {
-              renderAssociatedObjectsDetailsFlyout(item, datasourceName);
+              renderAssociatedObjectsDetailsFlyout(
+                item,
+                datasourceName,
+                loadStatus,
+                startLoading,
+                stopLoading
+              );
             } else {
               const acceleration = cachedAccelerations.find((acc) => acc.indexName === item.id);
               if (acceleration) {
@@ -118,7 +127,13 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
         return (
           <EuiButtonEmpty
             onClick={() => {
-              renderAssociatedObjectsDetailsFlyout(obj, datasourceName);
+              renderAssociatedObjectsDetailsFlyout(
+                obj,
+                datasourceName,
+                loadStatus,
+                startLoading,
+                stopLoading
+              );
             }}
             size="xs"
           >
@@ -175,7 +190,14 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
           icon: 'bolt',
           available: (item: AssociatedObject) => item.type === 'table',
           onClick: (item: AssociatedObject) =>
-            renderCreateAccelerationFlyout(datasourceName, item.database, item.name),
+            renderCreateAccelerationFlyout(
+              datasourceName,
+              loadStatus,
+              startLoading,
+              stopLoading,
+              item.database,
+              item.name
+            ),
         },
       ],
     },

--- a/public/components/datasources/components/manage/associated_objects/utils/associated_objects_tab_empty.tsx
+++ b/public/components/datasources/components/manage/associated_objects/utils/associated_objects_tab_empty.tsx
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiEmptyPrompt, EuiLink, EuiText } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import React from 'react';
 import { LoadCacheType } from '../../../../../../../common/types/data_connections';
-import { coreRefs } from '../../../../../../framework/core_refs';
 
 interface AssociatedObjectsTabEmptyProps {
   cacheType: LoadCacheType;
@@ -14,17 +13,6 @@ interface AssociatedObjectsTabEmptyProps {
 
 export const AssociatedObjectsTabEmpty: React.FC<AssociatedObjectsTabEmptyProps> = (props) => {
   const { cacheType } = props;
-  const { application } = coreRefs;
-
-  const QueryWorkbenchButton = (
-    <EuiButton
-      iconSide="right"
-      onClick={() => application!.navigateToApp('opensearch-query-workbench')}
-      iconType="popout"
-    >
-      Query Workbench
-    </EuiButton>
-  );
 
   let titleText;
   let bodyText;
@@ -51,12 +39,8 @@ export const AssociatedObjectsTabEmpty: React.FC<AssociatedObjectsTabEmptyProps>
             <h4>{titleText}</h4>
             <p>{bodyText}</p>
           </EuiText>
-          <EuiLink onClick={() => console.log()} external>
-            Learn more
-          </EuiLink>
         </>
       }
-      button={QueryWorkbenchButton}
     />
   );
 };

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -35,6 +35,7 @@ import {
 import {
   useLoadAccelerationsToCache,
   useLoadDatabasesToCache,
+  useLoadTableColumnsToCache,
   useLoadTablesToCache,
 } from '../../../../../public/framework/catalog_cache/cache_loader';
 import { DATA_SOURCE_TYPES } from '../../../../../common/constants/data_sources';
@@ -72,6 +73,11 @@ export const DataConnection = (props: any) => {
     loadStatus: accelerationsLoadStatus,
     startLoading: startLoadingAccelerations,
   } = useLoadAccelerationsToCache();
+  const {
+    loadStatus: tableColumnsLoadStatus,
+    startLoading: startLoadingTableColumns,
+    stopLoading: stopLoadingTableColumns,
+  } = useLoadTableColumnsToCache();
 
   const cacheLoadingHooks = {
     databasesLoadStatus,
@@ -80,6 +86,9 @@ export const DataConnection = (props: any) => {
     startLoadingTables,
     accelerationsLoadStatus,
     startLoadingAccelerations,
+    tableColumnsLoadStatus,
+    startLoadingTableColumns,
+    stopLoadingTableColumns,
   };
 
   const [dataSourceIntegrations, setDataSourceIntegrations] = useState(
@@ -111,7 +120,12 @@ export const DataConnection = (props: any) => {
   };
 
   const onclickAccelerationsCard = () => {
-    renderCreateAccelerationFlyout(dataSource);
+    renderCreateAccelerationFlyout(
+      dataSource,
+      tableColumnsLoadStatus,
+      startLoadingTableColumns,
+      stopLoadingTableColumns
+    );
   };
 
   const onclickDiscoverCard = () => {

--- a/public/components/datasources/components/manage/manage_data_connections_table.tsx
+++ b/public/components/datasources/components/manage/manage_data_connections_table.tsx
@@ -34,6 +34,7 @@ import S3Logo from '../../icons/s3-logo.svg';
 import { DataConnectionsHeader } from '../data_connections_header';
 import { DataConnectionsDescription } from './manage_data_connections_description';
 import { getRenderCreateAccelerationFlyout } from '../../../../../public/plugin';
+import { useLoadTableColumnsToCache } from '../../../../../public/framework/catalog_cache/cache_loader';
 
 interface DataConnection {
   connectionType: DatasourceType;
@@ -50,6 +51,7 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
   const [data, setData] = useState<DataConnection[]>([]);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [modalLayout, setModalLayout] = useState(<EuiOverlayMask />);
+  const { loadStatus, startLoading, stopLoading } = useLoadTableColumnsToCache();
 
   const deleteConnection = (connectionName: string) => {
     http!
@@ -137,7 +139,7 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
       type: 'icon',
       available: (datasource: DataConnection) => datasource.connectionType !== 'PROMETHEUS',
       onClick: (datasource: DataConnection) => {
-        renderCreateAccelerationFlyout(datasource.name);
+        renderCreateAccelerationFlyout(datasource.name, loadStatus, startLoading, stopLoading);
       },
       'data-test-subj': 'action-accelerate',
     },

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -94,6 +94,7 @@ import {
   ObservabilityStart,
   SetupDependencies,
 } from './types';
+import { DirectQueryLoadingStatus } from '../common/types/explorer';
 
 interface PublicConfig {
   query_assist: {
@@ -114,16 +115,29 @@ export const [
 export const [
   getRenderAssociatedObjectsDetailsFlyout,
   setRenderAssociatedObjectsDetailsFlyout,
-] = createGetterSetter<(tableDetail: AssociatedObject, datasourceName: string) => void>(
-  'renderAssociatedObjectsDetailsFlyout'
-);
+] = createGetterSetter<
+  (
+    tableDetail: AssociatedObject,
+    datasourceName: string,
+    loadStatus: DirectQueryLoadingStatus,
+    startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+    stopLoading: () => void
+  ) => void
+>('renderAssociatedObjectsDetailsFlyout');
 
 export const [
   getRenderCreateAccelerationFlyout,
   setRenderCreateAccelerationFlyout,
-] = createGetterSetter<(dataSource: string, databaseName?: string, tableName?: string) => void>(
-  'renderCreateAccelerationFlyout'
-);
+] = createGetterSetter<
+  (
+    dataSource: string,
+    loadStatus: DirectQueryLoadingStatus,
+    startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+    stopLoading: () => void,
+    databaseName?: string,
+    tableName?: string
+  ) => void
+>('renderCreateAccelerationFlyout');
 
 export class ObservabilityPlugin
   implements
@@ -421,13 +435,19 @@ export class ObservabilityPlugin
 
     const renderAssociatedObjectsDetailsFlyout = (
       tableDetail: AssociatedObject,
-      datasourceName: string
+      datasourceName: string,
+      loadStatus: DirectQueryLoadingStatus,
+      startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+      stopLoading: () => void
     ) => {
       const associatedObjectsDetailsFlyout = core.overlays.openFlyout(
         toMountPoint(
           <AssociatedObjectsDetailsFlyout
             tableDetail={tableDetail}
             datasourceName={datasourceName}
+            loadStatus={loadStatus}
+            startLoading={startLoading}
+            stopLoading={stopLoading}
             resetFlyout={() => associatedObjectsDetailsFlyout.close()}
           />
         )
@@ -437,6 +457,9 @@ export class ObservabilityPlugin
 
     const renderCreateAccelerationFlyout = (
       selectedDatasource: string,
+      loadStatus: DirectQueryLoadingStatus,
+      startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+      stopLoading: () => void,
       databaseName?: string,
       tableName?: string
     ) => {
@@ -445,6 +468,9 @@ export class ObservabilityPlugin
           <CreateAcceleration
             selectedDatasource={selectedDatasource}
             resetFlyout={() => createAccelerationFlyout.close()}
+            loadStatus={loadStatus}
+            startLoading={startLoading}
+            stopLoading={stopLoading}
             databaseName={databaseName}
             tableName={tableName}
           />

--- a/public/types.ts
+++ b/public/types.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DirectQueryLoadingStatus } from '../common/types/explorer';
 import { SavedObjectsClient } from '../../../src/core/server';
 import { DashboardStart } from '../../../src/plugins/dashboard/public';
 import { DataPublicPluginSetup, DataPublicPluginStart } from '../../../src/plugins/data/public';
@@ -45,13 +46,18 @@ export interface ObservabilityStart {
     datasourceName: string,
     handleRefresh?: () => void
   ) => void;
-  renderAssociatedObjectsDetailsFlyout: ({
-    tableDetail,
-  }: {
-    tableDetail: AssociatedObject;
-  }) => void;
+  renderAssociatedObjectsDetailsFlyout: (
+    tableDetail: AssociatedObject,
+    datasourceName: string,
+    loadStatus: DirectQueryLoadingStatus,
+    startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+    stopLoading: () => void
+  ) => void;
   renderCreateAccelerationFlyout: (
     dataSource: string,
+    loadStatus: DirectQueryLoadingStatus,
+    startLoading: (dataSourceName: string, databaseName?: string, tableName?: string) => void,
+    stopLoading: () => void,
     databaseName?: string,
     tableName?: string
   ) => void;


### PR DESCRIPTION
### Description
* Flyouts had an issue where `startLoading` would poll indefinitely when the flyout gets closed. Lifting the `useLoadTableColumnsToCache` hook out of flyouts stops this behavior. 
* Updated UI on empty associated objects table

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
