### PR TITLE
adding a link to the integrations catalog  release page 

### DIFF
--- a/common/constants/integrations.ts
+++ b/common/constants/integrations.ts
@@ -4,6 +4,8 @@
  */
 
 export const OPENSEARCH_DOCUMENTATION_URL = 'https://opensearch.org/docs/latest/integrations/index';
+export const OPENSEARCH_INTEGRATION_CATALOG_URL =
+  'https://github.com/opensearch-project/opensearch-catalog/blob/main/docs/integrations/Release.md';
 export const ASSET_FILTER_OPTIONS = [
   'index-pattern',
   'search',

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -72,7 +72,7 @@ export function IntegrationHeader() {
       </EuiText>
       <EuiSpacer size="s" />
       <EuiText size="s" color="subdued">
-        Integrations release catalog page.{' '}
+        Integrations release catalog.{' '}
         <EuiLink external={true} href={OPENSEARCH_INTEGRATION_CATALOG_URL} target="blank">
           Catalog Page Link
         </EuiLink>

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -14,7 +14,10 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React, { useState } from 'react';
-import { OPENSEARCH_DOCUMENTATION_URL } from '../../../../common/constants/integrations';
+import {
+  OPENSEARCH_DOCUMENTATION_URL,
+  OPENSEARCH_INTEGRATION_CATALOG_URL,
+} from '../../../../common/constants/integrations';
 
 export function IntegrationHeader() {
   const tabs = [
@@ -65,6 +68,13 @@ export function IntegrationHeader() {
         View integrations with preconfigured assets immediately within your OpenSearch setup.{' '}
         <EuiLink external={true} href={OPENSEARCH_DOCUMENTATION_URL} target="blank">
           Learn more
+        </EuiLink>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiText size="s" color="subdued">
+        Integrations release catalog page.{' '}
+        <EuiLink external={true} href={OPENSEARCH_INTEGRATION_CATALOG_URL} target="blank">
+          Catalog Page Link
         </EuiLink>
       </EuiText>
       <EuiSpacer size="l" />


### PR DESCRIPTION
### Description
adding a link to the integrations catalog  release page in the main integration page
![integration-main-page](https://github.com/opensearch-project/dashboards-observability/assets/48943349/75078c28-d2f7-4182-8aba-ecdaba607788)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
