### PR TITLE
[Backport 2.x] prevent logged out datasources call (#1653)

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -20,7 +20,8 @@
   ],
   "optionalPlugins": [
     "managementOverview",
-    "assistantDashboards"
+    "assistantDashboards",
+    "securityDashboards"
   ],
   "configPath": [
     "observability"

--- a/public/types.ts
+++ b/public/types.ts
@@ -25,6 +25,7 @@ export interface AppPluginStartDependencies {
   dashboard: DashboardStart;
   savedObjectsClient: SavedObjectsClient;
   data: DataPublicPluginStart;
+  securityDashboards?: {};
 }
 
 export interface SetupDependencies {


### PR DESCRIPTION
* prevent logged out datasources call

Signed-off-by: Paul Sebastian <paulstn@amazon.com>

* check if security plugin is installed

Signed-off-by: Paul Sebastian <paulstn@amazon.com>

* clean up logic

Signed-off-by: Paul Sebastian <paulstn@amazon.com>

* include a catch clause to register datasources when account api has non 401 error

Signed-off-by: Paul Sebastian <paulstn@amazon.com>

* included comment

Signed-off-by: Paul Sebastian <paulstn@amazon.com>

---------

Signed-off-by: Paul Sebastian <paulstn@amazon.com>
(cherry picked from commit c14c3f813c43bc296e1ded355a5b7e9bd425869b)

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
