### PR TITLE
[BugFix] Fix `S3_DATASOURCE_TYPE` naming typo in `plugin.tsx`

### DIFF
--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -21,7 +21,7 @@ import { createGetterSetter } from '../../../src/plugins/opensearch_dashboards_u
 import { CREATE_TAB_PARAM, CREATE_TAB_PARAM_KEY, TAB_CHART_ID } from '../common/constants/explorer';
 import {
   DATACONNECTIONS_BASE,
-  S3_DATASOURCE_TYPE,
+  S3_DATA_SOURCE_TYPE,
   SECURITY_PLUGIN_ACCOUNT_API,
   observabilityApplicationsID,
   observabilityApplicationsPluginOrder,


### PR DESCRIPTION
### Description
Fix `S3_DATASOURCE_TYPE` naming typo in `plugin.tsx`

### Error Msg
```
Version: 2.13.0
Build: 9007199254740991
ReferenceError: S3_DATA_SOURCE_TYPE is not defined
    at ObservabilityPlugin.start (http://0.0.0.0:5601/9007199254740991/bundles/plugin/observabilityDashboards/observabilityDashboards.plugin.js:370683:46)
    at PluginWrapper.start (http://0.0.0.0:5601/9007199254740991/bundles/core/core.entry.js:28328:47)
    at PluginsService.start (http://0.0.0.0:5601/9007199254740991/bundles/core/core.entry.js:28704:25)
    at async CoreSystem.start (http://0.0.0.0:5601/9007199254740991/bundles/core/core.entry.js:22094:7)
    at async Module.__osdBootstrap__ (http://0.0.0.0:5601/9007199254740991/bundles/core/core.entry.js:27045:17)
```

### Issues Resolved
* Introduced by https://github.com/opensearch-project/dashboards-observability/pull/1752

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
