### PR TITLE
Update intercept to check logout request

### DIFF
--- a/public/framework/catalog_cache/cache_intercept.ts
+++ b/public/framework/catalog_cache/cache_intercept.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  HttpInterceptorResponseError,
-  IHttpInterceptController,
-} from '../../../../../src/core/public';
+import { HttpFetchOptionsWithPath, IHttpInterceptController } from '../../../../../src/core/public';
 import { CatalogCacheManager } from './cache_manager';
 
-export function catalogCacheInterceptError(): any {
-  return (httpErrorResponse: HttpInterceptorResponseError, _: IHttpInterceptController) => {
-    if (httpErrorResponse.response?.status === 401) {
+export function catalogRequestIntercept(): any {
+  return (
+    fetchOptions: Readonly<HttpFetchOptionsWithPath>,
+    controller: IHttpInterceptController
+  ) => {
+    if (fetchOptions.path.includes('/logout')) {
       // Clears all user catalog cache details
       CatalogCacheManager.clearDataSourceCache();
       CatalogCacheManager.clearAccelerationsCache();

--- a/public/framework/catalog_cache/cache_intercept.ts
+++ b/public/framework/catalog_cache/cache_intercept.ts
@@ -9,7 +9,7 @@ import { CatalogCacheManager } from './cache_manager';
 export function catalogRequestIntercept(): any {
   return (
     fetchOptions: Readonly<HttpFetchOptionsWithPath>,
-    controller: IHttpInterceptController
+    _controller: IHttpInterceptController
   ) => {
     if (fetchOptions.path.includes('/logout')) {
       // Clears all user catalog cache details

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -20,7 +20,6 @@ import { createGetterSetter } from '../../../src/plugins/opensearch_dashboards_u
 import { CREATE_TAB_PARAM, CREATE_TAB_PARAM_KEY, TAB_CHART_ID } from '../common/constants/explorer';
 import {
   DATACONNECTIONS_BASE,
-  S3_DATASOURCE_TYPE,
   observabilityApplicationsID,
   observabilityApplicationsPluginOrder,
   observabilityApplicationsTitle,
@@ -46,6 +45,7 @@ import {
   observabilityTracesID,
   observabilityTracesPluginOrder,
   observabilityTracesTitle,
+  S3_DATASOURCE_TYPE,
 } from '../common/constants/shared';
 import { QueryManager } from '../common/query_manager';
 import { AssociatedObject, CachedAcceleration } from '../common/types/data_connections';
@@ -72,7 +72,7 @@ import {
   OBSERVABILITY_EMBEDDABLE_ID,
 } from './embeddable/observability_embeddable';
 import { ObservabilityEmbeddableFactoryDefinition } from './embeddable/observability_embeddable_factory';
-import { catalogCacheInterceptError } from './framework/catalog_cache/cache_intercept';
+import { catalogRequestIntercept } from './framework/catalog_cache/cache_intercept';
 import {
   useLoadAccelerationsToCache,
   useLoadDatabasesToCache,
@@ -402,7 +402,7 @@ export class ObservabilityPlugin
     });
 
     core.http.intercept({
-      responseError: catalogCacheInterceptError(),
+      request: catalogRequestIntercept(),
     });
 
     // Use overlay service to render flyouts


### PR DESCRIPTION
### Description
Update intercept to check logout request

### Issues Resolved
The Earlier intercept was not being triggered as it was being run after the security dashboards intercept on responseError. 
Hence, moving to intercept requests to catch the logout action from user to clear cache. 
Security plugin intercept: https://github.com/opensearch-project/security-dashboards-plugin/blob/main/public/utils/logout-utils.tsx
Old Observability plugin intercept: https://github.com/opensearch-project/dashboards-observability/blob/main/public/framework/catalog_cache/cache_intercept.ts
OSD response error intercepts code: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/2a94f32dc332f097ca447fd15887d346415fafdf/src/core/public/http/intercept.ts#L86

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
