### PR TITLE
Remove auto refresh option in create acceleration flyout

### DIFF
--- a/common/constants/data_sources.ts
+++ b/common/constants/data_sources.ts
@@ -33,6 +33,12 @@ export const ACCELERATION_TIME_INTERVAL = [
   { text: 'day(s)', value: 'day' },
   { text: 'week(s)', value: 'week' },
 ];
+export const ACCELERATION_REFRESH_TIME_INTERVAL = [
+  { text: 'minutes(s)', value: 'minute' },
+  { text: 'hour(s)', value: 'hour' },
+  { text: 'day(s)', value: 'day' },
+  { text: 'week(s)', value: 'week' },
+];
 
 export const ACCELERATION_ADD_FIELDS_TEXT = '(add fields here)';
 export const ACCELERATION_INDEX_NAME_REGEX = /^[a-z0-9_]+$/;

--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -217,7 +217,7 @@ export interface FormErrorsType {
   watermarkDelayError: string[];
 }
 
-export type AccelerationRefreshType = 'auto' | 'autoInterval' | 'manual' | 'manualIncrement';
+export type AccelerationRefreshType = 'autoInterval' | 'manual' | 'manualIncrement';
 
 export interface CreateAccelerationForm {
   dataSource: string;

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -583,7 +583,7 @@ Array [
                               <input
                                 id="random_html_id"
                                 type="hidden"
-                                value="auto"
+                                value="autoInterval"
                               />
                               <div
                                 class="euiFormControlLayout"
@@ -595,7 +595,7 @@ Array [
                                     class="euiScreenReaderOnly"
                                     id="random_html_id"
                                   >
-                                    Select an option: Auto, is selected
+                                    Select an option: Auto (Interval), is selected
                                   </span>
                                   <button
                                     aria-describedby="random_html_id-help-0"
@@ -604,7 +604,7 @@ Array [
                                     class="euiSuperSelectControl"
                                     type="button"
                                   >
-                                    Auto
+                                    Auto (Interval)
                                   </button>
                                   <div
                                     class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
@@ -638,6 +638,104 @@ Array [
                           id="random_html_id-help-0"
                         >
                           Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow"
+                      id="random_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="random_html_id"
+                        >
+                          Refresh increments
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout euiFormControlLayout--group"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-describedby="random_html_id-help-0"
+                              aria-label="Refresh increments"
+                              class="euiFieldNumber euiFieldNumber--inGroup"
+                              id="random_html_id"
+                              min="1"
+                              placeholder="Refresh increments"
+                              type="number"
+                              value="15"
+                            />
+                          </div>
+                          <div
+                            class="euiFormControlLayout"
+                          >
+                            <div
+                              class="euiFormControlLayout__childrenWrapper"
+                            >
+                              <select
+                                class="euiSelect euiFormControlLayout__append"
+                              >
+                                <option
+                                  value="minute"
+                                >
+                                  minutes(s)
+                                </option>
+                                <option
+                                  value="hour"
+                                >
+                                  hour(s)
+                                </option>
+                                <option
+                                  value="day"
+                                >
+                                  day(s)
+                                </option>
+                                <option
+                                  value="week"
+                                >
+                                  week(s)
+                                </option>
+                              </select>
+                              <div
+                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <span
+                                  class="euiFormControlLayoutCustomIcon"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="random_html_id-help-0"
+                        >
+                          Specify how frequent the index gets updated when performing the refresh job.
                         </div>
                       </div>
                     </div>
@@ -2036,7 +2134,7 @@ Array [
                                   <input
                                     id="random_html_id"
                                     type="hidden"
-                                    value="auto"
+                                    value="autoInterval"
                                   />,
                                   <div
                                     className="euiFormControlLayout"
@@ -2048,7 +2146,7 @@ Array [
                                         className="euiScreenReaderOnly"
                                         id="random_html_id"
                                       >
-                                        Select an option: Auto, is selected
+                                        Select an option: Auto (Interval), is selected
                                       </span>
                                       <button
                                         aria-describedby="random_html_id-help-0"
@@ -2061,7 +2159,7 @@ Array [
                                         onKeyDown={[Function]}
                                         type="button"
                                       >
-                                        Auto
+                                        Auto (Interval)
                                       </button>
                                       <div
                                         className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
@@ -2097,6 +2195,115 @@ Array [
                             id="random_html_id-help-0"
                           >
                             Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+                          </div>
+                        </div>
+                      </div>,
+                      <div
+                        className="euiFormRow"
+                        id="random_html_id-row"
+                      >
+                        <div
+                          className="euiFormRow__labelWrapper"
+                        >
+                          <label
+                            aria-invalid={false}
+                            className="euiFormLabel euiFormRow__label"
+                            htmlFor="random_html_id"
+                          >
+                            Refresh increments
+                          </label>
+                        </div>
+                        <div
+                          className="euiFormRow__fieldWrapper"
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--group"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <input
+                                aria-describedby="random_html_id-help-0"
+                                aria-label="Refresh increments"
+                                className="euiFieldNumber euiFieldNumber--inGroup"
+                                id="random_html_id"
+                                min={1}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Refresh increments"
+                                type="number"
+                                value={15}
+                              />
+                            </div>
+                            <div
+                              className="euiFormControlLayout"
+                            >
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <select
+                                  className="euiSelect euiFormControlLayout__append"
+                                  onChange={[Function]}
+                                  onMouseUp={[Function]}
+                                  value="minute"
+                                >
+                                  <option
+                                    key="0"
+                                    value="minute"
+                                  >
+                                    minutes(s)
+                                  </option>
+                                  <option
+                                    key="1"
+                                    value="hour"
+                                  >
+                                    hour(s)
+                                  </option>
+                                  <option
+                                    key="2"
+                                    value="day"
+                                  >
+                                    day(s)
+                                  </option>
+                                  <option
+                                    key="3"
+                                    value="week"
+                                  >
+                                    week(s)
+                                  </option>
+                                </select>
+                                <div
+                                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="euiFormHelpText euiFormRow__text"
+                            id="random_html_id-help-0"
+                          >
+                            Specify how frequent the index gets updated when performing the refresh job.
                           </div>
                         </div>
                       </div>,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -2244,6 +2244,7 @@ Array [
                               >
                                 <select
                                   className="euiSelect euiFormControlLayout__append"
+                                  onBlur={[Function]}
                                   onChange={[Function]}
                                   onMouseUp={[Function]}
                                   value="minute"

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/utils.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/utils.test.tsx
@@ -109,24 +109,36 @@ describe('validateReplicaCount', () => {
 
 describe('validateRefreshInterval', () => {
   it('should return an array with an error message when refreshType is "interval" and refreshWindow is less than 1', () => {
-    expect(validateRefreshInterval('autoInterval', 0)).toEqual([
+    expect(validateRefreshInterval('autoInterval', 0, 'hour')).toEqual([
       'refresh window should be greater than 0',
     ]);
-    expect(validateRefreshInterval('autoInterval', -1)).toEqual([
+    expect(validateRefreshInterval('autoInterval', -1, 'day')).toEqual([
       'refresh window should be greater than 0',
     ]);
-    expect(validateRefreshInterval('autoInterval', -10)).toEqual([
+    expect(validateRefreshInterval('autoInterval', -10, 'week')).toEqual([
       'refresh window should be greater than 0',
+    ]);
+    expect(validateRefreshInterval('autoInterval', 14, 'minute')).toEqual([
+      'refresh window should be greater than 15 minutes',
+    ]);
+    expect(validateRefreshInterval('autoInterval', 10, 'minute')).toEqual([
+      'refresh window should be greater than 15 minutes',
+    ]);
+    expect(validateRefreshInterval('autoInterval', 0, 'minute')).toEqual([
+      'refresh window should be greater than 15 minutes',
     ]);
   });
 
   it('should return an empty array when refreshType is not "interval" or when refreshWindow is greater than or equal to 1', () => {
-    expect(validateRefreshInterval('auto', 0)).toEqual([]);
-    expect(validateRefreshInterval('auto', 1)).toEqual([]);
-    expect(validateRefreshInterval('autoInterval', 1)).toEqual([]);
-    expect(validateRefreshInterval('autoInterval', 5)).toEqual([]);
-    expect(validateRefreshInterval('manual', 0)).toEqual([]);
-    expect(validateRefreshInterval('manualIncrement', 0)).toEqual([]);
+    expect(validateRefreshInterval('auto', 0, 'minute')).toEqual([]);
+    expect(validateRefreshInterval('auto', 1, 'minute')).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 15, 'minute')).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 20, 'minute')).toEqual([]);
+    expect(validateRefreshInterval('manual', 0, 'minute')).toEqual([]);
+    expect(validateRefreshInterval('manualIncrement', 0, 'minute')).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 1, 'hour')).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 2, 'day')).toEqual([]);
+    expect(validateRefreshInterval('autoInterval', 3, 'week')).toEqual([]);
   });
 });
 

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -18,6 +18,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import {
   ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+  ACCELERATION_REFRESH_TIME_INTERVAL,
   ACCELERATION_TIME_INTERVAL,
 } from '../../../../../../../../common/constants/data_sources';
 import {
@@ -75,15 +76,15 @@ export const CreateAcceleration = ({
     accelerationIndexName: ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
     primaryShardsCount: 1,
     replicaShardsCount: 1,
-    refreshType: 'auto',
+    refreshType: 'autoInterval',
     checkpointLocation: undefined,
     watermarkDelay: {
       delayWindow: 1,
       delayInterval: ACCELERATION_TIME_INTERVAL[2].value, // minutes
     },
     refreshIntervalOptions: {
-      refreshWindow: 1,
-      refreshInterval: ACCELERATION_TIME_INTERVAL[2].value, // minutes
+      refreshWindow: 15,
+      refreshInterval: ACCELERATION_REFRESH_TIME_INTERVAL[0].value, // minutes
     },
     formErrors: {
       dataSourceError: [],

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/utils.tsx
@@ -47,11 +47,16 @@ export const validateReplicaCount = (replicaCount: number) => {
 
 export const validateRefreshInterval = (
   refreshType: AccelerationRefreshType,
-  refreshWindow: number
+  refreshWindow: number,
+  refreshInterval: string
 ) => {
-  return refreshType === 'autoInterval' && refreshWindow < 1
-    ? ['refresh window should be greater than 0']
-    : [];
+  if (refreshType === 'autoInterval' && refreshInterval === 'minute' && refreshWindow < 15)
+    return ['refresh window should be greater than 15 minutes'];
+
+  if (refreshType === 'autoInterval' && refreshWindow < 1)
+    return ['refresh window should be greater than 0'];
+
+  return [];
 };
 
 export const validateWatermarkDelay = (
@@ -147,7 +152,8 @@ export const formValidator = (accelerationformData: CreateAccelerationForm) => {
     replicaShardsError: validateReplicaCount(replicaShardsCount),
     refreshIntervalError: validateRefreshInterval(
       refreshType,
-      refreshIntervalOptions.refreshWindow
+      refreshIntervalOptions.refreshWindow,
+      refreshIntervalOptions.refreshInterval
     ),
     checkpointLocationError: validateCheckpointLocation(refreshType, checkpointLocation),
     watermarkDelayError: validateWatermarkDelay(accelerationIndexType, watermarkDelay.delayWindow),

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
@@ -46,7 +46,7 @@ Array [
               <input
                 id="random_html_id"
                 type="hidden"
-                value="auto"
+                value="autoInterval"
               />,
               <div
                 className="euiFormControlLayout"
@@ -58,7 +58,7 @@ Array [
                     className="euiScreenReaderOnly"
                     id="random_html_id"
                   >
-                    Select an option: Auto, is selected
+                    Select an option: Auto (Interval), is selected
                   </span>
                   <button
                     aria-describedby="random_html_id-help-0"
@@ -71,7 +71,7 @@ Array [
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    Auto
+                    Auto (Interval)
                   </button>
                   <div
                     className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
@@ -107,6 +107,115 @@ Array [
         id="random_html_id-help-0"
       >
         Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="random_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="random_html_id"
+      >
+        Refresh increments
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="random_html_id-help-0"
+            aria-label="Refresh increments"
+            className="euiFieldNumber euiFieldNumber--inGroup"
+            id="random_html_id"
+            min={1}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Refresh increments"
+            type="number"
+            value={15}
+          />
+        </div>
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <select
+              className="euiSelect euiFormControlLayout__append"
+              onChange={[Function]}
+              onMouseUp={[Function]}
+              value="minute"
+            >
+              <option
+                key="0"
+                value="minute"
+              >
+                minutes(s)
+              </option>
+              <option
+                key="1"
+                value="hour"
+              >
+                hour(s)
+              </option>
+              <option
+                key="2"
+                value="day"
+              >
+                day(s)
+              </option>
+              <option
+                key="3"
+                value="week"
+              >
+                week(s)
+              </option>
+            </select>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                className="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="random_html_id-help-0"
+      >
+        Specify how frequent the index gets updated when performing the refresh job.
       </div>
     </div>
   </div>,
@@ -239,7 +348,7 @@ Array [
               <input
                 id="random_html_id"
                 type="hidden"
-                value="auto"
+                value="autoInterval"
               />,
               <div
                 className="euiFormControlLayout"
@@ -251,7 +360,7 @@ Array [
                     className="euiScreenReaderOnly"
                     id="random_html_id"
                   >
-                    Select an option: Auto, is selected
+                    Select an option: Auto (Interval), is selected
                   </span>
                   <button
                     aria-describedby="random_html_id-help-0"
@@ -264,7 +373,7 @@ Array [
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    Auto
+                    Auto (Interval)
                   </button>
                   <div
                     className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
@@ -301,6 +410,116 @@ Array [
         id="random_html_id-help-0"
       >
         Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="random_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="random_html_id"
+      >
+        Refresh increments
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="random_html_id-help-0"
+            aria-label="Refresh increments"
+            className="euiFieldNumber euiFieldNumber--inGroup"
+            id="random_html_id"
+            min={1}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Refresh increments"
+            type="number"
+            value={15}
+          />
+        </div>
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <select
+              className="euiSelect euiFormControlLayout__append"
+              onChange={[Function]}
+              onMouseUp={[Function]}
+              value="minute"
+            >
+              <option
+                key="0"
+                value="minute"
+              >
+                minutes(s)
+              </option>
+              <option
+                key="1"
+                value="hour"
+              >
+                hour(s)
+              </option>
+              <option
+                key="2"
+                value="day"
+              >
+                day(s)
+              </option>
+              <option
+                key="3"
+                value="week"
+              >
+                week(s)
+              </option>
+            </select>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                className="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="random_html_id-help-0"
+      >
+        Specify how frequent the index gets updated when performing the refresh job.
       </div>
     </div>
   </div>,
@@ -432,7 +651,7 @@ Array [
               <input
                 id="random_html_id"
                 type="hidden"
-                value="auto"
+                value="autoInterval"
               />,
               <div
                 className="euiFormControlLayout"
@@ -444,7 +663,7 @@ Array [
                     className="euiScreenReaderOnly"
                     id="random_html_id"
                   >
-                    Select an option: Auto, is selected
+                    Select an option: Auto (Interval), is selected
                   </span>
                   <button
                     aria-describedby="random_html_id-help-0"
@@ -457,7 +676,7 @@ Array [
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    Auto
+                    Auto (Interval)
                   </button>
                   <div
                     className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
@@ -494,6 +713,116 @@ Array [
         id="random_html_id-help-0"
       >
         Specify how often the index should refresh, which publishes the most recent changes and make them available for search.
+      </div>
+    </div>
+  </div>,
+  <div
+    className="euiFormRow"
+    id="random_html_id-row"
+  >
+    <div
+      className="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid={false}
+        className="euiFormLabel euiFormRow__label"
+        htmlFor="random_html_id"
+      >
+        Refresh increments
+      </label>
+    </div>
+    <div
+      className="euiFormRow__fieldWrapper"
+    >
+      <div
+        className="euiFormControlLayout euiFormControlLayout--group"
+      >
+        <div
+          className="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="random_html_id-help-0"
+            aria-label="Refresh increments"
+            className="euiFieldNumber euiFieldNumber--inGroup"
+            id="random_html_id"
+            min={1}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Refresh increments"
+            type="number"
+            value={15}
+          />
+        </div>
+        <div
+          className="euiFormControlLayout"
+        >
+          <div
+            className="euiFormControlLayout__childrenWrapper"
+          >
+            <select
+              className="euiSelect euiFormControlLayout__append"
+              onChange={[Function]}
+              onMouseUp={[Function]}
+              value="minute"
+            >
+              <option
+                key="0"
+                value="minute"
+              >
+                minutes(s)
+              </option>
+              <option
+                key="1"
+                value="hour"
+              >
+                hour(s)
+              </option>
+              <option
+                key="2"
+                value="day"
+              >
+                day(s)
+              </option>
+              <option
+                key="3"
+                value="week"
+              >
+                week(s)
+              </option>
+            </select>
+            <div
+              className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+            >
+              <span
+                className="euiFormControlLayoutCustomIcon"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                  focusable="false"
+                  height={16}
+                  role="img"
+                  style={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fillRule="non-zero"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="euiFormHelpText euiFormRow__text"
+        id="random_html_id-help-0"
+      >
+        Specify how frequent the index gets updated when performing the refresh job.
       </div>
     </div>
   </div>,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
@@ -156,6 +156,7 @@ Array [
           >
             <select
               className="euiSelect euiFormControlLayout__append"
+              onBlur={[Function]}
               onChange={[Function]}
               onMouseUp={[Function]}
               value="minute"
@@ -459,6 +460,7 @@ Array [
           >
             <select
               className="euiSelect euiFormControlLayout__append"
+              onBlur={[Function]}
               onChange={[Function]}
               onMouseUp={[Function]}
               value="minute"
@@ -762,6 +764,7 @@ Array [
           >
             <select
               className="euiSelect euiFormControlLayout__append"
+              onBlur={[Function]}
               onChange={[Function]}
               onMouseUp={[Function]}
               value="minute"

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/index_setting_options.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/index_setting_options.test.tsx
@@ -40,7 +40,7 @@ describe('Index settings acceleration components', () => {
       ...createAccelerationEmptyDataMock,
       primaryShardsCount: 1,
       replicaShardsCount: 5,
-      refreshType: 'auto',
+      refreshType: 'manual',
     };
     const setAccelerationFormData = jest.fn();
     const wrapper = mount(

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
@@ -88,7 +88,9 @@ export const IndexSettingOptions = ({
     'autoInterval'
   );
   const [refreshWindow, setRefreshWindow] = useState(15);
-  const [refreshInterval, setRefreshInterval] = useState(ACCELERATION_TIME_INTERVAL[2].value);
+  const [refreshInterval, setRefreshInterval] = useState(
+    ACCELERATION_REFRESH_TIME_INTERVAL[0].value
+  );
   const [delayWindow, setDelayWindow] = useState(1);
   const [delayInterval, setDelayInterval] = useState(ACCELERATION_TIME_INTERVAL[2].value);
   const [checkpoint, setCheckpoint] = useState('');
@@ -204,6 +206,17 @@ export const IndexSettingOptions = ({
                 value={refreshInterval}
                 onChange={onChangeRefreshInterval}
                 options={ACCELERATION_REFRESH_TIME_INTERVAL}
+                onBlur={(e) => {
+                  setAccelerationFormData(
+                    producer((accData) => {
+                      accData.formErrors.refreshIntervalError = validateRefreshInterval(
+                        refreshTypeSelected,
+                        refreshWindow,
+                        e.target.value
+                      );
+                    })
+                  );
+                }}
               />
             }
           />

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
@@ -17,6 +17,7 @@ import producer from 'immer';
 import React, { ChangeEvent, Fragment, useState } from 'react';
 import {
   ACC_CHECKPOINT_DOCUMENTATION_URL,
+  ACCELERATION_REFRESH_TIME_INTERVAL,
   ACCELERATION_TIME_INTERVAL,
 } from '../../../../../../../../common/constants/data_sources';
 import {
@@ -41,20 +42,6 @@ export const IndexSettingOptions = ({
   setAccelerationFormData,
 }: IndexSettingOptionsProps) => {
   const refreshOptions = [
-    {
-      value: 'auto',
-      inputDisplay: 'Auto',
-      dropdownDisplay: (
-        <Fragment>
-          <strong>Auto</strong>
-          <EuiText size="s" color="subdued">
-            <p className="EuiTextColor--subdued">
-              Automatically refreshes the index when new data is available.
-            </p>
-          </EuiText>
-        </Fragment>
-      ),
-    },
     {
       value: 'autoInterval',
       inputDisplay: 'Auto (Interval)',
@@ -97,8 +84,10 @@ export const IndexSettingOptions = ({
     },
   ];
 
-  const [refreshTypeSelected, setRefreshTypeSelected] = useState<AccelerationRefreshType>('auto');
-  const [refreshWindow, setRefreshWindow] = useState(1);
+  const [refreshTypeSelected, setRefreshTypeSelected] = useState<AccelerationRefreshType>(
+    'autoInterval'
+  );
+  const [refreshWindow, setRefreshWindow] = useState(15);
   const [refreshInterval, setRefreshInterval] = useState(ACCELERATION_TIME_INTERVAL[2].value);
   const [delayWindow, setDelayWindow] = useState(1);
   const [delayInterval, setDelayInterval] = useState(ACCELERATION_TIME_INTERVAL[2].value);
@@ -204,7 +193,8 @@ export const IndexSettingOptions = ({
                 producer((accData) => {
                   accData.formErrors.refreshIntervalError = validateRefreshInterval(
                     refreshTypeSelected,
-                    parseInt(e.target.value, 10)
+                    parseInt(e.target.value, 10),
+                    refreshInterval
                   );
                 })
               );
@@ -213,7 +203,7 @@ export const IndexSettingOptions = ({
               <EuiSelect
                 value={refreshInterval}
                 onChange={onChangeRefreshInterval}
-                options={ACCELERATION_TIME_INTERVAL}
+                options={ACCELERATION_REFRESH_TIME_INTERVAL}
               />
             }
           />

--- a/test/accelerations.ts
+++ b/test/accelerations.ts
@@ -5,6 +5,7 @@
 
 import {
   ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
+  ACCELERATION_REFRESH_TIME_INTERVAL,
   ACCELERATION_TIME_INTERVAL,
 } from '../common/constants/data_sources';
 import {
@@ -102,11 +103,11 @@ export const createAccelerationEmptyDataMock: CreateAccelerationForm = {
   accelerationIndexName: ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
   primaryShardsCount: 5,
   replicaShardsCount: 1,
-  refreshType: 'auto',
+  refreshType: 'autoInterval',
   checkpointLocation: undefined,
   refreshIntervalOptions: {
-    refreshWindow: 1,
-    refreshInterval: ACCELERATION_TIME_INTERVAL[1].value,
+    refreshWindow: 15,
+    refreshInterval: ACCELERATION_REFRESH_TIME_INTERVAL[0].value,
   },
   watermarkDelay: {
     delayWindow: 1,
@@ -132,12 +133,17 @@ export const indexOptionsMock1: CreateAccelerationForm = {
   ...createAccelerationEmptyDataMock,
   primaryShardsCount: 3,
   replicaShardsCount: 2,
-  refreshType: 'auto',
+  refreshType: 'autoInterval',
+  refreshIntervalOptions: {
+    refreshWindow: 15,
+    refreshInterval: ACCELERATION_REFRESH_TIME_INTERVAL[0].value,
+  },
 };
 
 export const indexOptionsMockResult1 = `WITH (
 index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
-auto_refresh = true
+auto_refresh = true,
+refresh_interval = '15 minutes'
 )`;
 
 export const indexOptionsMock2: CreateAccelerationForm = {
@@ -147,27 +153,32 @@ export const indexOptionsMock2: CreateAccelerationForm = {
   refreshType: 'autoInterval',
   refreshIntervalOptions: {
     refreshWindow: 10,
-    refreshInterval: 'minute',
+    refreshInterval: ACCELERATION_REFRESH_TIME_INTERVAL[1].value,
   },
 };
 
 export const indexOptionsMockResult2 = `WITH (
 index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
 auto_refresh = true,
-refresh_interval = '10 minutes'
+refresh_interval = '10 hours'
 )`;
 
 export const indexOptionsMock3: CreateAccelerationForm = {
   ...createAccelerationEmptyDataMock,
   primaryShardsCount: 3,
   replicaShardsCount: 2,
-  refreshType: 'auto',
+  refreshType: 'autoInterval',
+  refreshIntervalOptions: {
+    refreshWindow: 10,
+    refreshInterval: ACCELERATION_REFRESH_TIME_INTERVAL[1].value,
+  },
   checkpointLocation: 's3://path/to/checkpoint',
 };
 
 export const indexOptionsMockResult3 = `WITH (
 index_settings = '{"number_of_shards":3,"number_of_replicas":2}',
 auto_refresh = true,
+refresh_interval = '10 hours',
 checkpoint_location = 's3://path/to/checkpoint'
 )`;
 
@@ -294,7 +305,7 @@ export const skippingIndexBuilderMock2: CreateAccelerationForm = {
   ],
   primaryShardsCount: 5,
   replicaShardsCount: 3,
-  refreshType: 'auto',
+  refreshType: 'manual',
   checkpointLocation: 's3://test/',
 };
 
@@ -303,8 +314,8 @@ ON datasource.database.table (
    \`field1\` PARTITION
   ) WITH (
 index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
-auto_refresh = true,
-checkpoint_location = 's3://test/'
+auto_refresh = false,
+incremental_refresh = false
 )`;
 
 export const coveringIndexBuilderMock1: CreateAccelerationForm = {
@@ -345,7 +356,7 @@ export const coveringIndexBuilderMock2: CreateAccelerationForm = {
   coveringIndexQueryData: ['field1'],
   primaryShardsCount: 5,
   replicaShardsCount: 3,
-  refreshType: 'auto',
+  refreshType: 'manualIncrement',
   checkpointLocation: 's3://test/',
 };
 
@@ -354,7 +365,8 @@ ON datasource.database.table (
    \`field1\`
   ) WITH (
 index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
-auto_refresh = true,
+auto_refresh = false,
+incremental_refresh = true,
 checkpoint_location = 's3://test/'
 )`;
 
@@ -427,7 +439,7 @@ export const materializedViewBuilderMock2: CreateAccelerationForm = {
   },
   primaryShardsCount: 5,
   replicaShardsCount: 3,
-  refreshType: 'auto',
+  refreshType: 'manualIncrement',
   checkpointLocation: 's3://test/',
   watermarkDelay: {
     delayWindow: 2,
@@ -442,7 +454,8 @@ FROM datasource.database.table
 GROUP BY TUMBLE (\`timestamp\`, '2 hours')
  WITH (
 index_settings = '{"number_of_shards":5,"number_of_replicas":3}',
-auto_refresh = true,
+auto_refresh = false,
+incremental_refresh = true,
 watermark_delay = '2 minutes',
 checkpoint_location = 's3://test/'
 )`;


### PR DESCRIPTION
### Description
Remove auto refresh option, update tests

### Issues Resolved
1. Remove auto refresh option without interval
2. Set minimum refresh time as 15 mins
3. Update tests
<img width="1790" alt="Screenshot 2024-04-17 at 6 24 48 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/4348487/4f57ecb3-dcf4-4f42-a53b-b72ec1eb40e3">
<img width="1792" alt="Screenshot 2024-04-17 at 6 25 13 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/4348487/b050696c-0c16-4d34-ac90-d29507382aeb">



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
