### PR TITLE
Fix window start backtick during MV creation

### DIFF
--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
@@ -115,34 +115,39 @@ export const ColumnExpression = ({
                     />
                   </EuiFormRow>
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiFormRow label="Aggregation field">
-                    <EuiComboBox
-                      singleSelection={{ asPlainText: true }}
-                      options={[
-                        {
-                          label: '*',
-                          disabled: currentColumnExpressionValue.functionName !== 'count',
-                        },
-                        ...accelerationFormData.dataTableFields.map((x) => ({
-                          label: x.fieldName,
-                        })),
-                      ]}
-                      selectedOptions={[
-                        {
-                          label: currentColumnExpressionValue.functionParam,
-                        },
-                      ]}
-                      onChange={(fieldOption) =>
-                        updateColumnExpressionValue(
-                          { ...currentColumnExpressionValue, functionParam: fieldOption[0].label },
-                          index
-                        )
-                      }
-                      isClearable={false}
-                    />
-                  </EuiFormRow>
-                </EuiFlexItem>
+                {currentColumnExpressionValue.functionName !== 'window.start' && (
+                  <EuiFlexItem grow={false}>
+                    <EuiFormRow label="Aggregation field">
+                      <EuiComboBox
+                        singleSelection={{ asPlainText: true }}
+                        options={[
+                          {
+                            label: '*',
+                            disabled: currentColumnExpressionValue.functionName !== 'count',
+                          },
+                          ...accelerationFormData.dataTableFields.map((x) => ({
+                            label: x.fieldName,
+                          })),
+                        ]}
+                        selectedOptions={[
+                          {
+                            label: currentColumnExpressionValue.functionParam,
+                          },
+                        ]}
+                        onChange={(fieldOption) =>
+                          updateColumnExpressionValue(
+                            {
+                              ...currentColumnExpressionValue,
+                              functionParam: fieldOption[0].label,
+                            },
+                            index
+                          )
+                        }
+                        isClearable={false}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
             </>
           </EuiPopover>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/query_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/query_builder.tsx
@@ -148,7 +148,7 @@ const buildMaterializedViewColumns = (columnsValues: MaterializedViewColumn[]) =
         `   ${
           column.functionName !== 'window.start'
             ? `${column.functionName}(${buildMaterializedViewColumnName(column.functionParam!)})`
-            : `\`${column.functionName}\``
+            : `${column.functionName}`
         }${column.fieldAlias ? ` AS \`${column.fieldAlias}\`` : ``}`
     )
     .join(', \n');

--- a/test/accelerations.ts
+++ b/test/accelerations.ts
@@ -411,7 +411,7 @@ AS SELECT
    count(*) AS \`counter1\`, 
    sum(\`field2\`), 
    avg(\`field3\`) AS \`average\`, 
-   \`window.start\` AS \`start\`
+   window.start AS \`start\`
 FROM datasource.database.table
 GROUP BY TUMBLE (\`timestamp\`, '1 minute')
  WITH (


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>
(cherry picked from commit c7ee338cd882f0787e1537bc3924901682df085f)

### Description
Fix window start backtick during MV creation

### Issues Resolved
#1819 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
