### PR TITLE
fix small issues within explorer search bar and sample query

### DIFF
--- a/public/components/common/search/autocomplete.tsx
+++ b/public/components/common/search/autocomplete.tsx
@@ -29,6 +29,7 @@ interface AutocompleteProps extends IQueryBarProps {
   possibleCommands?: Array<{ label: string }>;
   append?: any;
   isSuggestionDisabled?: boolean;
+  ignoreShiftEnter?: boolean;
 }
 
 export const Autocomplete = (props: AutocompleteProps) => {
@@ -47,6 +48,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     possibleCommands,
     append,
     isSuggestionDisabled = false,
+    ignoreShiftEnter = false,
   } = props;
 
   const [autocompleteState, setAutocompleteState] = useState<AutocompleteState<AutocompleteItem>>({
@@ -63,6 +65,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
   const panelsFilter = tabId === 'panels-filter';
 
   useEffect(() => {
+    if (ignoreShiftEnter) return;
     const searchBar = document.getElementById('autocomplete-textarea');
 
     searchBar?.addEventListener('keydown', (e) => {

--- a/public/components/common/search/direct_search.tsx
+++ b/public/components/common/search/direct_search.tsx
@@ -391,6 +391,7 @@ export const DirectSearch = (props: any) => {
             tabId={tabId}
             isSuggestionDisabled={true}
             isDisabled={explorerSearchMetadata.isPolling}
+            ignoreShiftEnter={true}
           />
           {queryLang === QUERY_LANGUAGE.PPL && (
             <EuiBadge

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -389,9 +389,7 @@ export const Search = (props: any) => {
                   tempQuery={tempQuery}
                   baseQuery={baseQuery}
                   handleQueryChange={handleQueryChange}
-                  handleQuerySearch={() => {
-                    onQuerySearch(queryLang);
-                  }}
+                  handleQuerySearch={runChanges}
                   dslService={dslService}
                   getSuggestions={getSuggestions}
                   onItemSelect={onItemSelect}

--- a/public/components/event_analytics/explorer/no_results.tsx
+++ b/public/components/event_analytics/explorer/no_results.tsx
@@ -126,7 +126,7 @@ export const NoResults = ({ tabId }: any) => {
                     <p>Show a list of tables within a database</p>
                     <EuiSpacer size="s" />
                     <CreatedCodeBlock
-                      code={`SHOW TABLES EXTENDED IN ${datasourceName}.<database> LIKE '*'`}
+                      code={`SHOW TABLE EXTENDED IN ${datasourceName}.<database> LIKE '*'`}
                     />
                   </EuiFlexItem>
                   <EuiFlexItem>


### PR DESCRIPTION
### Description
Fixes:
- Typo with SHOW TABLES query -> SHOW TABLE
- unexpected behavior where the autocomplete component's shift enter listener populates the ran query as something stale, for direct queries
- non direct query updates everything needed now

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
