### PR TITLE
Bug Fix for Undefined Association

### DIFF
--- a/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
+++ b/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
@@ -125,7 +125,7 @@ export const AssociatedObjectsTable = (props: AssociatedObjectsTableProps) => {
               View all {accelerations.length}
             </EuiLink>
           );
-        } else {
+        } else if (accelerations) {
           return (
             <EuiLink
               onClick={() =>


### PR DESCRIPTION
### Description
On some edge cases where databases and accelerations are loaded at the same time, some associated objects could have undefined accelerations/associations. This PR checks if the association is defined first before displaying.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
