### PR TITLE
remove defaulting to query assist time range

### DIFF
--- a/public/components/event_analytics/explorer/log_explorer.tsx
+++ b/public/components/event_analytics/explorer/log_explorer.tsx
@@ -79,9 +79,7 @@ export const LogExplorer = ({
     });
   };
 
-  const dateRange = coreRefs.queryAssistEnabled
-    ? [QUERY_ASSIST_START_TIME, QUERY_ASSIST_END_TIME]
-    : getDateRange(undefined, undefined, queries[tabIds[0]]);
+  const dateRange = getDateRange(undefined, undefined, queries[tabIds[0]]);
   const [startTime, setStartTime] = useState(dateRange[0]);
   const [endTime, setEndTime] = useState(dateRange[1]);
 


### PR DESCRIPTION
### Description
Query assist enabled variable will gets reloaded based on http response telling whether PPL agent is configured. The time range usually sets before the response returns, which makes the time range to be last 40 years if query assist is enabled but not configured. Since time range picker is removed from UI, this logic can also be removed.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
