### PR TITLE
Convert cache to session storage

### DIFF
--- a/public/framework/catalog_cache/cache_manager.test.tsx
+++ b/public/framework/catalog_cache/cache_manager.test.tsx
@@ -22,8 +22,8 @@ interface LooseObject {
   [key: string]: any;
 }
 
-// Mock localStorage
-const localStorageMock = (() => {
+// Mock sessionStorage
+const sessionStorageMock = (() => {
   let store = {} as LooseObject;
   return {
     getItem(key: string) {
@@ -41,13 +41,13 @@ const localStorageMock = (() => {
   };
 })();
 
-Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
 
 describe('CatalogCacheManager', () => {
   beforeEach(() => {
-    jest.spyOn(window.localStorage, 'setItem');
-    jest.spyOn(window.localStorage, 'getItem');
-    jest.spyOn(window.localStorage, 'removeItem');
+    jest.spyOn(window.sessionStorage, 'setItem');
+    jest.spyOn(window.sessionStorage, 'getItem');
+    jest.spyOn(window.sessionStorage, 'removeItem');
   });
 
   afterEach(() => {
@@ -68,7 +68,7 @@ describe('CatalogCacheManager', () => {
         ],
       };
       CatalogCacheManager.saveDataSourceCache(cacheData);
-      expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect(sessionStorage.setItem).toHaveBeenCalledWith(
         ASYNC_QUERY_DATASOURCE_CACHE,
         JSON.stringify(cacheData)
       );
@@ -86,7 +86,7 @@ describe('CatalogCacheManager', () => {
           },
         ],
       };
-      localStorage.setItem(ASYNC_QUERY_DATASOURCE_CACHE, JSON.stringify(initialCacheData));
+      sessionStorage.setItem(ASYNC_QUERY_DATASOURCE_CACHE, JSON.stringify(initialCacheData));
 
       const newCacheData: DataSourceCacheData = {
         version: '1.1',
@@ -100,7 +100,7 @@ describe('CatalogCacheManager', () => {
         ],
       };
       CatalogCacheManager.saveDataSourceCache(newCacheData);
-      expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect(sessionStorage.setItem).toHaveBeenCalledWith(
         ASYNC_QUERY_DATASOURCE_CACHE,
         JSON.stringify(newCacheData)
       );
@@ -120,13 +120,13 @@ describe('CatalogCacheManager', () => {
           },
         ],
       };
-      localStorage.setItem(ASYNC_QUERY_DATASOURCE_CACHE, JSON.stringify(cacheData));
+      sessionStorage.setItem(ASYNC_QUERY_DATASOURCE_CACHE, JSON.stringify(cacheData));
       expect(CatalogCacheManager.getDataSourceCache()).toEqual(cacheData);
     });
 
     it('should return default cache object if cache is not found', () => {
       const defaultCacheObject = { version: CATALOG_CACHE_VERSION, dataSources: [] };
-      localStorage.removeItem(ASYNC_QUERY_DATASOURCE_CACHE);
+      sessionStorage.removeItem(ASYNC_QUERY_DATASOURCE_CACHE);
       expect(CatalogCacheManager.getDataSourceCache()).toEqual(defaultCacheObject);
     });
   });
@@ -138,7 +138,7 @@ describe('CatalogCacheManager', () => {
         dataSources: [],
       };
       CatalogCacheManager.saveAccelerationsCache(cacheData);
-      expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect(sessionStorage.setItem).toHaveBeenCalledWith(
         ASYNC_QUERY_ACCELERATIONS_CACHE,
         JSON.stringify(cacheData)
       );
@@ -151,7 +151,7 @@ describe('CatalogCacheManager', () => {
         version: CATALOG_CACHE_VERSION,
         dataSources: [],
       };
-      localStorage.setItem(ASYNC_QUERY_ACCELERATIONS_CACHE, JSON.stringify(cacheData));
+      sessionStorage.setItem(ASYNC_QUERY_ACCELERATIONS_CACHE, JSON.stringify(cacheData));
       expect(CatalogCacheManager.getAccelerationsCache()).toEqual(cacheData);
     });
 
@@ -160,7 +160,7 @@ describe('CatalogCacheManager', () => {
         version: CATALOG_CACHE_VERSION,
         dataSources: [],
       };
-      localStorage.removeItem(ASYNC_QUERY_ACCELERATIONS_CACHE);
+      sessionStorage.removeItem(ASYNC_QUERY_ACCELERATIONS_CACHE);
       expect(CatalogCacheManager.getAccelerationsCache()).toEqual(defaultCacheObject);
     });
   });
@@ -381,14 +381,14 @@ describe('CatalogCacheManager', () => {
   describe('clearDataSourceCache', () => {
     it('should clear data source cache from local storage', () => {
       CatalogCacheManager.clearDataSourceCache();
-      expect(localStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_DATASOURCE_CACHE);
+      expect(sessionStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_DATASOURCE_CACHE);
     });
   });
 
   describe('clearAccelerationsCache', () => {
     it('should clear accelerations cache from local storage', () => {
       CatalogCacheManager.clearAccelerationsCache();
-      expect(localStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_ACCELERATIONS_CACHE);
+      expect(sessionStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_ACCELERATIONS_CACHE);
     });
   });
 
@@ -404,7 +404,7 @@ describe('CatalogCacheManager', () => {
       CatalogCacheManager.addOrUpdateAccelerationsByDataSource(dataSource);
 
       // Verify that saveAccelerationsCache is called with the updated cache data
-      expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect(sessionStorage.setItem).toHaveBeenCalledWith(
         ASYNC_QUERY_ACCELERATIONS_CACHE,
         JSON.stringify({
           version: '1.0',
@@ -431,7 +431,7 @@ describe('CatalogCacheManager', () => {
       CatalogCacheManager.addOrUpdateAccelerationsByDataSource(updatedDataSource);
 
       // Verify that saveAccelerationsCache is called with the updated cache data
-      expect(localStorage.setItem).toHaveBeenCalledWith(
+      expect(sessionStorage.setItem).toHaveBeenCalledWith(
         ASYNC_QUERY_ACCELERATIONS_CACHE,
         JSON.stringify({
           version: '1.0',

--- a/public/framework/catalog_cache/cache_manager.ts
+++ b/public/framework/catalog_cache/cache_manager.ts
@@ -37,7 +37,7 @@ export class CatalogCacheManager {
    * @param {DataSourceCacheData} cacheData - The data source cache data to save.
    */
   static saveDataSourceCache(cacheData: DataSourceCacheData): void {
-    localStorage.setItem(this.datasourceCacheKey, JSON.stringify(cacheData));
+    sessionStorage.setItem(this.datasourceCacheKey, JSON.stringify(cacheData));
   }
 
   /**
@@ -45,7 +45,7 @@ export class CatalogCacheManager {
    * @returns {DataSourceCacheData} The retrieved data source cache.
    */
   static getDataSourceCache(): DataSourceCacheData {
-    const catalogData = localStorage.getItem(this.datasourceCacheKey);
+    const catalogData = sessionStorage.getItem(this.datasourceCacheKey);
 
     if (catalogData) {
       return JSON.parse(catalogData);
@@ -61,7 +61,7 @@ export class CatalogCacheManager {
    * @param {AccelerationsCacheData} cacheData - The accelerations cache data to save.
    */
   static saveAccelerationsCache(cacheData: AccelerationsCacheData): void {
-    localStorage.setItem(this.accelerationsCacheKey, JSON.stringify(cacheData));
+    sessionStorage.setItem(this.accelerationsCacheKey, JSON.stringify(cacheData));
   }
 
   /**
@@ -69,7 +69,7 @@ export class CatalogCacheManager {
    * @returns {AccelerationsCacheData} The retrieved accelerations cache.
    */
   static getAccelerationsCache(): AccelerationsCacheData {
-    const accelerationCacheData = localStorage.getItem(this.accelerationsCacheKey);
+    const accelerationCacheData = sessionStorage.getItem(this.accelerationsCacheKey);
 
     if (accelerationCacheData) {
       return JSON.parse(accelerationCacheData);
@@ -234,13 +234,13 @@ export class CatalogCacheManager {
    * Clears the data source cache from local storage.
    */
   static clearDataSourceCache(): void {
-    localStorage.removeItem(this.datasourceCacheKey);
+    sessionStorage.removeItem(this.datasourceCacheKey);
   }
 
   /**
    * Clears the accelerations cache from local storage.
    */
   static clearAccelerationsCache(): void {
-    localStorage.removeItem(this.accelerationsCacheKey);
+    sessionStorage.removeItem(this.accelerationsCacheKey);
   }
 }


### PR DESCRIPTION
### Description
Convert cache to session storage

### Issues Resolved
This PR helps to reduce the lifecycle of the catalog cache to be limited to a browser's tab lifecycle. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
