### PR TITLE
[BUGFIX] Fix integration data reading double escape

### DIFF
--- a/server/adaptors/integrations/repository/integration_reader.ts
+++ b/server/adaptors/integrations/repository/integration_reader.ts
@@ -107,7 +107,7 @@ export class IntegrationReader {
       }
       return {
         ok: true,
-        value: { ...asset, data: JSON.stringify(maybeBuffer.value.toString('utf8')) },
+        value: { ...asset, data: maybeBuffer.value.toString('utf8') },
       };
     }
   }


### PR DESCRIPTION
### Description
Integration data assets are JSON stringified before being serialized, which means that they get sent escaped to further endpoints. This breaks the query API usage. This PR removes the extra escape.

TODO: Tests to catch this in the future.

Big props to @seankao-az for setting up the infra to test the functionality and find this

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
