### PR TITLE
Sanitize create acceleration queries and direct queries

### DIFF
--- a/common/constants/data_sources.ts
+++ b/common/constants/data_sources.ts
@@ -38,6 +38,7 @@ export const ACCELERATION_ADD_FIELDS_TEXT = '(add fields here)';
 export const ACCELERATION_INDEX_NAME_REGEX = /^[a-z0-9_]+$/;
 export const ACCELERATION_S3_URL_REGEX = /^(s3|s3a):\/\/[a-zA-Z0-9.\-]+/;
 export const SPARK_HIVE_TABLE_REGEX = /Provider:\s*hive/;
+export const SANITIZE_QUERY_REGEX = /\s+/g;
 export const TIMESTAMP_DATATYPE = 'timestamp';
 
 export const ACCELERATION_INDEX_TYPES = [

--- a/public/components/common/search/direct_search.tsx
+++ b/public/components/common/search/direct_search.tsx
@@ -18,11 +18,15 @@ import {
   EuiPopoverFooter,
   EuiToolTip,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { isEmpty, isEqual } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
-import { i18n } from '@osd/i18n';
-import { ASYNC_POLLING_INTERVAL, QUERY_LANGUAGE } from '../../../../common/constants/data_sources';
+import {
+  ASYNC_POLLING_INTERVAL,
+  QUERY_LANGUAGE,
+  SANITIZE_QUERY_REGEX,
+} from '../../../../common/constants/data_sources';
 import {
   APP_ANALYTICS_TAB_ID_REGEX,
   RAW_QUERY,
@@ -223,9 +227,10 @@ export const DirectSearch = (props: any) => {
       );
     });
     const sessionId = getAsyncSessionId(explorerSearchMetadata.datasources[0].label);
+    const requestQuery = tempQuery || query;
     const requestPayload = {
       lang: lang.toLowerCase(),
-      query: tempQuery || query,
+      query: requestQuery.replaceAll(SANITIZE_QUERY_REGEX, ' '),
       datasource: explorerSearchMetadata.datasources[0].label,
     } as DirectQueryRequest;
 

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration_button.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration_button.tsx
@@ -5,6 +5,7 @@
 
 import { EuiButton } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
+import { SANITIZE_QUERY_REGEX } from '../../../../../../../../common/constants/data_sources';
 import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
 import {
   DirectQueryLoadingStatus,
@@ -39,7 +40,7 @@ export const CreateAccelerationButton = ({
 
     const requestPayload: DirectQueryRequest = {
       lang: 'sql',
-      query: accelerationQueryBuilder(accelerationFormData),
+      query: accelerationQueryBuilder(accelerationFormData).replaceAll(SANITIZE_QUERY_REGEX, ' '),
       datasource: accelerationFormData.dataSource,
     };
 


### PR DESCRIPTION
### Description
Sanitize queries which have a potential for users to add in a `\n`, `\t` or extra white spaces

### Issues Resolved
1. Sanitize direct queries from explorer
2. Sanitize direct queries from create acceleration flyout

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
