### PR TITLE
Optimize lodash use for tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lint-staged": "^13.1.0"
   },
   "resolutions": {
+    "@types/react": "^16.14.23",
     "react-syntax-highlighter": "^15.4.3",
     "prismjs": "^1.22.0",
     "trim": "^1.0.0",

--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -31,7 +31,7 @@ import {
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import React, { ReactElement, useEffect, useState } from 'react';
 import moment from 'moment';
 import { DeleteModal } from '../../common/helpers/delete_modal';
@@ -222,7 +222,7 @@ export function AppTable(props: AppTableProps) {
       truncateText: true,
       render: (value, record) => (
         <EuiLink data-test-subj={`${record.name}ApplicationLink`} href={`#/${record.id}`}>
-          {_.truncate(record.name, { length: 100 })}
+          {truncate(record.name, { length: 100 })}
         </EuiLink>
       ),
     },

--- a/public/components/application_analytics/components/application.tsx
+++ b/public/components/application_analytics/components/application.tsx
@@ -25,7 +25,6 @@ import TimestampUtils from 'public/services/timestamp/timestamp';
 import React, { ReactChild, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { last } from 'lodash';
 import { VisualizationType } from 'common/types/custom_panels';
 import { TracesContent } from '../../../components/trace_analytics/components/traces/traces_content';
 import { DashboardContent } from '../../../components/trace_analytics/components/dashboard/dashboard_content';

--- a/public/components/application_analytics/components/configuration.tsx
+++ b/public/components/application_analytics/components/configuration.tsx
@@ -24,7 +24,6 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { ApplicationRequestType, ApplicationType } from 'common/types/application_analytics';
-import { last } from 'lodash';
 import React, { useState } from 'react';
 
 interface ConfigProps {

--- a/public/components/application_analytics/components/create.tsx
+++ b/public/components/application_analytics/components/create.tsx
@@ -26,7 +26,6 @@ import {
 import DSLService from 'public/services/requests/dsl';
 import React, { ReactChild, useEffect, useState } from 'react';
 import PPLService from 'public/services/requests/ppl';
-import { last } from 'lodash';
 import { AppAnalyticsComponentDeps } from '../home';
 import { TraceConfig } from './config_components/trace_config';
 import { ServiceConfig } from './config_components/service_config';

--- a/public/components/application_analytics/components/flyout_components/service_detail_flyout.tsx
+++ b/public/components/application_analytics/components/flyout_components/service_detail_flyout.tsx
@@ -13,7 +13,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   filtersToDsl,
@@ -79,7 +79,7 @@ export function ServiceDetailFlyout(props: ServiceFlyoutProps) {
       ),
       getListItem(
         'Error rate',
-        fields.error_rate !== undefined ? _.round(fields.error_rate, 2).toString() + '%' : '-'
+        fields.error_rate !== undefined ? round(fields.error_rate, 2).toString() + '%' : '-'
       ),
       getListItem('Throughput', fields.throughput !== undefined ? fields.throughput : '-'),
       getListItem('Traces', fields.traces === 0 || fields.traces ? fields.traces : '-'),

--- a/public/components/application_analytics/home.tsx
+++ b/public/components/application_analytics/home.tsx
@@ -12,7 +12,7 @@ import SavedObjects from 'public/services/saved_objects/event_analytics/saved_ob
 import TimestampUtils from 'public/services/timestamp/timestamp';
 import { EuiGlobalToastList, EuiLink } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
-import { isEmpty, last } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useDispatch } from 'react-redux';
 import { AppTable } from './components/app_table';
 import { Application } from './components/application';

--- a/public/components/common/debounced_component/debounced_component.tsx
+++ b/public/components/common/debounced_component/debounced_component.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useMemo, useEffect, memo, FunctionComponent } from 'react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 /**
  * debouncedComponent wraps the specified React component, returning a component which

--- a/public/components/common/helpers/ppl_reference_flyout.tsx
+++ b/public/components/common/helpers/ppl_reference_flyout.tsx
@@ -19,7 +19,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { PPL_DOCUMENTATION_URL } from '../../../../common/constants/shared';
-import _ from 'lodash';
+import find from 'lodash/find';
 import React, { useState } from 'react';
 import { FlyoutContainers } from '../flyout_containers';
 import { Group1, Group2, Group3 } from './ppl_docs/groups';
@@ -33,7 +33,7 @@ type Props = {
 export const PPLReferenceFlyout = ({ module, closeFlyout }: Props) => {
   const allOptionsStatic = [{ label: 'Overview', value: overview }, Group1, Group2, Group3];
   const defaultOption =
-    module === 'explorer' ? [allOptionsStatic[0]] : [_.find(Group1.options, ['label', 'where'])];
+    module === 'explorer' ? [allOptionsStatic[0]] : [find(Group1.options, ['label', 'where'])];
   const [selectedOptions, setSelected] = useState(defaultOption);
   const [flyoutContent, setFlyoutContent] = useState(
     <EuiMarkdownFormat>{defaultOption[0].value}</EuiMarkdownFormat>

--- a/public/components/common/query_utils/index.ts
+++ b/public/components/common/query_utils/index.ts
@@ -5,7 +5,7 @@
 
 import dateMath from '@elastic/datemath';
 import { Moment } from 'moment-timezone';
-import _, { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { SearchMetaData } from '../../event_analytics/redux/slices/search_meta_data_slice';
 import {
   PPL_DEFAULT_PATTERN_REGEX_FILETER,

--- a/public/components/common/search/autocomplete_logic.ts
+++ b/public/components/common/search/autocomplete_logic.ts
@@ -4,7 +4,7 @@
  */
 
 import DSLService from 'public/services/requests/dsl';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { getDataValueQuery } from './queries/data_queries';
 import {
   statsCommands,

--- a/public/components/common/search/direct_search.tsx
+++ b/public/components/common/search/direct_search.tsx
@@ -19,7 +19,8 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { isEmpty, isEqual } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import React, { useEffect, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import {

--- a/public/components/common/search/request_handler.tsx
+++ b/public/components/common/search/request_handler.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
 import { CoreStart } from '../../../../../../src/core/public';
 
 const DSL_ROUTE = '/api/dsl/search';

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -20,7 +20,7 @@ import {
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import React, { useEffect, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import { QUERY_LANGUAGE } from '../../../../common/constants/data_sources';

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -31,7 +31,8 @@ import {
 } from '@elastic/eui';
 import React, { ReactElement, useEffect, useState } from 'react';
 import moment from 'moment';
-import _ from 'lodash';
+import last from 'lodash/last';
+import truncate from 'lodash/truncate';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { coreRefs } from '../../framework/core_refs';
@@ -315,8 +316,8 @@ export const CustomPanelTable = ({
       sortable: true,
       truncateText: true,
       render: (value, record) => (
-        <EuiLink href={`${_.last(parentBreadcrumbs)!.href}${record.id}`}>
-          {_.truncate(value, { length: 100 })}
+        <EuiLink href={`${last(parentBreadcrumbs)!.href}${record.id}`}>
+          {truncate(value, { length: 100 })}
         </EuiLink>
       ),
     },

--- a/public/components/custom_panels/custom_panel_view.tsx
+++ b/public/components/custom_panels/custom_panel_view.tsx
@@ -25,11 +25,11 @@ import {
   OnTimeChangeProps,
   ShortDate,
 } from '@elastic/eui';
-import { last } from 'lodash';
+import last from 'lodash/last';
+import isEmpty from 'lodash/isEmpty';
 import React, { useEffect, useState } from 'react';
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
 import moment from 'moment';
-import _ from 'lodash';
 import { useDispatch } from 'react-redux';
 import DSLService from '../../services/requests/dsl';
 import { CoreStart } from '../../../../../src/core/public';
@@ -392,7 +392,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
         (error: VizContainerError) => setToast(error.errorMessage, 'danger')
       );
 
-      if (!_.isEmpty(visData)) {
+      if (!isEmpty(visData)) {
         const moreIndices = parseForIndices(visData.query);
         for (let j = 0; j < moreIndices.length; j++) {
           if (!indices.includes(moreIndices[j])) {

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -27,7 +27,7 @@ import {
   ShortDate,
 } from '@elastic/eui';
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
-import { last } from 'lodash';
+import last from 'lodash/last';
 import moment from 'moment';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';

--- a/public/components/custom_panels/helpers/utils.tsx
+++ b/public/components/custom_panels/helpers/utils.tsx
@@ -5,7 +5,11 @@
 
 import { ShortDate } from '@elastic/eui';
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
-import _, { forEach, isEmpty, min } from 'lodash';
+import differenceWith from 'lodash/differenceWith';
+import forEach from 'lodash/forEach';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import min from 'lodash/min';
 import { Moment } from 'moment-timezone';
 import React from 'react';
 import { Layout } from 'react-grid-layout';
@@ -215,7 +219,7 @@ export const renderSavedVisualization = async ({
   setIsLoading(true);
   setIsError({} as VizContainerError);
 
-  if (_.isEmpty(visualization)) {
+  if (isEmpty(visualization)) {
     setIsLoading(false);
     return;
   }
@@ -724,7 +728,7 @@ export const displayVisualization = (metaData: any, data: any, type: string) => 
 
   metaData.userConfigs = parseMetadataUserConfig(metaData.userConfigs);
   const dataConfig = { ...(metaData.userConfigs?.dataConfig || {}) };
-  const hasBreakdowns = !_.isEmpty(dataConfig.breakdowns);
+  const hasBreakdowns = !isEmpty(dataConfig.breakdowns);
   const realTimeParsedStats = {
     ...getDefaultVisConfig(new QueryManager().queryParser().parse(metaData.query).getStats()),
   };
@@ -733,8 +737,8 @@ export const displayVisualization = (metaData: any, data: any, type: string) => 
 
   // filter out breakdowns from dimnesions
   if (hasBreakdowns) {
-    finalDimensions = _.differenceWith(finalDimensions, breakdowns, (dimn, brkdwn) =>
-      _.isEqual(removeBacktick(dimn.name), removeBacktick(brkdwn.name))
+    finalDimensions = differenceWith(finalDimensions, breakdowns, (dimn, brkdwn) =>
+      isEqual(removeBacktick(dimn.name), removeBacktick(brkdwn.name))
     );
   }
 

--- a/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
+++ b/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
@@ -4,7 +4,8 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import _ from 'lodash';
+import reject from 'lodash/reject';
+import omit from 'lodash/omit';
 import React, { useEffect, useState } from 'react';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
 import useObservable from 'react-use/lib/useObservable';
@@ -130,7 +131,7 @@ export const PanelGrid = (props: PanelGridProps) => {
 
   // remove visualization from panel in edit mode
   const removeVisualization = (visualizationId: string) => {
-    const newVisualizationList = _.reject(panelVisualizations, {
+    const newVisualizationList = reject(panelVisualizations, {
       id: visualizationId,
     });
     mergeLayoutAndVisualizations(postEditLayout, newVisualizationList, setPanelVisualizations);
@@ -164,7 +165,7 @@ export const PanelGrid = (props: PanelGridProps) => {
   useEffect(() => {
     if (editActionType === 'save') {
       const visualizationParams = postEditLayout.map((layout) =>
-        _.omit(layout, ['static', 'moved'])
+        omit(layout, ['static', 'moved'])
       );
       saveVisualizationLayouts(panelId, visualizationParams);
       if (updateAvailabilityVizId) {

--- a/public/components/custom_panels/panel_modules/panel_grid/panel_grid_so.tsx
+++ b/public/components/custom_panels/panel_modules/panel_grid/panel_grid_so.tsx
@@ -4,7 +4,9 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import _, { forEach } from 'lodash';
+import forEach from 'lodash/forEach';
+import reject from 'lodash/reject';
+import omit from 'lodash/omit';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Layout, Responsive, WidthProvider } from 'react-grid-layout';
@@ -129,7 +131,7 @@ export const PanelGridSO = (props: PanelGridProps) => {
 
   // remove visualization from panel in edit mode
   const removeVisualization = (visualizationId: string) => {
-    const newVisualizationList = _.reject(panelVisualizations, {
+    const newVisualizationList = reject(panelVisualizations, {
       id: visualizationId,
     });
     mergeLayoutAndVisualizations(postEditLayout, newVisualizationList, setPanelVisualizations);
@@ -174,7 +176,7 @@ export const PanelGridSO = (props: PanelGridProps) => {
   useEffect(() => {
     if (editActionType === 'save') {
       const visualizationParams = postEditLayout.map((layout) =>
-        _.omit(layout, ['static', 'moved'])
+        omit(layout, ['static', 'moved'])
       );
       saveVisualizationLayouts(panelId, visualizationParams);
       if (updateAvailabilityVizId) {

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -25,7 +25,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import React, { useEffect, useMemo, useState } from 'react';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useSelector } from 'react-redux';
 import {
   displayVisualization,

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -32,7 +32,7 @@ import {
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, { useEffect, useState } from 'react';
 import { CoreStart } from '../../../../../../../src/core/public';
 import { CUSTOM_PANELS_API_PREFIX } from '../../../../../common/constants/custom_panels';
@@ -382,7 +382,7 @@ export const VisaulizationFlyout = ({
           <EuiFlexItem>
             {previewLoading ? (
               <EuiLoadingChart size="xl" mono className="visualization-loading-chart-preview" />
-            ) : !_.isEmpty(isPreviewError) ? (
+            ) : !isEmpty(isPreviewError) ? (
               <div className="visualization-error-div">
                 <EuiIcon type="alert" color="danger" size="s" />
                 <EuiSpacer size="s" />

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -32,7 +32,7 @@ import {
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { CoreStart } from '../../../../../../../src/core/public';
@@ -364,7 +364,7 @@ export const VisaulizationFlyoutSO = ({
           <EuiFlexItem>
             {previewLoading ? (
               <EuiLoadingChart size="xl" mono className="visualization-loading-chart-preview" />
-            ) : !_.isEmpty(isPreviewError) ? (
+            ) : !isEmpty(isPreviewError) ? (
               <div className="visualization-error-div">
                 <EuiIcon type="alert" color="danger" size="s" />
                 <EuiSpacer size="s" />

--- a/public/components/custom_panels/redux/panel_slice.ts
+++ b/public/components/custom_panels/redux/panel_slice.ts
@@ -6,7 +6,7 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { concat, from, Observable, of } from 'rxjs';
 import { map, mergeMap, toArray } from 'rxjs/operators';
-import { forEach } from 'lodash';
+import forEach from 'lodash/forEach';
 import {
   createDemoPanel,
   CUSTOM_PANELS_API_PREFIX,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
@@ -14,7 +14,7 @@ import {
   EuiPopover,
 } from '@elastic/eui';
 import producer from 'immer';
-import _ from 'lodash';
+import filter from 'lodash/filter';
 import React, { useState } from 'react';
 import { ACCELERATION_AGGREGRATION_FUNCTIONS } from '../../../../../../../../../common/constants/data_sources';
 import {
@@ -51,7 +51,7 @@ export const ColumnExpression = ({
 
   const onDeleteColumnExpression = () => {
     const newColumnExpresionValue = [
-      ..._.filter(columnExpressionValues, (o) => o.id !== currentColumnExpressionValue.id),
+      ...filter(columnExpressionValues, (o) => o.id !== currentColumnExpressionValue.id),
     ];
     setAccelerationFormData(
       producer((accData) => {

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/materialized_view_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/materialized_view_builder.tsx
@@ -12,7 +12,7 @@ import {
   htmlIdGenerator,
 } from '@elastic/eui';
 import producer from 'immer';
-import { map } from 'lodash';
+import map from 'lodash/map';
 import React, { useEffect, useState } from 'react';
 import {
   AggregationFunctionType,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/add_fields_modal.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/add_fields_modal.tsx
@@ -14,7 +14,7 @@ import {
   EuiTableFieldDataColumnType,
 } from '@elastic/eui';
 import producer from 'immer';
-import _ from 'lodash';
+import differenceBy from 'lodash/differenceBy';
 import React, { useState } from 'react';
 import {
   CreateAccelerationForm,
@@ -66,7 +66,7 @@ export const AddFieldsModal = ({
 
       <EuiModalBody>
         <EuiInMemoryTable
-          items={_.differenceBy(
+          items={differenceBy(
             accelerationFormData.dataTableFields,
             accelerationFormData.skippingIndexQueryData,
             'id'

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/delete_fields_modal.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/delete_fields_modal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalHeaderTitle,
   EuiTableFieldDataColumnType,
 } from '@elastic/eui';
-import _ from 'lodash';
+import differenceBy from 'lodash/differenceBy';
 import React, { useState } from 'react';
 import {
   CreateAccelerationForm,
@@ -88,7 +88,7 @@ export const DeleteFieldsModal = ({
           onClick={() => {
             setAccelerationFormData({
               ...accelerationFormData,
-              skippingIndexQueryData: _.differenceBy(
+              skippingIndexQueryData: differenceBy(
                 accelerationFormData.skippingIndexQueryData,
                 selectedFields,
                 'id'

--- a/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
+++ b/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import _ from 'lodash';
 import {
   EuiInMemoryTable,
   EuiLink,

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -19,7 +19,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
+import escapeRegExp from 'lodash/escapeRegExp';
 import React, { useEffect, useState } from 'react';
 import {
   DATACONNECTIONS_BASE,
@@ -91,7 +91,7 @@ export const DataConnection = (props: { dataSource: string }) => {
 
   useEffect(() => {
     const searchDataSourcePattern = new RegExp(
-      `flint_${_.escapeRegExp(datasourceDetails.name)}_default_.*`
+      `flint_${escapeRegExp(datasourceDetails.name)}_default_.*`
     );
     const findIntegrations = async () => {
       // TODO: we just get all results and filter, ideally we send a filtering query to the API

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -18,7 +18,7 @@ import {
   EuiText,
   EuiFlyout,
 } from '@elastic/eui';
-import _ from 'lodash';
+import escapeRegExp from 'lodash/escapeRegExp';
 import { IntegrationHealthBadge } from '../../../../integrations/components/added_integration';
 import { SetupIntegrationForm } from '../../../../integrations/components/setup_integration';
 import { coreRefs } from '../../../../../framework/core_refs';
@@ -211,7 +211,7 @@ export const InstalledIntegrationsTable = ({
   const [query, setQuery] = useState('');
   const filteredIntegrations = integrations
     .map(instanceToTableEntry)
-    .filter((i) => i.name.match(new RegExp(_.escapeRegExp(query), 'i')));
+    .filter((i) => i.name.match(new RegExp(escapeRegExp(query), 'i')));
 
   const [showAvailableFlyout, setShowAvailableFlyout] = useState(false);
   const toggleFlyout = () => setShowAvailableFlyout((prev) => !prev);

--- a/public/components/datasources/components/manage/manage_data_connections_table.tsx
+++ b/public/components/datasources/components/manage/manage_data_connections_table.tsx
@@ -16,7 +16,7 @@ import {
   EuiPageContent,
   EuiTableFieldDataColumnType,
 } from '@elastic/eui';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import React, { useEffect, useState } from 'react';
 import {
   DATACONNECTIONS_BASE,
@@ -206,7 +206,7 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
               data-test-subj={`${record.name}DataConnectionsLink`}
               href={`#/manage/${record.name}`}
             >
-              {_.truncate(record.name, { length: 100 })}
+              {truncate(record.name, { length: 100 })}
             </EuiLink>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/public/components/event_analytics/explorer/events_views/docViewRow.tsx
+++ b/public/components/event_analytics/explorer/events_views/docViewRow.tsx
@@ -5,7 +5,11 @@
 
 import moment from 'moment';
 import React, { forwardRef, useImperativeHandle, useMemo, useState } from 'react';
-import { toPairs, uniqueId, has, forEach, isEqual } from 'lodash';
+import toPairs from 'lodash/toPairs';
+import uniqueId from 'lodash/uniqueId';
+import has from 'lodash/has';
+import forEach from 'lodash/forEach';
+import isEqual from 'lodash/isEqual';
 import { EuiButtonIcon, EuiLink } from '@elastic/eui';
 import { useEffect } from 'react';
 import { IExplorerFields, IField } from '../../../../../common/types/explorer';

--- a/public/components/event_analytics/explorer/events_views/docViewer.tsx
+++ b/public/components/event_analytics/explorer/events_views/docViewer.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import _ from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -37,7 +37,7 @@ export function DocViewer(props: IDocViewerProps) {
   const getTabList = () => {
     return [
       {
-        id: _.uniqueId('doc_viewer_tab_'),
+        id: uniqueId('doc_viewer_tab_'),
         name: 'Table',
         component: (tabProps: any) => (
           <DocViewTable
@@ -50,13 +50,13 @@ export function DocViewer(props: IDocViewerProps) {
         otherProps: {},
       },
       {
-        id: _.uniqueId('doc_viewer_tab_'),
+        id: uniqueId('doc_viewer_tab_'),
         name: 'JSON',
         component: (tabProps: any) => <JsonCodeBlock {...tabProps} />,
         otherProps: {},
       },
       {
-        id: _.uniqueId('doc_viewer_tab_'),
+        id: uniqueId('doc_viewer_tab_'),
         name: (
           <>
             <span>Traces</span>

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -21,7 +21,10 @@ import {
   EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
-import _, { isEmpty, isEqual, reduce } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import reduce from 'lodash/reduce';
+import sum from 'lodash/sum';
 import React, {
   ReactElement,
   useCallback,
@@ -559,7 +562,7 @@ export const Explorer = ({
                     {countDistribution?.data && !isLiveTailOnRef.current && (
                       <EuiPanel>
                         <HitsCounter
-                          hits={_.sum(countDistribution.data?.['count()'])}
+                          hits={sum(countDistribution.data?.['count()'])}
                           showResetButton={false}
                           onResetQuery={() => {}}
                         />
@@ -658,7 +661,7 @@ export const Explorer = ({
                         rawQuery={appBasedRef.current || queryRef.current![RAW_QUERY]}
                         totalHits={
                           showTimeBasedComponents
-                            ? _.sum(countDistribution.data?.['count()']) ||
+                            ? sum(countDistribution.data?.['count()']) ||
                               explorerData.datarows.length
                             : explorerData.datarows.length
                         }

--- a/public/components/event_analytics/explorer/log_explorer.tsx
+++ b/public/components/event_analytics/explorer/log_explorer.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /* eslint-disable react-hooks/exhaustive-deps */
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';

--- a/public/components/event_analytics/explorer/log_patterns/patterns_table.tsx
+++ b/public/components/event_analytics/explorer/log_patterns/patterns_table.tsx
@@ -12,7 +12,7 @@ import {
   SortDirection,
 } from '@elastic/eui';
 import { IQuery, PatternTableData } from 'common/types/explorer';
-import { round } from 'lodash';
+import round from 'lodash/round';
 import React from 'react';
 import { FILTERED_PATTERN } from '../../../../../common/constants/explorer';
 import { PPL_DOCUMENTATION_URL } from '../../../../../common/constants/shared';

--- a/public/components/event_analytics/explorer/save_panel/save_panel.tsx
+++ b/public/components/event_analytics/explorer/save_panel/save_panel.tsx
@@ -13,7 +13,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { useEffect } from 'react';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useDispatch, useSelector } from 'react-redux';
 import SavedObjects from '../../../../services/saved_objects/event_analytics/saved_objects';
 import {

--- a/public/components/event_analytics/explorer/sidebar/field.tsx
+++ b/public/components/event_analytics/explorer/sidebar/field.tsx
@@ -15,7 +15,9 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { isEqual, toUpper, upperFirst } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import toUpper from 'lodash/toUpper';
+import upperFirst from 'lodash/upperFirst';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { DEFAULT_DATA_SOURCE_TYPE } from '../../../../../common/constants/data_sources';

--- a/public/components/event_analytics/explorer/sidebar/field_insights.tsx
+++ b/public/components/event_analytics/explorer/sidebar/field_insights.tsx
@@ -4,7 +4,8 @@
  */
 
 import React, { useMemo, useState, useEffect } from 'react';
-import { indexOf, last } from 'lodash';
+import indexOf from 'lodash/indexOf';
+import last from 'lodash/last';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiBasicTable } from '@elastic/eui';
 import { getIndexPatternFromRawQuery } from '../../../common/query_utils';
 import { coreRefs } from '../../../../framework/core_refs';

--- a/public/components/event_analytics/explorer/sidebar/observability_sidebar.tsx
+++ b/public/components/event_analytics/explorer/sidebar/observability_sidebar.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import _, { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { changeQuery, selectQueries } from '../../redux/slices/query_slice';
 import { selectQueryResult } from '../../redux/slices/query_result_slice';
 import { selectFields } from '../../redux/slices/field_slice';

--- a/public/components/event_analytics/explorer/sidebar/sidebar.tsx
+++ b/public/components/event_analytics/explorer/sidebar/sidebar.tsx
@@ -13,7 +13,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, { useCallback, useState } from 'react';
 import { batch, useDispatch } from 'react-redux';
 import { AVAILABLE_FIELDS, SELECTED_FIELDS } from '../../../../../common/constants/explorer';

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
@@ -12,7 +12,7 @@ import {
   EuiTabbedContentTab,
 } from '@elastic/eui';
 import hjson from 'hjson';
-import { find } from 'lodash';
+import find from 'lodash/find';
 import { ENABLED_VIS_TYPES } from '../../../../../../common/constants/shared';
 import { getVisTypeData } from '../../../../visualizations/charts/helpers/viz_types';
 import { TabContext } from '../../../hooks';

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
@@ -19,7 +19,7 @@ import {
   htmlIdGenerator,
   EuiText,
 } from '@elastic/eui';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { AvailabilityInfoFlyout } from '../../../../../../application_analytics/components/flyout_components/availability_info_flyout';
 import { PPL_SPAN_REGEX } from '../../../../../../../../common/constants/shared';
 

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_theme.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_theme.tsx
@@ -16,7 +16,7 @@ import {
   htmlIdGenerator,
   EuiComboBox,
 } from '@elastic/eui';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { ADD_BUTTON_TEXT, AGGREGATIONS } from '../../../../../../../../common/constants/explorer';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import { getPropName } from '../../../../../../../components/event_analytics/utils/utils';

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_gauge_options.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_gauge_options.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useMemo, useCallback, Fragment } from 'react';
-import { indexOf } from 'lodash';
+import indexOf from 'lodash/indexOf';
 import { EuiAccordion, EuiSpacer } from '@elastic/eui';
 import { PanelItem } from './config_panel_item';
 import { NUMERICAL_FIELDS } from '../../../../../../../../common/constants/shared';

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_item.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { uniqueId, isEmpty } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
+import isEmpty from 'lodash/isEmpty';
 import { EuiTitle, EuiComboBox, EuiSpacer } from '@elastic/eui';
 
 export const PanelItem = ({

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_option_gauge.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_option_gauge.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { EuiFormRow, EuiFieldNumber } from '@elastic/eui';
-import { find } from 'lodash';
+import find from 'lodash/find';
 import {
   DEFAULT_GAUGE_CHART_PARAMETERS,
   GROUPBY,

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds.tsx
@@ -18,7 +18,7 @@ import {
   htmlIdGenerator,
   EuiToolTip,
 } from '@elastic/eui';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 export interface ThresholdUnitType {
   thid: string;

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
@@ -4,7 +4,7 @@
  */
 
 import { EuiButtonIcon, EuiLink, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import React, { Fragment } from 'react';
 import { ParentUnitType, TreemapParentsProps } from '../../../../../../../../common/types/explorer';
 

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_yaxis_side.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_yaxis_side.tsx
@@ -15,7 +15,7 @@ import {
   htmlIdGenerator,
   EuiComboBox,
 } from '@elastic/eui';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import {
   ADD_SERIES_POSITION_TEXT,
   AGGREGATIONS,

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -15,7 +15,9 @@ import {
   EuiFormRow,
   EuiFormLabel,
 } from '@elastic/eui';
-import { isArray, isEmpty, lowerCase } from 'lodash';
+import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
+import lowerCase from 'lodash/lowerCase';
 import {
   AGGREGATIONS,
   CUSTOM_LABEL,

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -20,7 +20,9 @@ import {
   EuiFlexGroup,
   EuiHorizontalRule,
 } from '@elastic/eui';
-import { filter, isEmpty, isEqual } from 'lodash';
+import filter from 'lodash/filter';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import {
   AGGREGATIONS,
   AGGREGATION_OPTIONS,

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
@@ -14,7 +14,7 @@ import {
   EuiIcon,
   EuiText,
 } from '@elastic/eui';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import {
   AGGREGATIONS,

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -14,7 +14,6 @@ import {
   EuiTitle,
   htmlIdGenerator,
 } from '@elastic/eui';
-import { uniqueId } from 'lodash';
 import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { ActionCreatorWithPayload } from '@reduxjs/toolkit';

--- a/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useMemo } from 'react';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { EuiPanel, EuiSwitch } from '@elastic/eui';
 import { Visualization } from '../../../../visualizations/visualization';
 import { DataTable } from '../../../../visualizations/charts/data_table/data_table';

--- a/public/components/event_analytics/hooks/use_fetch_direct_events.ts
+++ b/public/components/event_analytics/hooks/use_fetch_direct_events.ts
@@ -5,7 +5,7 @@
 
 import { useState, useRef } from 'react';
 import { batch } from 'react-redux';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useDispatch, useSelector } from 'react-redux';
 import { IField } from 'common/types/explorer';
 import {

--- a/public/components/event_analytics/hooks/use_fetch_events.ts
+++ b/public/components/event_analytics/hooks/use_fetch_events.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { useRef, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import {

--- a/public/components/event_analytics/hooks/use_fetch_patterns.ts
+++ b/public/components/event_analytics/hooks/use_fetch_patterns.ts
@@ -4,7 +4,7 @@
  */
 
 import { IField, PatternTableData } from 'common/types/explorer';
-import { isUndefined } from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 import PPLService from 'public/services/requests/ppl';
 import { useRef } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';

--- a/public/components/event_analytics/redux/slices/field_slice.ts
+++ b/public/components/event_analytics/redux/slices/field_slice.ts
@@ -4,7 +4,7 @@
  */
 
 import { createSlice, createSelector } from '@reduxjs/toolkit';
-import { forEach } from 'lodash';
+import forEach from 'lodash/forEach';
 import { initialTabId } from '../../../../framework/redux/store/shared_state';
 import {
   SELECTED_FIELDS,

--- a/public/components/event_analytics/redux/slices/query_tab_slice.ts
+++ b/public/components/event_analytics/redux/slices/query_tab_slice.ts
@@ -4,7 +4,7 @@
  */
 
 import { createSlice, createSelector } from '@reduxjs/toolkit';
-import { assign } from 'lodash';
+import assign from 'lodash/assign';
 import { initialTabId } from '../../../../framework/redux/store/shared_state';
 import {
   SELECTED_QUERY_TAB,

--- a/public/components/event_analytics/utils/utils.tsx
+++ b/public/components/event_analytics/utils/utils.tsx
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-bitwise */
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import moment from 'moment';
 import React, { MutableRefObject } from 'react';
 import { EuiDataGridSorting, EuiText } from '@elastic/eui';

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
 import {
   EuiButton,
   EuiFieldText,

--- a/public/components/integrations/components/added_integration.tsx
+++ b/public/components/integrations/components/added_integration.tsx
@@ -24,7 +24,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import { PanelTitle } from '../../trace_analytics/components/common/helper_functions';
 import { ASSET_FILTER_OPTIONS } from '../../../../common/constants/integrations';
 import { INTEGRATIONS_BASE } from '../../../../common/constants/shared';
@@ -183,7 +183,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
               data-click-metric-element="integrations.dashboard_link"
               onClick={() => window.location.assign(`dashboards#/view/${record.assetId}`)}
             >
-              {_.truncate(record.description, { length: 100 })}
+              {truncate(record.description, { length: 100 })}
             </EuiLink>
           );
         case 'index-pattern':
@@ -197,7 +197,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
                 )
               }
             >
-              {_.truncate(record.description, { length: 100 })}
+              {truncate(record.description, { length: 100 })}
             </EuiLink>
           );
         case 'search':
@@ -207,7 +207,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
               data-click-metric-element="integrations.search_link"
               onClick={() => window.location.assign(`discover#/view/${record.assetId}`)}
             >
-              {_.truncate(record.description, { length: 100 })}
+              {truncate(record.description, { length: 100 })}
             </EuiLink>
           );
         case 'visualization':
@@ -217,7 +217,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
               data-click-metric-element="integrations.viz-link"
               onClick={() => window.location.assign(`visualize#/edit/${record.assetId}`)}
             >
-              {_.truncate(record.description, { length: 100 })}
+              {truncate(record.description, { length: 100 })}
             </EuiLink>
           );
         case 'observability-search':
@@ -231,13 +231,13 @@ export function AddedIntegration(props: AddedIntegrationProps) {
                 )
               }
             >
-              {_.truncate(record.description, { length: 100 })}
+              {truncate(record.description, { length: 100 })}
             </EuiLink>
           );
         default:
           return (
             <EuiText data-test-subj={`IntegrationAssetText`}>
-              {_.truncate(record.description, { length: 100 })}
+              {truncate(record.description, { length: 100 })}
             </EuiText>
           );
       }
@@ -279,7 +279,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
         truncateText: true,
         render: (_value, record) => (
           <EuiText data-test-subj={`${record.assetType}AssetTypeDescription`}>
-            {_.truncate(record.assetType, { length: 100 })}
+            {truncate(record.assetType, { length: 100 })}
           </EuiText>
         ),
       },

--- a/public/components/integrations/components/added_integration_overview_page.tsx
+++ b/public/components/integrations/components/added_integration_overview_page.tsx
@@ -5,7 +5,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { EuiPage, EuiPageBody } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { IntegrationHeader } from './integration_header';
 import { AddedIntegrationsTable } from './added_integration_table';

--- a/public/components/integrations/components/added_integration_table.tsx
+++ b/public/components/integrations/components/added_integration_table.tsx
@@ -15,7 +15,7 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
 } from '@elastic/eui';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import React, { useState } from 'react';
 import {
   AddedIntegrationType,
@@ -41,7 +41,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
       truncateText: true,
       render: (value, record) => (
         <EuiLink data-test-subj={`${record.name}IntegrationLink`} href={`#/installed/${record.id}`}>
-          {_.truncate(record.name, { length: 100 })}
+          {truncate(record.name, { length: 100 })}
         </EuiLink>
       ),
     },
@@ -55,7 +55,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
           data-test-subj={`${record.templateName}IntegrationDescription`}
           href={`#/available/${record.templateName}`}
         >
-          {_.truncate(record.templateName, { length: 100 })}
+          {truncate(record.templateName, { length: 100 })}
         </EuiLink>
       ),
     },
@@ -66,7 +66,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
       truncateText: true,
       render: (value, record) => (
         <EuiText data-test-subj={`${record.templateName}IntegrationDescription`}>
-          {_.truncate(record.creationDate, { length: 100 })}
+          {truncate(record.creationDate, { length: 100 })}
         </EuiText>
       ),
     },

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -12,7 +12,6 @@ import {
   EuiFieldSearch,
   EuiButtonGroup,
 } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useState } from 'react';
 import {
   AvailableIntegrationsCardViewProps,

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -14,7 +14,6 @@ import {
   EuiPopover,
   EuiPopoverTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { IntegrationHeader } from './integration_header';
 import { AvailableIntegrationsTable } from './available_integration_table';

--- a/public/components/integrations/components/available_integration_table.tsx
+++ b/public/components/integrations/components/available_integration_table.tsx
@@ -14,7 +14,7 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
 } from '@elastic/eui';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import React, { useState } from 'react';
 import { basePathLink } from '../../../../common/utils/shared';
 import { AvailableIntegrationsTableProps } from './available_integration_overview_page';
@@ -64,7 +64,7 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
               data-test-subj={`${record.name}IntegrationLink`}
               onClick={() => setInstallingIntegration(record.name)}
             >
-              {_.truncate(record.displayName || record.name, { length: 100 })}
+              {truncate(record.displayName || record.name, { length: 100 })}
             </EuiLink>
           );
         } else {
@@ -73,7 +73,7 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
               data-test-subj={`${record.name}IntegrationLink`}
               href={basePathLink(`/app/integrations#/available/${record.name}`)}
             >
-              {_.truncate(record.displayName || record.name, { length: 100 })}
+              {truncate(record.displayName || record.name, { length: 100 })}
             </EuiLink>
           );
         }
@@ -86,7 +86,7 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
       truncateText: true,
       render: (_value, record) => (
         <EuiText data-test-subj={`${record.name}IntegrationDescription`}>
-          {_.truncate(record.description, { length: 100 })}
+          {truncate(record.description, { length: 100 })}
         </EuiText>
       ),
     },

--- a/public/components/integrations/components/integration_assets_panel.tsx
+++ b/public/components/integrations/components/integration_assets_panel.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React from 'react';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import { ASSET_FILTER_OPTIONS } from '../../../../common/constants/integrations';
 import { SavedObject } from '../../../../../../src/core/types';
 
@@ -49,7 +49,7 @@ export function IntegrationAssets(props: {
       truncateText: true,
       render: (value, record) => (
         <EuiText data-test-subj={`${record.id}IntegrationLink`}>
-          {_.truncate(record.name, {
+          {truncate(record.name, {
             length: 100,
           })}
         </EuiText>
@@ -61,7 +61,7 @@ export function IntegrationAssets(props: {
       truncateText: true,
       render: (_value, record) => (
         <EuiText data-test-subj={`${record.type}IntegrationDescription`}>
-          {_.truncate(record.type, { length: 100 })}
+          {truncate(record.type, { length: 100 })}
         </EuiText>
       ),
     },

--- a/public/components/integrations/components/integration_fields_panel.tsx
+++ b/public/components/integrations/components/integration_fields_panel.tsx
@@ -12,7 +12,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React from 'react';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 
 export function IntegrationFields(props: any) {
   const config = props.integration;
@@ -32,7 +32,7 @@ export function IntegrationFields(props: any) {
       truncateText: true,
       render: (value, record) => (
         <EuiText data-test-subj={`${record.name}IntegrationLink`}>
-          {_.truncate(record.name, { length: 100 })}
+          {truncate(record.name, { length: 100 })}
         </EuiText>
       ),
     },
@@ -43,7 +43,7 @@ export function IntegrationFields(props: any) {
       truncateText: true,
       render: (value, record) => (
         <EuiText data-test-subj={`${record.type}IntegrationDescription`}>
-          {_.truncate(record.type, { length: 100 })}
+          {truncate(record.type, { length: 100 })}
         </EuiText>
       ),
     },
@@ -54,7 +54,7 @@ export function IntegrationFields(props: any) {
       truncateText: true,
       render: (value, record) => (
         <EuiText data-test-subj={`${record.type}IntegrationDescription`}>
-          {_.truncate(record.category, { length: 100 })}
+          {truncate(record.category, { length: 100 })}
         </EuiText>
       ),
     },

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -13,7 +13,6 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useState } from 'react';
 import { OPENSEARCH_DOCUMENTATION_URL } from '../../../../common/constants/integrations';
 

--- a/public/components/metrics/redux/slices/metrics_slice.ts
+++ b/public/components/metrics/redux/slices/metrics_slice.ts
@@ -5,7 +5,10 @@
 
 import { ouiPaletteColorBlindBehindText } from '@elastic/eui';
 import { createSlice } from '@reduxjs/toolkit';
-import { keyBy, mergeWith, pick, sortBy } from 'lodash';
+import keyBy from 'lodash/keyBy';
+import mergeWith from 'lodash/mergeWith';
+import pick from 'lodash/pick';
+import sortBy from 'lodash/sortBy';
 import {
   OBSERVABILITY_CUSTOM_METRIC,
   PPL_DATASOURCES_REQUEST,

--- a/public/components/metrics/sidebar/metrics_accordion.tsx
+++ b/public/components/metrics/sidebar/metrics_accordion.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { EuiAccordion, EuiTitle } from '@elastic/eui';
-import { min } from 'lodash';
+import min from 'lodash/min';
 import { MetricName } from './metric_name';
 
 interface IMetricNameProps {

--- a/public/components/metrics/sidebar/search_bar.tsx
+++ b/public/components/metrics/sidebar/search_bar.tsx
@@ -6,7 +6,7 @@
 import { EuiSearchBar } from '@elastic/eui';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { searchSelector, setSearch } from '../redux/slices/metrics_slice';
 
 export const SearchBar = () => {

--- a/public/components/metrics/sidebar/sidebar.tsx
+++ b/public/components/metrics/sidebar/sidebar.tsx
@@ -5,7 +5,8 @@
 
 import { EuiSpacer } from '@elastic/eui';
 import { I18nProvider } from '@osd/i18n/react';
-import { keyBy, sortBy } from 'lodash';
+import keyBy from 'lodash/keyBy';
+import sortBy from 'lodash/sortBy';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
 import { OTEL_METRIC_SUBTYPE, PPL_METRIC_SUBTYPE } from '../../../../common/constants/shared';

--- a/public/components/metrics/top_menu/metrics_export.tsx
+++ b/public/components/metrics/top_menu/metrics_export.tsx
@@ -14,7 +14,7 @@ import {
 } from '@elastic/eui';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { max } from 'lodash';
+import max from 'lodash/max';
 import semver from 'semver';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { I18nProvider } from '@osd/i18n/react';

--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -27,7 +27,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 import moment from 'moment';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -267,7 +267,7 @@ export function NoteTable({
       sortable: true,
       truncateText: true,
       render: (value, record) => (
-        <EuiLink href={`#/${record.id}`}>{_.truncate(value, { length: 100 })}</EuiLink>
+        <EuiLink href={`#/${record.id}`}>{truncate(value, { length: 100 })}</EuiLink>
       ),
     },
     {

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -21,7 +21,7 @@ import {
   EuiText,
   htmlIdGenerator,
 } from '@elastic/eui';
-import _ from 'lodash';
+import filter from 'lodash/filter';
 import moment from 'moment';
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { CoreStart } from '../../../../../../../src/core/public';
@@ -161,7 +161,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
     ];
     setVisOptions(allVisualizations);
 
-    const selectedObject = _.filter([...opt1, ...opt2], {
+    const selectedObject = filter([...opt1, ...opt2], {
       key: para.visSavedObjId,
     });
     if (selectedObject.length > 0) {

--- a/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
@@ -10,7 +10,7 @@ import {
   EuiFormRow,
   EuiSpacer,
 } from '@elastic/eui';
-import _ from 'lodash';
+import get from 'lodash/get';
 import { TraceAnalyticsMode } from 'public/components/trace_analytics/home';
 import React from 'react';
 
@@ -64,7 +64,7 @@ const getType = (field: string): string | null => {
     endTime: 'date_nanos',
     startTime: 'date_nanos',
   };
-  const type = _.get(typeMapping, field, 'keyword');
+  const type = get(typeMapping, field, 'keyword');
   return typeof type === 'string' ? type : null;
 };
 
@@ -113,7 +113,7 @@ export const getOperatorOptions = (field: string) => {
   };
   const operators = [
     ...operatorMapping.default_first,
-    ..._.get(operatorMapping, type),
+    ...get(operatorMapping, type),
     ...operatorMapping.default_last,
   ];
   return operators;

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -7,7 +7,8 @@
 import dateMath from '@elastic/datemath';
 import { EuiButton, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
 import { SpacerSize } from '@elastic/eui/src/components/spacer/spacer';
-import { isEmpty, round } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import round from 'lodash/round';
 import React from 'react';
 import {
   DATA_PREPPER_INDEX_NAME,

--- a/public/components/trace_analytics/components/common/plots/latency_trend_plt.tsx
+++ b/public/components/trace_analytics/components/common/plots/latency_trend_plt.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
+import round from 'lodash/round';
 import React, { useMemo } from 'react';
 import { Plt } from '../../../../visualizations/plotly/plot';
 
@@ -67,7 +67,7 @@ export function LatencyPlt(props: { data: Plotly.Data[] }) {
             arrowhead: 0,
             xref: 'x',
             yref: 'y',
-            text: `Now: ${_.round(props.data[0].y[props.data[0].y.length - 1] as number, 2)}ms`,
+            text: `Now: ${round(props.data[0].y[props.data[0].y.length - 1] as number, 2)}ms`,
             ax: 0,
             ay: -140,
             borderpad: 10,

--- a/public/components/trace_analytics/components/common/plots/service_map_scale.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map_scale.tsx
@@ -4,7 +4,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
-import _ from 'lodash';
+import merge from 'lodash/merge';
 import React, { useEffect, useState } from 'react';
 import { BarOrientation } from '../../../../../../common/constants/shared';
 import { Plt } from '../../../../visualizations/plotly/plot';
@@ -67,7 +67,7 @@ export function ServiceMapScale(props: {
       },
     ] as Plotly.Data;
 
-    const layout = _.merge(
+    const layout = merge(
       {
         plot_bgcolor: 'rgba(0, 0, 0, 0)',
         paper_bgcolor: 'rgba(0, 0, 0, 0)',

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -11,7 +11,7 @@ import {
   EuiSpacer,
   EuiSuperDatePicker,
 } from '@elastic/eui';
-import _ from 'lodash';
+import debounce from 'lodash/debounce';
 import React, { useState } from 'react';
 import { uiSettingsService } from '../../../../../common/utils';
 import { Filters, FiltersProps } from './filters/filters';
@@ -54,7 +54,7 @@ interface SearchBarOwnProps extends SearchBarProps {
 export function SearchBar(props: SearchBarOwnProps) {
   // use another query state to avoid typing delay
   const [query, setQuery] = useState(props.query);
-  const setGlobalQuery = _.debounce((q) => props.setQuery(q), 50);
+  const setGlobalQuery = debounce((q) => props.setQuery(q), 50);
 
   return (
     <>

--- a/public/components/trace_analytics/components/dashboard/dashboard_content.tsx
+++ b/public/components/trace_analytics/components/dashboard/dashboard_content.tsx
@@ -6,7 +6,7 @@
 
 import dateMath from '@elastic/datemath';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useState } from 'react';
 import { useToast } from '../../../../../public/components/common/toast';
 import {
@@ -206,7 +206,7 @@ export function DashboardContent(props: DashboardProps) {
         setPercentileMap
       ).then(() => setLoading(false));
       // service map should not be filtered by service name (https://github.com/opensearch-project/observability/issues/442)
-      const serviceMapDSL = _.cloneDeep(DSL);
+      const serviceMapDSL = cloneDeep(DSL);
       serviceMapDSL.query.bool.must = serviceMapDSL.query.bool.must.filter(
         (must: any) => must?.term?.serviceName == null
       );

--- a/public/components/trace_analytics/components/dashboard/dashboard_table.tsx
+++ b/public/components/trace_analytics/components/dashboard/dashboard_table.tsx
@@ -19,7 +19,8 @@ import {
   PropertySort,
 } from '@elastic/eui';
 import { CriteriaWithPagination } from '@elastic/eui/src/components/basic_table/basic_table';
-import _ from 'lodash';
+import round from 'lodash/round';
+import truncate from 'lodash/truncate';
 import React, { useMemo, useState } from 'react';
 import { FilterType } from '../common/filters/filters';
 import { calculateTicks, NoMatchMessage, PanelTitle } from '../common/helper_functions';
@@ -116,7 +117,7 @@ export function DashboardTable(props: {
               {item.length < 48 ? (
                 decodeURI(item)
               ) : (
-                <div title={item}>{_.truncate(decodeURI(item), { length: 48 })}</div>
+                <div title={item}>{truncate(decodeURI(item), { length: 48 })}</div>
               )}
             </EuiLink>
           ) : (
@@ -231,7 +232,7 @@ export function DashboardTable(props: {
         align: 'right',
         sortable: true,
         dataType: 'number',
-        render: (item) => (item === 0 || item ? _.round(item, 2) : '-'),
+        render: (item) => (item === 0 || item ? round(item, 2) : '-'),
       },
       {
         field: '24_hour_latency_trend',
@@ -296,7 +297,7 @@ export function DashboardTable(props: {
         align: 'right',
         sortable: true,
         render: (item) =>
-          item === 0 || item ? <EuiText size="s">{`${_.round(item, 2)}%`}</EuiText> : '-',
+          item === 0 || item ? <EuiText size="s">{`${round(item, 2)}%`}</EuiText> : '-',
       },
       {
         field: 'dashboard_traces',

--- a/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
+++ b/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
@@ -4,7 +4,6 @@
  */
 
 import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiText } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useState } from 'react';
 import { LatencyPlt, LinePlt } from '../common/plots/latency_trend_plt';
 

--- a/public/components/trace_analytics/components/dashboard/top_error_rates_table.tsx
+++ b/public/components/trace_analytics/components/dashboard/top_error_rates_table.tsx
@@ -19,7 +19,8 @@ import {
   PropertySort,
 } from '@elastic/eui';
 import { CriteriaWithPagination } from '@elastic/eui/src/components/basic_table/basic_table';
-import _ from 'lodash';
+import round from 'lodash/round';
+import truncate from 'lodash/truncate';
 import React, { useMemo, useState } from 'react';
 import { FilterType } from '../common/filters/filters';
 import { NoMatchMessage, PanelTitle } from '../common/helper_functions';
@@ -91,7 +92,7 @@ export function ErrorRatesTable(props: {
               {item.length < 48 ? (
                 decodeURI(item)
               ) : (
-                <div title={item}>{_.truncate(decodeURI(item), { length: 48 })}</div>
+                <div title={item}>{truncate(decodeURI(item), { length: 48 })}</div>
               )}
             </EuiLink>
           ) : (
@@ -126,7 +127,7 @@ export function ErrorRatesTable(props: {
         align: 'right',
         sortable: true,
         dataType: 'number',
-        render: (item) => (item === 0 || item ? _.round(item, 2) : '-'),
+        render: (item) => (item === 0 || item ? round(item, 2) : '-'),
       },
       {
         field: 'dashboard_error_rate',
@@ -156,7 +157,7 @@ export function ErrorRatesTable(props: {
         align: 'right',
         sortable: false,
         render: (item) =>
-          item === 0 || item ? <EuiText size="s">{`${_.round(item, 2)}%`}</EuiText> : '-',
+          item === 0 || item ? <EuiText size="s">{`${round(item, 2)}%`}</EuiText> : '-',
       },
       {
         field: 'dashboard_traces',

--- a/public/components/trace_analytics/components/dashboard/top_latency_table.tsx
+++ b/public/components/trace_analytics/components/dashboard/top_latency_table.tsx
@@ -19,7 +19,8 @@ import {
   PropertySort,
 } from '@elastic/eui';
 import { CriteriaWithPagination } from '@elastic/eui/src/components/basic_table/basic_table';
-import _ from 'lodash';
+import round from 'lodash/round';
+import truncate from 'lodash/truncate';
 import React, { useMemo, useState } from 'react';
 import { FilterType } from '../common/filters/filters';
 import { calculateTicks, NoMatchMessage, PanelTitle } from '../common/helper_functions';
@@ -126,7 +127,7 @@ export function LatencyTable(props: {
               {item.length < 48 ? (
                 decodeURI(item)
               ) : (
-                <div title={item}>{_.truncate(decodeURI(item), { length: 48 })}</div>
+                <div title={item}>{truncate(decodeURI(item), { length: 48 })}</div>
               )}
             </EuiLink>
           ) : (
@@ -241,7 +242,7 @@ export function LatencyTable(props: {
         align: 'right',
         sortable: true,
         dataType: 'number',
-        render: (item) => (item === 0 || item ? _.round(item, 2) : '-'),
+        render: (item) => (item === 0 || item ? round(item, 2) : '-'),
       },
       {
         field: 'dashboard_error_rate',
@@ -271,7 +272,7 @@ export function LatencyTable(props: {
         align: 'right',
         sortable: true,
         render: (item) =>
-          item === 0 || item ? <EuiText size="s">{`${_.round(item, 2)}%`}</EuiText> : '-',
+          item === 0 || item ? <EuiText size="s">{`${round(item, 2)}%`}</EuiText> : '-',
       },
       {
         field: 'dashboard_traces',

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -18,7 +18,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   DataSourceManagementPluginSetup,
@@ -198,7 +198,7 @@ export function ServiceView(props: ServiceViewProps) {
                   <EuiText className="overview-title">Error rate</EuiText>
                   <EuiText size="s" className="overview-content">
                     {fields.error_rate !== undefined
-                      ? _.round(fields.error_rate, 2).toString() + '%'
+                      ? round(fields.error_rate, 2).toString() + '%'
                       : '-'}
                   </EuiText>
                 </EuiFlexItem>

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { EuiAccordion, EuiPanel, EuiSpacer } from '@elastic/eui';
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useState } from 'react';
 import {
   handleServiceMapRequest,
@@ -101,7 +101,7 @@ export function ServicesContent(props: ServicesProps) {
       appConfigs
     );
     // service map should not be filtered by service name
-    const serviceMapDSL = _.cloneDeep(DSL);
+    const serviceMapDSL = cloneDeep(DSL);
     serviceMapDSL.query.bool.must = serviceMapDSL.query.bool.must.filter(
       (must: any) => must?.term?.serviceName == null
     );

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -16,7 +16,8 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
+import truncate from 'lodash/truncate';
 import React, { useMemo } from 'react';
 import { TraceAnalyticsMode } from '../../home';
 import { FilterType } from '../common/filters/filters';
@@ -70,7 +71,7 @@ export function ServicesTable(props: ServicesTableProps) {
           sortable: true,
           render: (item: any) => (
             <EuiLink data-test-subj="service-link" onClick={() => nameColumnAction(item)}>
-              {item.length < 24 ? item : <div title={item}>{_.truncate(item, { length: 24 })}</div>}
+              {item.length < 24 ? item : <div title={item}>{truncate(item, { length: 24 })}</div>}
             </EuiLink>
           ),
         },
@@ -79,7 +80,7 @@ export function ServicesTable(props: ServicesTableProps) {
           name: 'Average duration (ms)',
           align: 'right',
           sortable: true,
-          render: (item: any) => (item === 0 || item ? _.round(item, 2) : '-'),
+          render: (item: any) => (item === 0 || item ? round(item, 2) : '-'),
         },
         {
           field: 'error_rate',
@@ -87,7 +88,7 @@ export function ServicesTable(props: ServicesTableProps) {
           align: 'right',
           sortable: true,
           render: (item) =>
-            item === 0 || item ? <EuiText size="s">{`${_.round(item, 2)}%`}</EuiText> : '-',
+            item === 0 || item ? <EuiText size="s">{`${round(item, 2)}%`}</EuiText> : '-',
         },
         {
           field: 'throughput',
@@ -120,7 +121,7 @@ export function ServicesTable(props: ServicesTableProps) {
                 truncateText: true,
                 render: (item: any) =>
                   item ? (
-                    <EuiText size="s">{_.truncate(item.join(', '), { length: 50 })}</EuiText>
+                    <EuiText size="s">{truncate(item.join(', '), { length: 50 })}</EuiText>
                   ) : (
                     '-'
                   ),

--- a/public/components/trace_analytics/components/traces/service_breakdown_panel.tsx
+++ b/public/components/trace_analytics/components/traces/service_breakdown_panel.tsx
@@ -12,7 +12,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
 import React, { useMemo } from 'react';
 import { Plt } from '../../../visualizations/plotly/plot';
 import { PanelTitle } from '../common/helper_functions';
@@ -54,7 +54,7 @@ export function ServiceBreakdownPanel(props: { data: Plotly.Data[] }) {
           <EuiFlexGroup direction="column" alignItems="flexEnd" gutterSize="m" responsive={false}>
             {props.data[0].values.map((value, i) => (
               <EuiFlexItem key={`value-${i}`}>
-                <EuiText size="s">{_.round(value, 2)}%</EuiText>
+                <EuiText size="s">{round(value, 2)}%</EuiText>
               </EuiFlexItem>
             ))}
           </EuiFlexGroup>

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -17,7 +17,9 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
+import get from 'lodash/get';
+import round from 'lodash/round';
+import isEmpty from 'lodash/isEmpty';
 import moment from 'moment';
 import React, { useEffect, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
@@ -56,7 +58,7 @@ const getSpanFieldKey = (mode: TraceAnalyticsMode, field: SpanField) => MODE_TO_
 const getSpanValue = (span: object, mode: TraceAnalyticsMode, field: SpanField) => {
   const fieldKey = getSpanFieldKey(mode, field);
   if (fieldKey === undefined) return undefined;
-  return _.get(span, fieldKey);
+  return get(span, fieldKey);
 };
 
 export function SpanDetailFlyout(props: {
@@ -86,13 +88,13 @@ export function SpanDetailFlyout(props: {
         description={description}
         key={`list-item-${title}`}
         addSpanFilter={
-          fieldKey ? () => props.addSpanFilter(fieldKey, _.get(span, fieldKey)) : undefined
+          fieldKey ? () => props.addSpanFilter(fieldKey, get(span, fieldKey)) : undefined
         }
       />
     );
   };
 
-  const isEmpty = (value) => {
+  const _isEmpty = (value) => {
     return (
       value == null ||
       (value.hasOwnProperty('length') && value.length === 0) ||
@@ -101,7 +103,7 @@ export function SpanDetailFlyout(props: {
   };
 
   const renderContent = () => {
-    if (!span || _.isEmpty(span)) return '-';
+    if (!span || isEmpty(span)) return '-';
     const overviewList = [
       getListItem(
         getSpanFieldKey(mode, 'SPAN_ID'),
@@ -158,8 +160,8 @@ export function SpanDetailFlyout(props: {
         'Duration',
         `${
           mode === 'data_prepper'
-            ? _.round(nanoToMilliSec(Math.max(0, span.durationInNanos)), 2)
-            : _.round(microToMilliSec(Math.max(0, span.duration)), 2)
+            ? round(nanoToMilliSec(Math.max(0, span.durationInNanos)), 2)
+            : round(microToMilliSec(Math.max(0, span.duration)), 2)
         } ms`
       ),
       getListItem(
@@ -167,7 +169,7 @@ export function SpanDetailFlyout(props: {
         'Start time',
         mode === 'data_prepper'
           ? moment(span.startTime).format(TRACE_ANALYTICS_DATE_FORMAT)
-          : moment(_.round(microToMilliSec(Math.max(0, span.startTime)), 2)).format(
+          : moment(round(microToMilliSec(Math.max(0, span.startTime)), 2)).format(
               TRACE_ANALYTICS_DATE_FORMAT
             )
       ),
@@ -176,7 +178,7 @@ export function SpanDetailFlyout(props: {
         'End time',
         mode === 'data_prepper'
           ? moment(span.endTime).format(TRACE_ANALYTICS_DATE_FORMAT)
-          : moment(_.round(microToMilliSec(Math.max(0, span.startTime + span.duration)), 2)).format(
+          : moment(round(microToMilliSec(Math.max(0, span.startTime + span.duration)), 2)).format(
               TRACE_ANALYTICS_DATE_FORMAT
             )
       ),
@@ -216,20 +218,20 @@ export function SpanDetailFlyout(props: {
     const attributesList = Object.keys(span)
       .filter((key) => !ignoredKeys.has(key))
       .sort((keyA, keyB) => {
-        const isANull = isEmpty(span[keyA]);
-        const isBNull = isEmpty(span[keyB]);
+        const isANull = _isEmpty(span[keyA]);
+        const isBNull = _isEmpty(span[keyB]);
         if ((isANull && isBNull) || (!isANull && !isBNull)) return keyA < keyB ? -1 : 1;
         if (isANull) return 1;
         return -1;
       })
       .map((key) => {
-        if (isEmpty(span[key])) return getListItem(key, key, '-');
+        if (_isEmpty(span[key])) return getListItem(key, key, '-');
         let value = span[key];
         if (typeof value === 'object') value = JSON.stringify(value);
         return getListItem(key, key, value);
       });
 
-    const eventsComponent = _.isEmpty(span.events) ? null : (
+    const eventsComponent = isEmpty(span.events) ? null : (
       <>
         <EuiText size="m">
           <span className="panel-title">Event</span>

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -13,7 +13,8 @@ import {
   EuiPanel,
   EuiSpacer,
 } from '@elastic/eui';
-import _ from 'lodash';
+import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
 import React, { useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
 import { Plt } from '../../../visualizations/plotly/plot';
@@ -78,8 +79,8 @@ export function SpanDetailPanel(props: {
     }
   };
 
-  const refresh = _.debounce(() => {
-    if (_.isEmpty(props.colorMap)) return;
+  const refresh = debounce(() => {
+    if (isEmpty(props.colorMap)) return;
     const refreshDSL = spanFiltersToDSL();
     setDSL(refreshDSL);
     handleSpansGanttRequest(

--- a/public/components/trace_analytics/components/traces/span_detail_table.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_table.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { EuiDataGrid, EuiDataGridColumn, EuiLink, EuiText } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
 import moment from 'moment';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
@@ -219,18 +219,18 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
         case 'spanID':
           return <EuiLink onClick={() => props.openFlyout(value)}>{value}</EuiLink>;
         case 'durationInNanos':
-          return `${_.round(nanoToMilliSec(Math.max(0, value)), 2)} ms`;
+          return `${round(nanoToMilliSec(Math.max(0, value)), 2)} ms`;
         case 'duration':
-          return `${_.round(microToMilliSec(Math.max(0, value)), 2)} ms`;
+          return `${round(microToMilliSec(Math.max(0, value)), 2)} ms`;
         case 'startTime':
           return mode === 'jaeger'
-            ? moment(_.round(microToMilliSec(Math.max(0, value)), 2)).format(
+            ? moment(round(microToMilliSec(Math.max(0, value)), 2)).format(
                 TRACE_ANALYTICS_DATE_FORMAT
               )
             : moment(value).format(TRACE_ANALYTICS_DATE_FORMAT);
         case 'jaegerEndTime':
           return moment(
-            _.round(
+            round(
               microToMilliSec(
                 Math.max(0, items[adjustedRowIndex].startTime + items[adjustedRowIndex].duration)
               ),

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -18,7 +18,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
 import React, { useEffect, useState } from 'react';
 import { MountPoint } from '../../../../../../../src/core/public';
 import {
@@ -216,8 +216,8 @@ export function TraceView(props: TraceViewProps) {
     Object.entries(services).forEach(([serviceName, service]: [string, any]) => {
       if (!serviceMap[serviceName]) return;
       filteredServiceMap[serviceName] = serviceMap[serviceName];
-      filteredServiceMap[serviceName].latency = _.round(service.latency / service.throughput, 2);
-      filteredServiceMap[serviceName].error_rate = _.round(
+      filteredServiceMap[serviceName].latency = round(service.latency / service.throughput, 2);
+      filteredServiceMap[serviceName].error_rate = round(
         (service.errors / service.throughput) * 100,
         2
       );

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -18,7 +18,8 @@ import {
   EuiText,
   PropertySort,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
+import truncate from 'lodash/truncate';
 import React, { useMemo, useState } from 'react';
 import { TRACES_MAX_NUM } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../home';
@@ -68,7 +69,7 @@ export function TracesTable(props: TracesTableProps) {
                   {item.length < 24 ? (
                     item
                   ) : (
-                    <div title={item}>{_.truncate(item, { length: 24 })}</div>
+                    <div title={item}>{truncate(item, { length: 24 })}</div>
                   )}
                 </EuiLink>
               </EuiFlexItem>
@@ -101,7 +102,7 @@ export function TracesTable(props: TracesTableProps) {
                 {item.length < 36 ? (
                   item
                 ) : (
-                  <div title={item}>{_.truncate(item, { length: 36 })}</div>
+                  <div title={item}>{truncate(item, { length: 36 })}</div>
                 )}
               </EuiText>
             ) : (
@@ -126,7 +127,7 @@ export function TracesTable(props: TracesTableProps) {
           align: 'right',
           sortable: true,
           render: (item) =>
-            item === 0 || item ? <EuiText size="s">{`${_.round(item, 2)}th`}</EuiText> : '-',
+            item === 0 || item ? <EuiText size="s">{`${round(item, 2)}th`}</EuiText> : '-',
         },
         {
           field: 'error_count',
@@ -168,7 +169,7 @@ export function TracesTable(props: TracesTableProps) {
                     {item.length < 24 ? (
                       item
                     ) : (
-                      <div title={item}>{_.truncate(item, { length: 24 })}</div>
+                      <div title={item}>{truncate(item, { length: 24 })}</div>
                     )}
                   </EuiLink>
                 </EuiFlexItem>

--- a/public/components/trace_analytics/requests/dashboard_request_handler.ts
+++ b/public/components/trace_analytics/requests/dashboard_request_handler.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
+import round from 'lodash/round';
 import moment from 'moment';
 import { TRACE_ANALYTICS_PLOTS_DATE_FORMAT } from '../../../../common/constants/trace_analytics';
 import {
@@ -49,7 +49,7 @@ export const handleDashboardRequest = async (
       response.aggregations.trace_group.buckets.forEach((traceGroup) => {
         map[traceGroup.key] = Object.values(
           traceGroup.latency_variance_nanos.values
-        ).map((nano: number) => _.round(nanoToMilliSec(Math.max(0, nano)), 2));
+        ).map((nano: number) => round(nanoToMilliSec(Math.max(0, nano)), 2));
       });
       return map;
     })
@@ -255,7 +255,7 @@ export const handleJaegerDashboardRequest = async (
           response.aggregations.trace_group.buckets.forEach((traceGroup) => {
             map[traceGroup.key_as_string] = Object.values(
               traceGroup.latency_variance_micros.values
-            ).map((nano: number) => _.round(microToMilliSec(Math.max(0, nano)), 2));
+            ).map((nano: number) => round(microToMilliSec(Math.max(0, nano)), 2));
           });
           return map;
         })
@@ -446,7 +446,7 @@ export const handleDashboardErrorRatePltRequest = (
           ? [
               {
                 x: buckets.map((bucket) => bucket.key),
-                y: buckets.map((bucket) => _.round(bucket.error_rate?.value || 0, 2)),
+                y: buckets.map((bucket) => round(bucket.error_rate?.value || 0, 2)),
                 marker: {
                   color: '#fad963',
                 },

--- a/public/components/trace_analytics/requests/services_request_handler.ts
+++ b/public/components/trace_analytics/requests/services_request_handler.ts
@@ -5,7 +5,7 @@
 /* eslint-disable no-console */
 
 import dateMath from '@elastic/datemath';
-import _ from 'lodash';
+import round from 'lodash/round';
 import DSLService from 'public/services/requests/dsl';
 import { HttpSetup } from '../../../../../../src/core/public';
 import { ServiceObject } from '../components/common/plots/service_map';
@@ -152,10 +152,10 @@ export const handleServiceMapRequest = async (
   );
   latencies.aggregations.service_name.buckets.map((bucket: any) => {
     map[bucket.key].latency = bucket.average_latency.value;
-    map[bucket.key].error_rate = _.round(bucket.error_rate.value, 2) || 0;
+    map[bucket.key].error_rate = round(bucket.error_rate.value, 2) || 0;
     map[bucket.key].throughput = bucket.doc_count;
     if (minutesInDateRange != null)
-      map[bucket.key].throughputPerMinute = _.round(bucket.doc_count / minutesInDateRange, 2);
+      map[bucket.key].throughputPerMinute = round(bucket.doc_count / minutesInDateRange, 2);
   });
 
   if (currService) {

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
+import get from 'lodash/get';
+import round from 'lodash/round';
 import moment from 'moment';
 import { v1 as uuid } from 'uuid';
 import { HttpSetup } from '../../../../../../src/core/public';
@@ -247,14 +248,14 @@ const hitsToSpanDetailData = async (hits: any, colorMap: any, mode: TraceAnalyti
         : nanoToMilliSec(hit.sort[0]) - minStartTime;
     const duration =
       mode === 'jaeger'
-        ? _.round(microToMilliSec(hit._source.duration), 2)
-        : _.round(nanoToMilliSec(hit._source.durationInNanos), 2);
+        ? round(microToMilliSec(hit._source.duration), 2)
+        : round(nanoToMilliSec(hit._source.durationInNanos), 2);
     const serviceName =
       mode === 'jaeger'
-        ? _.get(hit, ['_source', 'process']).serviceName
-        : _.get(hit, ['_source', 'serviceName']);
+        ? get(hit, ['_source', 'process']).serviceName
+        : get(hit, ['_source', 'serviceName']);
     const name =
-      mode === 'jaeger' ? _.get(hit, '_source.operationName') : _.get(hit, '_source.name');
+      mode === 'jaeger' ? get(hit, '_source.operationName') : get(hit, '_source.name');
     const error =
       mode === 'jaeger'
         ? hit._source.tag?.['error'] === true

--- a/public/components/visualizations/charts/bar/bar.tsx
+++ b/public/components/visualizations/charts/bar/bar.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { last } from 'lodash';
+import last from 'lodash/last';
 import {
   AGGREGATIONS,
   BREAKDOWNS,

--- a/public/components/visualizations/charts/bubble/bubble.tsx
+++ b/public/components/visualizations/charts/bubble/bubble.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from 'react';
-import { take, merge, isEmpty } from 'lodash';
+import take from 'lodash/take';
+import merge from 'lodash/merge';
 import { Plt } from '../../plotly/plot';
 import { PLOTLY_COLOR } from '../../../../../common/constants/shared';
 

--- a/public/components/visualizations/charts/financial/gauge/gauge.tsx
+++ b/public/components/visualizations/charts/financial/gauge/gauge.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { find, isEmpty } from 'lodash';
+import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
 import Plotly from 'plotly.js-dist';
 import React, { useMemo } from 'react';
 import {

--- a/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/public/components/visualizations/charts/helpers/viz_types.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty, take } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import take from 'lodash/take';
 import {
   AGGREGATIONS,
   CUSTOM_LABEL,

--- a/public/components/visualizations/charts/histogram/histogram.tsx
+++ b/public/components/visualizations/charts/histogram/histogram.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty, take } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import take from 'lodash/take';
 import React, { useMemo } from 'react';
 import { GROUPBY } from '../../../../../common/constants/explorer';
 import {

--- a/public/components/visualizations/charts/lines/line.tsx
+++ b/public/components/visualizations/charts/lines/line.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty, last } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import last from 'lodash/last';
+import forEach from 'lodash/forEach';
 import React, { useMemo } from 'react';
-import _ from 'lodash';
 import { AGGREGATIONS, GROUPBY } from '../../../../../common/constants/explorer';
 import {
   DEFAULT_CHART_STYLES,
@@ -58,7 +59,7 @@ export const Line = ({ visualizations, layout, config }: any) => {
       } = {},
     },
     vis: { name },
-  }: IVisualizationContainerProps = visualizations;
+  }: IVisualizationContainerProps = visualizations as IVisualizationContainerProps;
 
   const tooltipMode =
     tooltipOptions.tooltipMode !== undefined ? tooltipOptions.tooltipMode : 'show';
@@ -99,7 +100,7 @@ export const Line = ({ visualizations, layout, config }: any) => {
 
   const preprocessMetricsJsonData = (json): any => {
     const data: any[] = [];
-    _.forEach(json, (row) => {
+    forEach(json, (row) => {
       const record: any = {};
       record['@labels'] = JSON.parse(row['@labels']);
       record['@timestamp'] = JSON.parse(row['@timestamp']);

--- a/public/components/visualizations/charts/maps/heatmap.tsx
+++ b/public/components/visualizations/charts/maps/heatmap.tsx
@@ -4,7 +4,9 @@
  */
 import React, { useMemo } from 'react';
 import { colorPalette } from '@elastic/eui';
-import { forEach, isEmpty, map } from 'lodash';
+import forEach from 'lodash/forEach';
+import isEmpty from 'lodash/isEmpty';
+import map from 'lodash/map';
 import Plotly from 'plotly.js-dist';
 import {
   HEATMAP_PALETTE_COLOR,

--- a/public/components/visualizations/charts/maps/treemaps.tsx
+++ b/public/components/visualizations/charts/maps/treemaps.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty, isEqual, uniq } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import uniq from 'lodash/uniq';
 import React, { useMemo } from 'react';
 
 import {

--- a/public/components/visualizations/charts/metrics/metrics.tsx
+++ b/public/components/visualizations/charts/metrics/metrics.tsx
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { find, isEmpty, uniqBy } from 'lodash';
+import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
+import uniqBy from 'lodash/uniqBy';
 import Plotly from 'plotly.js-dist';
 import React, { useMemo } from 'react';
 import { COLOR_BLACK, COLOR_WHITE } from '../../../../../common/constants/colors';

--- a/public/components/visualizations/charts/shared/common.ts
+++ b/public/components/visualizations/charts/shared/common.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty, forEach, mapKeys } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import forEach from 'lodash/forEach';
+import mapKeys from 'lodash/mapKeys';
 import { CUSTOM_LABEL } from '../../../../../common/constants/explorer';
 import {
   ConfigList,

--- a/public/components/visualizations/charts/shared/shared_configs.ts
+++ b/public/components/visualizations/charts/shared/shared_configs.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { forIn } from 'lodash';
-
 export const getPlotlySharedConfigs = () => {
   return {
     layout: {

--- a/public/components/visualizations/saved_object_visualization.tsx
+++ b/public/components/visualizations/saved_object_visualization.tsx
@@ -4,7 +4,9 @@
  */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import differenceWith from 'lodash/differenceWith';
 import React, { useEffect, useState } from 'react';
 import { Filter, Query, TimeRange } from '../../../../../src/plugins/data/common';
 import { QueryManager } from '../../../common/query_manager';
@@ -49,7 +51,7 @@ export const SavedObjectVisualization: React.FC<SavedObjectVisualizationProps> =
     };
     const userConfigs = getUserConfigFrom(metaData);
     const dataConfig = { ...(userConfigs.dataConfig || {}) };
-    const hasBreakdowns = !_.isEmpty(dataConfig.breakdowns);
+    const hasBreakdowns = !isEmpty(dataConfig.breakdowns);
     const realTimeParsedStats = isPromqlMetric
       ? getMetricVisConfig(metaData)
       : {
@@ -61,8 +63,8 @@ export const SavedObjectVisualization: React.FC<SavedObjectVisualizationProps> =
 
     // filter out breakdowns from dimnesions
     if (hasBreakdowns) {
-      finalDimensions = _.differenceWith(finalDimensions, breakdowns, (dimn, brkdwn) =>
-        _.isEqual(removeBacktick(dimn.name), removeBacktick(brkdwn.name))
+      finalDimensions = differenceWith(finalDimensions, breakdowns, (dimn, brkdwn) =>
+        isEqual(removeBacktick(dimn.name), removeBacktick(brkdwn.name))
       );
     }
 

--- a/public/components/visualizations/visualization.tsx
+++ b/public/components/visualizations/visualization.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { VisualizationChart } from './visualization_chart';
 import { VisWorkspaceDefault } from '../event_analytics/explorer/visualizations/shared_components';
 import { IVisualizationContainerProps } from '../../../common/types/explorer';

--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { IDefaultTimestampState, IQuery } from '../../../../common/types/explorer';
 import { IDataFetcher } from '../fetch_interface';
 import { DataFetcherBase } from '../fetcher_base';

--- a/public/services/data_fetchers/sql/sql_data_fetcher.ts
+++ b/public/services/data_fetchers/sql/sql_data_fetcher.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
 import { IDefaultTimestampState, IQuery } from '../../../../common/types/explorer';
 import { IDataFetcher } from '../fetch_interface';
 import { DataFetcherBase } from '../fetcher_base';

--- a/public/services/saved_objects/event_analytics/saved_objects.ts
+++ b/public/services/saved_objects/event_analytics/saved_objects.ts
@@ -4,7 +4,9 @@
  */
 /* eslint-disable no-unused-vars */
 
-import { has, isArray, isEmpty } from 'lodash';
+import has from 'lodash/has';
+import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
 import { IField } from '../../../../common/types/explorer';
 import {
   EVENT_ANALYTICS,

--- a/public/services/saved_objects/saved_object_client/osd_saved_objects/osd_saved_object_client.ts
+++ b/public/services/saved_objects/saved_object_client/osd_saved_objects/osd_saved_object_client.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import {
   SavedObjectsClientContract,
   SimpleSavedObject,

--- a/public/services/saved_objects/saved_object_client/ppl/ppl_client.ts
+++ b/public/services/saved_objects/saved_object_client/ppl/ppl_client.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { has, isArray, isEmpty } from 'lodash';
+import has from 'lodash/has';
+import isArray from 'lodash/isArray';
+import isEmpty from 'lodash/isEmpty';
 import { HttpStart } from '../../../../../../../src/core/public';
 import {
   EVENT_ANALYTICS,

--- a/public/services/saved_objects/saved_object_loaders/explorer_saved_object_loader.ts
+++ b/public/services/saved_objects/saved_object_loaders/explorer_saved_object_loader.ts
@@ -4,7 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { batch as Batch } from 'react-redux';
 import { NotificationsStart } from '../../../../../../src/core/public';
 import {

--- a/public/services/saved_objects/saved_object_loaders/ppl/ppl_loader.ts
+++ b/public/services/saved_objects/saved_object_loaders/ppl/ppl_loader.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { batch as Batch } from 'react-redux';
 import { updateFields as updateFieldsAction } from '../../../../components/event_analytics/redux/slices/field_slice';
 import { changeQuery as changeQueryAction } from '../../../../components/event_analytics/redux/slices/query_slice';

--- a/public/services/saved_objects/saved_object_savers/ppl/save_as_new_vis.ts
+++ b/public/services/saved_objects/saved_object_savers/ppl/save_as_new_vis.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { forEach } from 'lodash';
 import {
   addVizToPanels,
   fetchPanel,

--- a/public/services/saved_objects/saved_object_savers/saver_base.ts
+++ b/public/services/saved_objects/saved_object_savers/saver_base.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { capitalize } from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { CoreStart } from '../../../../../../src/core/public';
 import { ISavedObjectSaver } from './saver_interface';
 

--- a/public/services/timestamp/timestamp.ts
+++ b/public/services/timestamp/timestamp.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty, isEqual, values, keys } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import values from 'lodash/values';
+import keys from 'lodash/keys';
 import DSLService from '../requests/dsl';
 import { IDefaultTimestampState } from '../../../common/types/explorer';
 import PPLService from '../requests/ppl';

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,22 +292,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.2.21"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
-  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
+"@types/react@*", "@types/react@^16", "@types/react@^16.14.23":
+  version "16.14.60"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.60.tgz#f7ab62a329b82826f12d02bc8031d4ef4b5e0d81"
+  integrity sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16":
-  version "16.14.46"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.46.tgz#42ac91aece416176e6b6127cd9ec9e381ea67e16"
-  integrity sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/sanitize-filename@^1.6.3":
@@ -317,10 +308,10 @@
   dependencies:
     sanitize-filename "*"
 
-"@types/scheduler@*":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
-  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"


### PR DESCRIPTION
### Description
Optimize lodash use for tree-shaking: Not a huge impact but a necessary step. There are nearly 550 linting problems which are unrelated to the changes.

| File   |      Before      |  After |
|----------|-------------:|------:|
| observabilityDashboards.plugin.js |  20.67 MB | 20.40 MB |
| observabilityDashboards.chunk.3.js |  5.12 MB  |  5.25 MB |
| observabilityDashboards.chunk.4.js |  1.77 MB  |  1.76 MB |
| Overall |  29.18 MB  |  29.03 MB |

Additionally, the incorrect version of `@types/react` (18) was included in the deps which was corrected in this change.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
