### PR TITLE
Fix data connection api 404 error

### DIFF
--- a/server/routes/data_connections/data_connections_router.ts
+++ b/server/routes/data_connections/data_connections_router.ts
@@ -183,6 +183,29 @@ export function registerDataConnectionsRoute(router: IRouter, dataSourceEnabled:
 
   router.get(
     {
+      path: `${DATACONNECTIONS_BASE}`,
+      validate: false,
+    },
+    async (context, request, response): Promise<any> => {
+      try {
+        const dataConnectionsresponse = await context.observability_plugin.observabilityClient
+          .asScoped(request)
+          .callAsCurrentUser('ppl.getDataConnections');
+        return response.ok({
+          body: dataConnectionsresponse,
+        });
+      } catch (error: any) {
+        console.error('Issue in fetching data sources:', error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.response,
+        });
+      }
+    }
+  );
+
+  router.get(
+    {
       path: `${DATACONNECTIONS_BASE}/dataSourceMDSId={dataSourceMDSId?}`,
       validate: {
         params: schema.object({


### PR DESCRIPTION
### Description
/api/dataconnections API is failing with 404 due to changes introduced from this [change](https://github.com/opensearch-project/dashboards-observability/commit/fdf2808f515f87d03068412f73b4b884296615ea#diff-ffbf68401b3813188bc809411d7b447f47dbefcc686286394a00c910bcc78c64L48):  this PR fix this issue.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
