### PR TITLE
Fix DSL router, update UI for query assist

### DIFF
--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -5,7 +5,6 @@
 
 import {
   EuiButton,
-  EuiButtonIcon,
   EuiCallOut,
   EuiComboBoxOptionOption,
   EuiFieldText,
@@ -109,6 +108,16 @@ const emptyQueryCallOut = (
   />
 );
 
+const pplGenerated = (
+  <EuiCallOut
+    data-test-subj="query-assist-ppl-callout"
+    title="PPL query generated"
+    size="s"
+    color="success"
+    iconType="check"
+  />
+);
+
 export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props) => {
   // @ts-ignore
   const queryRedux = useSelector(selectQueries)[props.tabId];
@@ -176,6 +185,7 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
         },
       })
     );
+    setCallOut(pplGenerated);
     return generatedPPL;
   };
   const formatError = (error: ResponseError | Error): Error => {
@@ -365,16 +375,6 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
               ))}
             </EuiListGroup>
           </EuiInputPopover>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="returnKey"
-            display={props.lastFocusedInput === 'nlq_input' ? 'fill' : 'base'}
-            isDisabled={loading}
-            onClick={runAndSummarize}
-            size="m"
-            aria-label="submit-question"
-          />
         </EuiFlexItem>
       </EuiFlexGroup>
       {callOut}

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -95,6 +95,7 @@ const prohibitedQueryCallOut = (
     size="s"
     color="danger"
     iconType="alert"
+    dismissible
   />
 );
 
@@ -105,6 +106,7 @@ const emptyQueryCallOut = (
     size="s"
     color="warning"
     iconType="iInCircle"
+    dismissible
   />
 );
 
@@ -115,6 +117,7 @@ const pplGenerated = (
     size="s"
     color="success"
     iconType="check"
+    dismissible
   />
 );
 

--- a/server/routes/dsl.ts
+++ b/server/routes/dsl.ts
@@ -52,7 +52,7 @@ export function registerDslRoute({ router }: { router: IRouter; facet: DSLFacet 
       validate: {
         query: schema.object({
           format: schema.string(),
-          index: schema.string(),
+          index: schema.maybe(schema.string()),
         }),
       },
     },


### PR DESCRIPTION
### Description
* In this [PR](https://github.com/opensearch-project/dashboards-observability/pull/1521/files#diff-1f9448392ecc6df0b6d0408be8f0fc5220624ca9d18b4303c0c49bf6313978d9R55), `cat.indices` is validated to have a `format` field and `index` field. Since `cat.indices` does not require an `index` field, I changed it to a maybe so that it doesn't break other components that call this API.
* When query assist successfully generates PPL, display a callout.
* Remove return button next to query assist input field.

https://github.com/opensearch-project/dashboards-observability/assets/47805161/f649b704-bac5-4a53-ac80-619f18fd5bf3

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
