### PR TITLE
Disable close button when integration is being installed

### DIFF
--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -934,6 +934,7 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
   setAvailableIntegrations={[Function]}
 >
   <EuiFlyout
+    hideCloseButton={false}
     onClose={[Function]}
   >
     <OuiWindowEvent

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -154,7 +154,7 @@ export const InstallIntegrationFlyout = ({
   const [installingIntegration, setInstallingIntegration] = useState<string | null>(null);
 
   return (
-    <EuiFlyout onClose={closeFlyout}>
+    <EuiFlyout onClose={closeFlyout} hideCloseButton={installingIntegration !== null}>
       {installingIntegration === null ? (
         <AvailableIntegrationsTable
           loading={false}

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -181,7 +181,7 @@ export const InstallIntegrationFlyout = ({
                 }
               : undefined
           }
-          onStartInstalling={() => setIsInstalling(true)}
+          setIsInstalling={setIsInstalling}
         />
       )}
     </EuiFlyout>

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -152,9 +152,15 @@ export const InstallIntegrationFlyout = ({
   };
 
   const [installingIntegration, setInstallingIntegration] = useState<string | null>(null);
+  const [isInstalling, setIsInstalling] = useState(false);
+  const maybeCloseFlyout = () => {
+    if (!isInstalling) {
+      closeFlyout();
+    }
+  };
 
   return (
-    <EuiFlyout onClose={closeFlyout} hideCloseButton={installingIntegration !== null}>
+    <EuiFlyout onClose={maybeCloseFlyout} hideCloseButton={isInstalling}>
       {installingIntegration === null ? (
         <AvailableIntegrationsTable
           loading={false}
@@ -175,6 +181,7 @@ export const InstallIntegrationFlyout = ({
                 }
               : undefined
           }
+          onStartInstalling={() => setIsInstalling(true)}
         />
       )}
     </EuiFlyout>

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -540,7 +540,7 @@ export function SetupBottomBar({
   setLoading,
   setSetupCallout,
   unsetIntegration,
-  onStartInstalling,
+  setIsInstalling,
 }: {
   config: IntegrationSetupInputs;
   integration: IntegrationConfig;
@@ -548,7 +548,7 @@ export function SetupBottomBar({
   setLoading: (loading: boolean) => void;
   setSetupCallout: (setupCallout: SetupCallout) => void;
   unsetIntegration?: () => void;
-  onStartInstalling?: () => void;
+  setIsInstalling?: (isInstalling: boolean) => void;
 }) {
   // Drop-in replacement for setToast
   const setCalloutLikeToast = (title: string, color?: Color, text?: string) =>
@@ -590,10 +590,20 @@ export function SetupBottomBar({
           isLoading={loading}
           disabled={!isConfigValid(config, integration)}
           onClick={async () => {
-            if (onStartInstalling) {
-              onStartInstalling();
+            if (setIsInstalling) {
+              setIsInstalling(true);
+              await addIntegration({
+                integration,
+                config,
+                setLoading: (newLoading: boolean) => {
+                  setLoading(newLoading);
+                  setIsInstalling(newLoading);
+                },
+                setCalloutLikeToast,
+              });
+            } else {
+              await addIntegration({ integration, config, setLoading, setCalloutLikeToast });
             }
-            await addIntegration({ integration, config, setLoading, setCalloutLikeToast });
           }}
           data-test-subj="create-instance-button"
         >
@@ -621,7 +631,7 @@ export function SetupIntegrationForm({
   renderType = 'page',
   unsetIntegration,
   forceConnection,
-  onStartInstalling,
+  setIsInstalling,
 }: {
   integration: string;
   renderType: 'page' | 'flyout';
@@ -630,7 +640,7 @@ export function SetupIntegrationForm({
     name: string;
     type: string;
   };
-  onStartInstalling?: () => void;
+  setIsInstalling?: (isInstalling: boolean) => void;
 }) {
   const [integConfig, setConfig] = useState({
     displayName: `${integration} Integration`,
@@ -692,7 +702,7 @@ export function SetupIntegrationForm({
             setLoading={setShowLoading}
             setSetupCallout={setSetupCallout}
             unsetIntegration={unsetIntegration}
-            onStartInstalling={onStartInstalling}
+            setIsInstalling={setIsInstalling}
           />
         </EuiBottomBar>
       </>
@@ -721,7 +731,7 @@ export function SetupIntegrationForm({
             setLoading={setShowLoading}
             setSetupCallout={setSetupCallout}
             unsetIntegration={unsetIntegration}
-            onStartInstalling={onStartInstalling}
+            setIsInstalling={setIsInstalling}
           />
         </EuiFlyoutFooter>
       </>

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -540,6 +540,7 @@ export function SetupBottomBar({
   setLoading,
   setSetupCallout,
   unsetIntegration,
+  onStartInstalling,
 }: {
   config: IntegrationSetupInputs;
   integration: IntegrationConfig;
@@ -547,6 +548,7 @@ export function SetupBottomBar({
   setLoading: (loading: boolean) => void;
   setSetupCallout: (setupCallout: SetupCallout) => void;
   unsetIntegration?: () => void;
+  onStartInstalling?: () => void;
 }) {
   // Drop-in replacement for setToast
   const setCalloutLikeToast = (title: string, color?: Color, text?: string) =>
@@ -587,9 +589,12 @@ export function SetupBottomBar({
           iconSide="right"
           isLoading={loading}
           disabled={!isConfigValid(config, integration)}
-          onClick={async () =>
-            addIntegration({ integration, config, setLoading, setCalloutLikeToast })
-          }
+          onClick={async () => {
+            if (onStartInstalling) {
+              onStartInstalling();
+            }
+            await addIntegration({ integration, config, setLoading, setCalloutLikeToast });
+          }}
           data-test-subj="create-instance-button"
         >
           Add Integration
@@ -616,6 +621,7 @@ export function SetupIntegrationForm({
   renderType = 'page',
   unsetIntegration,
   forceConnection,
+  onStartInstalling,
 }: {
   integration: string;
   renderType: 'page' | 'flyout';
@@ -624,6 +630,7 @@ export function SetupIntegrationForm({
     name: string;
     type: string;
   };
+  onStartInstalling?: () => void;
 }) {
   const [integConfig, setConfig] = useState({
     displayName: `${integration} Integration`,
@@ -685,6 +692,7 @@ export function SetupIntegrationForm({
             setLoading={setShowLoading}
             setSetupCallout={setSetupCallout}
             unsetIntegration={unsetIntegration}
+            onStartInstalling={onStartInstalling}
           />
         </EuiBottomBar>
       </>
@@ -713,6 +721,7 @@ export function SetupIntegrationForm({
             setLoading={setShowLoading}
             setSetupCallout={setSetupCallout}
             unsetIntegration={unsetIntegration}
+            onStartInstalling={onStartInstalling}
           />
         </EuiFlyoutFooter>
       </>


### PR DESCRIPTION
### Description
Disables the ability to close the integration install flyout when an integration is being installed.

<img width="996" alt="image" src="https://github.com/opensearch-project/dashboards-observability/assets/31739405/c6f4d6f8-8e09-4b28-a866-b586c4e83411">

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
