### PR TITLE
[Forward port] Set up a default refresh interval for VPC integration's MV

### DIFF
--- a/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/vpc_live_all_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_vpc_flow/assets/vpc_live_all_mv-1.0.0.sql
@@ -54,9 +54,9 @@ CREATE MATERIALIZED VIEW {table_name}__week_live_mview AS
     {table_name}
 WITH (
   auto_refresh = true,
-  refresh_interval = '1 Minute',
+  refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
-  watermark_delay = '10 Second',
+  watermark_delay = '1 Minute',
   extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
 )
 


### PR DESCRIPTION
### Description
Set up a default refresh interval for VPC integration's MV

### Issues Resolved
* Relate https://github.com/opensearch-project/dashboards-observability/pull/1721

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
