### PR TITLE
Updating catch for guardrails

### DIFF
--- a/common/constants/query_assist.ts
+++ b/common/constants/query_assist.ts
@@ -12,4 +12,4 @@ export const QUERY_ASSIST_API = {
 
 export const ML_COMMONS_API_PREFIX = '/_plugins/_ml';
 
-export const ERROR_DETAILS = { GUARDRAILS_TRIGGERED: 'guardrail triggered' };
+export const ERROR_DETAILS = { GUARDRAILS_TRIGGERED: 'guardrails triggered' };

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
   "version": "3.0.0.0",
-  "opensearchDashboardsVersion": "2.13.0",
+  "opensearchDashboardsVersion": "3.0.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
   "version": "3.0.0.0",
-  "opensearchDashboardsVersion": "3.0.0",
+  "opensearchDashboardsVersion": "2.13.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -200,7 +200,7 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
         } as Error;
       if (
         error.body.statusCode === 400 &&
-        error.body.message === ERROR_DETAILS.GUARDRAILS_TRIGGERED
+        error.body.message.includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
       )
         return new ProhibitedQueryError(error.body.message);
       return error.body as Error;

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -95,7 +95,6 @@ const prohibitedQueryCallOut = (
     size="s"
     color="danger"
     iconType="alert"
-    dismissible
   />
 );
 
@@ -106,7 +105,6 @@ const emptyQueryCallOut = (
     size="s"
     color="warning"
     iconType="iInCircle"
-    dismissible
   />
 );
 
@@ -117,7 +115,6 @@ const pplGenerated = (
     size="s"
     color="success"
     iconType="check"
-    dismissible
   />
 );
 

--- a/server/routes/query_assist/routes.ts
+++ b/server/routes/query_assist/routes.ts
@@ -84,7 +84,7 @@ export function registerQueryAssistRoutes(router: IRouter) {
         if (
           isResponseError(error) &&
           error.statusCode === 400 &&
-          error.body.error.details === ERROR_DETAILS.GUARDRAILS_TRIGGERED
+          error.body.includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
         ) {
           return response.badRequest({ body: ERROR_DETAILS.GUARDRAILS_TRIGGERED });
         }
@@ -156,7 +156,7 @@ export function registerQueryAssistRoutes(router: IRouter) {
         if (
           isResponseError(error) &&
           error.statusCode === 400 &&
-          error.body.error.details === ERROR_DETAILS.GUARDRAILS_TRIGGERED
+          error.body.includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
         ) {
           return response.badRequest({ body: ERROR_DETAILS.GUARDRAILS_TRIGGERED });
         }


### PR DESCRIPTION
### Description
Catch for guardrails was added in #1523, but seems to not work as `error.body.error` is undefined because `error.body` is a string. 
```
ResponseError: Response Error
    at onBody (/Users/lnse/opensearch/OpenSearch-Dashboards/node_modules/@opensearch-project/opensearch/lib/Transport.js:426:23)
    at IncomingMessage.onEnd (/Users/lnse/opensearch/OpenSearch-Dashboards/node_modules/@opensearch-project/opensearch/lib/Transport.js:341:11)
    at IncomingMessage.emit (node:events:525:35)
    at IncomingMessage.emit (node:domain:489:12)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at processTicksAndRejections (node:internal/process/task_queues:82:21) {
  meta: {
    body: '{"error":{"reason":"Invalid Request","details":"guardrails triggered for user input","type":"IllegalArgumentException"},"status":400}',
    statusCode: 400,
    headers: {
      'x-opaque-id': '7d7be6c4-33e8-4a26-9534-838095b15ec9',
      'content-type': 'text/plain; charset=UTF-8',
      'content-length': '133'
    },
    meta: {
      context: null,
      request: [Object],
      name: 'opensearch-js',
      connection: [Object],
      attempts: 0,
      aborted: false
    }
  }
}
```


Updated accordingly to check for guardrails errors.
```
[2024-03-26T11:11:45,194][ERROR][o.o.m.e.a.r.RemoteModel  ] [b0f1d8522b4f] Failed to call remote model.
java.lang.IllegalArgumentException: guardrails triggered for user input
```

Also removing `dismissible` flag on callouts since they don't work.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
