### PR TITLE
Correctly Utilize Cache in Tables Flyout

### DIFF
--- a/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
@@ -226,21 +226,20 @@ export const AssociatedObjectsDetailsFlyout = ({
 
   useEffect(() => {
     if (tableDetail && !tableDetail.columns) {
-      let tables;
       try {
-        tables = CatalogCacheManager.getTable(
+        const tables = CatalogCacheManager.getTable(
           datasourceName,
           tableDetail.database,
           tableDetail.name
         );
+        if (tables?.columns) {
+          setTableColumns(tables?.columns);
+        } else {
+          startLoading(datasourceName, tableDetail.database, tableDetail.name);
+        }
       } catch (error) {
         console.error(error);
         setToast('Your cache is outdated, refresh databases and tables', 'warning');
-      }
-      if (tables?.columns) {
-        setTableColumns(tables?.columns);
-      } else {
-        startLoading(datasourceName, tableDetail.database, tableDetail.name);
       }
     } else if (tableDetail && tableDetail.columns) {
       setTableColumns(tableDetail.columns);

--- a/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
@@ -226,7 +226,22 @@ export const AssociatedObjectsDetailsFlyout = ({
 
   useEffect(() => {
     if (tableDetail && !tableDetail.columns) {
-      startLoading(datasourceName, tableDetail.database, tableDetail.name);
+      let tables;
+      try {
+        tables = CatalogCacheManager.getTable(
+          datasourceName,
+          tableDetail.database,
+          tableDetail.name
+        );
+      } catch (error) {
+        console.error(error);
+        setToast('Your cache is outdated, refresh databases and tables', 'warning');
+      }
+      if (tables?.columns) {
+        setTableColumns(tables?.columns);
+      } else {
+        startLoading(datasourceName, tableDetail.database, tableDetail.name);
+      }
     } else if (tableDetail && tableDetail.columns) {
       setTableColumns(tableDetail.columns);
     }


### PR DESCRIPTION
### Description
Previously, updating the cache in the tables flyout doesn't update it in the associated objects array. Fix by checking cache before loading schema.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
