### PR TITLE
Clear callout in query assist 

### DIFF
--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -341,7 +341,10 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
                 }
                 disabled={loading}
                 value={props.nlqInput}
-                onChange={(e) => props.setNlqInput(e.target.value)}
+                onChange={(e) => {
+                  props.setNlqInput(e.target.value);
+                  setCallOut(null);
+                }}
                 onKeyDown={(e) => {
                   // listen to enter key manually. the cursor jumps to CodeEditor with EuiForm's onSubmit
                   if (e.key === 'Enter') runAndSummarize();


### PR DESCRIPTION
### Description
Dismissible flag in callouts is buggy in query assist, so to update the UI, we should clear the callout once user starts to type another query.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
