### PR TITLE
Fix datagrid snapshots for 2.x 

### DIFF
--- a/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
+++ b/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
@@ -1109,9 +1109,7 @@ exports[`Datagrid component renders data grid with no timestamp 1`] = `
         },
         "basePath": BasePath {
           "basePath": "",
-          "clientBasePath": "",
           "get": [Function],
-          "getBasePath": [Function],
           "prepend": [Function],
           "remove": [Function],
           "serverBasePath": "",
@@ -1139,9 +1137,7 @@ exports[`Datagrid component renders data grid with no timestamp 1`] = `
           },
           "basePath": BasePath {
             "basePath": "",
-            "clientBasePath": "",
             "get": [Function],
-            "getBasePath": [Function],
             "prepend": [Function],
             "remove": [Function],
             "serverBasePath": "",


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/dashboards-observability/pull/1533 -> PR fixed test snapshots on main but somehow got trickled down to 2.x and 2.13 restoring older snapshots as this is not backported to core yet. 

### Issues Resolved
* Restore explorer datagrid snapshots

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
