### PR TITLE
[Integrations] Add default refresh interval for all the integrations and correct the version on `main`

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
-  "version": "2.13.0.0",
-  "opensearchDashboardsVersion": "2.13.0",
+  "version": "3.0.0.0",
+  "opensearchDashboardsVersion": "3.0.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observability-dashboards",
-  "version": "2.13.0.0",
+  "version": "3.0.0.0",
   "main": "index.ts",
   "license": "Apache-2.0",
   "scripts": {

--- a/server/adaptors/integrations/__data__/repository/apache/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/apache/assets/create_mv-1.0.0.sql
@@ -9,7 +9,8 @@ SELECT
     'apache.access' AS `event.domain`
 FROM {table_name}
 WITH (
-    auto_refresh = 'true',
+    auto_refresh = true,
+    refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
     watermark_delay = '1 Minute',
     extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/aws_cloudfront/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_cloudfront/assets/create_mv-1.0.0.sql
@@ -36,6 +36,7 @@ FROM
   {table_name}
 WITH (
   auto_refresh = true,
+  refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
   watermark_delay = '1 Minute',
   extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-1.0.0.sql
@@ -48,6 +48,7 @@ FROM
     LATERAL VIEW explode(Records) myTable AS rec
 WITH (
     auto_refresh = true,
+    refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
     watermark_delay = '1 Minute',
     extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/aws_elb/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_elb/assets/create_mv-1.0.0.sql
@@ -53,6 +53,7 @@ FROM
     {table_name}
 WITH (
     auto_refresh = true,
+    refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
     watermark_delay = '1 Minute',
     extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/aws_s3/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_s3/assets/create_mv-1.0.0.sql
@@ -29,6 +29,7 @@ FROM
   {table_name}
 WITH (
   auto_refresh = true,
+  refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
   watermark_delay = '1 Minute',
   extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/aws_waf/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_waf/assets/create_mv-1.0.0.sql
@@ -22,6 +22,7 @@ FROM
     {table_name}
 WITH (
   auto_refresh = true,
+  refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
   watermark_delay = '1 Minute',
   extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/haproxy/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/haproxy/assets/create_mv-1.0.0.sql
@@ -144,6 +144,7 @@ SELECT
 FROM {table_name}
 WITH (
     auto_refresh = true,
+    refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
     watermark_delay = '1 Minute',
     extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'

--- a/server/adaptors/integrations/__data__/repository/nginx/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/nginx/assets/create_mv-1.0.0.sql
@@ -10,6 +10,7 @@ SELECT
 FROM {table_name}
 WITH (
     auto_refresh = 'true',
+    refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
     watermark_delay = '1 Minute',
     extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'


### PR DESCRIPTION
### Description
- Add default refresh interval for all the integrations, and limit it to `15 Minute` as default.
- Correct the version on `main`

### Note
For VPC integration still awaiting on PR: https://github.com/opensearch-project/dashboards-observability/pull/1691 (cc: @YANG-DB )

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
