### PR TITLE
Lake formation support updates

### DIFF
--- a/common/constants/data_connections.ts
+++ b/common/constants/data_connections.ts
@@ -19,6 +19,7 @@ export const QUERY_ALL = 'query-all';
 export const DatasourceTypeToDisplayName: { [key in DatasourceType]: string } = {
   PROMETHEUS: 'Prometheus',
   S3GLUE: 'Amazon S3',
+  SECURITYLAKE: 'Amazon Security Lake',
 };
 
 export const PrometheusURL = 'Prometheus';

--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -247,11 +247,14 @@ export interface LoadCachehookOutput {
   stopLoading: () => void;
 }
 
+export type ObjectLoaderDataSourceType = 'SecurityLake' | 'Other';
+
 export interface StartLoadingParams {
   dataSourceName: string;
   dataSourceMDSId?: string;
   databaseName?: string;
   tableName?: string;
+  dataSourceType?: ObjectLoaderDataSourceType;
 }
 
 export interface RenderAccelerationFlyoutParams {

--- a/common/types/data_connections.ts
+++ b/common/types/data_connections.ts
@@ -47,12 +47,11 @@ export interface AssociatedObject {
 
 export type Role = EuiComboBoxOptionOption;
 
-export type DatasourceType = 'S3GLUE' | 'PROMETHEUS';
+export type DatasourceType = 'S3GLUE' | 'PROMETHEUS' | 'SECURITYLAKE';
 
 export interface S3GlueProperties {
   'glue.indexstore.opensearch.uri': string;
   'glue.indexstore.opensearch.region': string;
-  'glue.lakeformation.enabled'?: boolean;
 }
 
 export interface PrometheusProperties {
@@ -247,18 +246,17 @@ export interface LoadCachehookOutput {
   stopLoading: () => void;
 }
 
-export type ObjectLoaderDataSourceType = 'SecurityLake' | 'Other';
-
 export interface StartLoadingParams {
   dataSourceName: string;
   dataSourceMDSId?: string;
   databaseName?: string;
   tableName?: string;
-  dataSourceType?: ObjectLoaderDataSourceType;
+  dataSourceType?: DatasourceType;
 }
 
 export interface RenderAccelerationFlyoutParams {
   dataSource: string;
+  dataSourceType: DatasourceType;
   dataSourceMDSId?: string;
   databaseName?: string;
   tableName?: string;
@@ -268,9 +266,9 @@ export interface RenderAccelerationFlyoutParams {
 export interface RenderAssociatedObjectsDetailsFlyoutParams {
   tableDetail: AssociatedObject;
   dataSourceName: string;
+  dataSourceType: DatasourceType;
   handleRefresh?: () => void;
   dataSourceMDSId?: string;
-  isS3ConnectionWithLakeFormation?: boolean;
 }
 
 export interface RenderAccelerationDetailsFlyoutParams {

--- a/common/types/integrations.ts
+++ b/common/types/integrations.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type IntegrationConnectionType = 's3' | 'index' | 'securityLake';

--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -319,6 +319,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
               >
                 <CreateAccelerationFlyoutButton
                   dataSourceName="mock_data_source"
+                  dataSourceType="S3GLUE"
                   handleRefresh={[Function]}
                   renderCreateAccelerationFlyout={[MockFunction]}
                 >
@@ -738,9 +739,9 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                     },
                   ]
                 }
+                dataSourceType="S3GLUE"
                 datasourceName="mock_data_source"
                 handleRefresh={[Function]}
-                isS3ConnectionWithLakeFormation={false}
               >
                 <EuiInMemoryTable
                   columns={
@@ -5197,6 +5198,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
               >
                 <CreateAccelerationFlyoutButton
                   dataSourceName="mock_data_source"
+                  dataSourceType="S3GLUE"
                   handleRefresh={[Function]}
                   renderCreateAccelerationFlyout={[MockFunction]}
                 >

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -409,6 +409,7 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
           Array [
             Object {
               "assets": 3,
+              "id": "d5b55c60-e08c-11ee-9c80-ff3b93498fea",
               "locator": Object {
                 "id": "d5b55c60-e08c-11ee-9c80-ff3b93498fea",
                 "name": "aws_waf-sample",
@@ -444,6 +445,7 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
             Array [
               Object {
                 "assets": 3,
+                "id": "d5b55c60-e08c-11ee-9c80-ff3b93498fea",
                 "locator": Object {
                   "id": "d5b55c60-e08c-11ee-9c80-ff3b93498fea",
                   "name": "aws_waf-sample",

--- a/public/components/datasources/components/__tests__/acceleration_table.test.tsx
+++ b/public/components/datasources/components/__tests__/acceleration_table.test.tsx
@@ -95,7 +95,11 @@ describe('AccelerationTable Component', () => {
 
   it('renders without crashing', () => {
     const wrapper = mount(
-      <AccelerationTable dataSourceName="testDataSource" cacheLoadingHooks={cacheLoadingHooks} />
+      <AccelerationTable
+        dataSourceName="testDataSource"
+        cacheLoadingHooks={cacheLoadingHooks}
+        dataSourceType="S3GLUE"
+      />
     );
     expect(wrapper).toBeDefined();
   });
@@ -111,7 +115,11 @@ describe('AccelerationTable Component', () => {
     let wrapper: ReactWrapper;
     await act(async () => {
       wrapper = mount(
-        <AccelerationTable dataSourceName="testDataSource" cacheLoadingHooks={cacheLoadingHooks} />
+        <AccelerationTable
+          dataSourceName="testDataSource"
+          cacheLoadingHooks={cacheLoadingHooks}
+          dataSourceType="S3GLUE"
+        />
       );
     });
 
@@ -132,7 +140,11 @@ describe('AccelerationTable Component', () => {
     let wrapper: ReactWrapper;
     await act(async () => {
       wrapper = mount(
-        <AccelerationTable dataSourceName="testDataSource" cacheLoadingHooks={cacheLoadingHooks} />
+        <AccelerationTable
+          dataSourceName="testDataSource"
+          cacheLoadingHooks={cacheLoadingHooks}
+          dataSourceType="S3GLUE"
+        />
       );
     });
     wrapper!.update();
@@ -152,7 +164,11 @@ describe('AccelerationTable Component', () => {
     let wrapper: ReactWrapper;
     await act(async () => {
       wrapper = mount(
-        <AccelerationTable dataSourceName="testDataSource" cacheLoadingHooks={cacheLoadingHooks} />
+        <AccelerationTable
+          dataSourceName="testDataSource"
+          cacheLoadingHooks={cacheLoadingHooks}
+          dataSourceType="S3GLUE"
+        />
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
       wrapper!.update();
@@ -172,7 +188,11 @@ describe('AccelerationTable Component', () => {
     let wrapper: ReactWrapper;
     await act(async () => {
       wrapper = mount(
-        <AccelerationTable dataSourceName="testDataSource" cacheLoadingHooks={cacheLoadingHooks} />
+        <AccelerationTable
+          dataSourceName="testDataSource"
+          cacheLoadingHooks={cacheLoadingHooks}
+          dataSourceType="S3GLUE"
+        />
       );
     });
     wrapper!.update();

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -21,6 +21,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   CachedAcceleration,
   CachedDataSourceStatus,
+  DatasourceType,
 } from '../../../../../../common/types/data_connections';
 import { DirectQueryLoadingStatus } from '../../../../../../common/types/explorer';
 import { CatalogCacheManager } from '../../../../../framework/catalog_cache/cache_manager';
@@ -45,7 +46,7 @@ import {
 interface AccelerationTableProps {
   dataSourceName: string;
   cacheLoadingHooks: any;
-  isS3ConnectionWithLakeFormation: boolean;
+  dataSourceType: DatasourceType;
 }
 
 interface ModalState {
@@ -56,7 +57,7 @@ interface ModalState {
 export const AccelerationTable = ({
   dataSourceName,
   cacheLoadingHooks,
-  isS3ConnectionWithLakeFormation,
+  dataSourceType,
 }: AccelerationTableProps) => {
   const [accelerations, setAccelerations] = useState<CachedAcceleration[]>([]);
   const [updatedTime, setUpdatedTime] = useState<string>();
@@ -171,6 +172,7 @@ export const AccelerationTable = ({
               <EuiFlexItem grow={false}>
                 <CreateAccelerationFlyoutButton
                   dataSourceName={dataSourceName}
+                  dataSourceType={dataSourceType}
                   renderCreateAccelerationFlyout={renderCreateAccelerationFlyout}
                   handleRefresh={handleRefresh}
                 />
@@ -327,11 +329,12 @@ export const AccelerationTable = ({
     },
   };
 
-  const accelerationTableColumns = !isS3ConnectionWithLakeFormation
-    ? Object.values(accelerationTableColumnsCollection)
-    : Object.entries(accelerationTableColumnsCollection)
-        .filter(([key]) => key !== 'database' && key !== 'table')
-        .map(([_key, val]) => val);
+  const accelerationTableColumns =
+    dataSourceType.toUpperCase() === 'SECURITYLAKE'
+      ? Object.entries(accelerationTableColumnsCollection)
+          .filter(([key]) => key !== 'database' && key !== 'table')
+          .map(([_key, val]) => val)
+      : Object.values(accelerationTableColumnsCollection);
 
   const pagination = {
     initialPageSize: 10,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/create_acceleration.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/create_acceleration.test.tsx
@@ -36,7 +36,11 @@ describe('Create acceleration flyout components', () => {
     coreStartMock.http.get = jest.fn().mockResolvedValue(mockDatasourcesQuery);
 
     const wrapper = mount(
-      <CreateAcceleration selectedDatasource={selectedDatasource} resetFlyout={resetFlyout} />
+      <CreateAcceleration
+        selectedDatasource={selectedDatasource}
+        resetFlyout={resetFlyout}
+        selectedDatasourceType="S3GLUE"
+      />
     );
     wrapper.update();
     await waitFor(() => {

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -67,7 +67,7 @@ export const CreateAcceleration = ({
     database: databaseName ?? '',
     dataTable: tableName ?? '',
     dataTableFields: [],
-    accelerationIndexType: 'skipping',
+    accelerationIndexType: selectedDatasourceType === 'SECURITYLAKE' ? 'materialized' : 'skipping',
     skippingIndexQueryData: [],
     coveringIndexQueryData: [],
     materializedViewQueryData: {

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -245,6 +245,7 @@ export const CreateAcceleration = ({
                 setDataSourceFormData: setAccelerationFormData,
               }}
               selectedDatasource={selectedDatasource}
+              selectedDataSourceType={isS3ConnectionWithLakeFormation ? 'SecurityLake' : 'Other'}
               dataSourcesPreselected={dataSourcesPreselected}
               tableFieldsLoading={tableFieldsLoading}
               dataSourceMDSId={dataSourceMDSId}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -24,6 +24,7 @@ import {
 import {
   CachedTable,
   CreateAccelerationForm,
+  DatasourceType,
 } from '../../../../../../../../common/types/data_connections';
 import { DirectQueryLoadingStatus } from '../../../../../../../../common/types/explorer';
 import { useLoadTableColumnsToCache } from '../../../../../../../framework/catalog_cache/cache_loader';
@@ -39,11 +40,10 @@ import { QueryVisualEditor } from '../visual_editors/query_visual_editor';
 import { CreateAccelerationButton } from './create_acceleration_button';
 import { CreateAccelerationHeader } from './create_acceleration_header';
 import { hasError } from './utils';
-import { DATACONNECTIONS_BASE } from '../../../../../../../../common/constants/shared';
-import { checkIsConnectionWithLakeFormation } from '../../../../../utils/helpers';
 
 export interface CreateAccelerationProps {
   selectedDatasource: string;
+  selectedDatasourceType: DatasourceType;
   resetFlyout: () => void;
   databaseName?: string;
   tableName?: string;
@@ -53,6 +53,7 @@ export interface CreateAccelerationProps {
 
 export const CreateAcceleration = ({
   selectedDatasource,
+  selectedDatasourceType,
   resetFlyout,
   databaseName,
   tableName,
@@ -61,7 +62,6 @@ export const CreateAcceleration = ({
 }: CreateAccelerationProps) => {
   const { setToast } = useToast();
   const http = coreRefs!.http;
-  const [isS3ConnectionWithLakeFormation, setIsS3ConnectionWithLakeFormation] = useState(false);
   const [accelerationFormData, setAccelerationFormData] = useState<CreateAccelerationForm>({
     dataSource: selectedDatasource,
     database: databaseName ?? '',
@@ -170,16 +170,6 @@ export const CreateAcceleration = ({
     }
   };
 
-  const updateDataSourceConnectionInfo = () => {
-    coreRefs.http!.get(`${DATACONNECTIONS_BASE}/${selectedDatasource}`).then((data: any) => {
-      setIsS3ConnectionWithLakeFormation(checkIsConnectionWithLakeFormation(data));
-    });
-  };
-
-  useEffect(() => {
-    updateDataSourceConnectionInfo();
-  }, [selectedDatasource]);
-
   useEffect(() => {
     if (databaseName !== undefined && tableName !== undefined) {
       initiateColumnLoad(
@@ -245,7 +235,7 @@ export const CreateAcceleration = ({
                 setDataSourceFormData: setAccelerationFormData,
               }}
               selectedDatasource={selectedDatasource}
-              selectedDataSourceType={isS3ConnectionWithLakeFormation ? 'SecurityLake' : 'Other'}
+              selectedDataSourceType={selectedDatasourceType}
               dataSourcesPreselected={dataSourcesPreselected}
               tableFieldsLoading={tableFieldsLoading}
               dataSourceMDSId={dataSourceMDSId}
@@ -253,7 +243,7 @@ export const CreateAcceleration = ({
             <EuiSpacer size="xxl" />
             <IndexTypeSelector
               accelerationFormData={accelerationFormData}
-              isS3ConnectionWithLakeFormation={isS3ConnectionWithLakeFormation}
+              dataSourceType={selectedDatasourceType}
               setAccelerationFormData={setAccelerationFormData}
               initiateColumnLoad={initiateColumnLoad}
             />

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/index_type_selector.test.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/index_type_selector.test.tsx
@@ -21,9 +21,9 @@ describe('Index type selector components', () => {
     const wrapper = mount(
       <IndexTypeSelector
         accelerationFormData={accelerationFormData}
+        dataSourceType="S3GLUE"
         setAccelerationFormData={setAccelerationFormData}
         initiateColumnLoad={jest.fn()}
-        loading={false}
       />
     );
     wrapper.update();
@@ -46,9 +46,9 @@ describe('Index type selector components', () => {
     const wrapper = mount(
       <IndexTypeSelector
         accelerationFormData={accelerationFormData}
+        dataSourceType="S3GLUE"
         setAccelerationFormData={setAccelerationFormData}
         initiateColumnLoad={jest.fn()}
-        loading={true}
       />
     );
     wrapper.update();

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
@@ -12,32 +12,33 @@ import {
 import {
   AccelerationIndexType,
   CreateAccelerationForm,
+  DatasourceType,
 } from '../../../../../../../../common/types/data_connections';
 
 interface IndexTypeSelectorProps {
   accelerationFormData: CreateAccelerationForm;
-  isS3ConnectionWithLakeFormation: boolean;
+  dataSourceType: DatasourceType;
   setAccelerationFormData: React.Dispatch<React.SetStateAction<CreateAccelerationForm>>;
   initiateColumnLoad: (dataSource: string, database: string, dataTable: string) => void;
 }
 
 export const IndexTypeSelector = ({
   accelerationFormData,
-  isS3ConnectionWithLakeFormation,
+  dataSourceType,
   setAccelerationFormData,
   initiateColumnLoad,
 }: IndexTypeSelectorProps) => {
   const [value, setValue] = useState('skipping');
   // This is used to track if user changed the value
-  // If so, we skip changing it based on 'isS3ConnectionWithLakeFormation' in the effect below
+  // If so, we skip changing it based on 'dataSourceType' in the effect below
   const valueSetAlready = useRef(false);
 
   useEffect(() => {
     if (!valueSetAlready.current) {
-      const defaultSelectedOption = isS3ConnectionWithLakeFormation ? 'materialized' : 'skipping';
+      const defaultSelectedOption = dataSourceType === 'SECURITYLAKE' ? 'materialized' : 'skipping';
       updateState(defaultSelectedOption);
     }
-  }, [isS3ConnectionWithLakeFormation]);
+  }, [dataSourceType]);
 
   useEffect(() => {
     initiateColumnLoad(
@@ -62,24 +63,25 @@ export const IndexTypeSelector = ({
     valueSetAlready.current = true;
   };
 
-  const baseOptions = !isS3ConnectionWithLakeFormation
-    ? [
-        {
-          value: 'skipping',
-          inputDisplay: 'Skipping index',
-          dropdownDisplay: (
-            <Fragment>
-              <strong>Skipping index</strong>
-              <EuiText size="s" color="subdued">
-                <p className="EuiTextColor--subdued">
-                  Accelerate direct queries by storing table meta-data in OpenSearch.
-                </p>
-              </EuiText>
-            </Fragment>
-          ),
-        },
-      ]
-    : [];
+  const baseOptions =
+    dataSourceType.toUpperCase() !== 'SECURITYLAKE'
+      ? [
+          {
+            value: 'skipping',
+            inputDisplay: 'Skipping index',
+            dropdownDisplay: (
+              <Fragment>
+                <strong>Skipping index</strong>
+                <EuiText size="s" color="subdued">
+                  <p className="EuiTextColor--subdued">
+                    Accelerate direct queries by storing table meta-data in OpenSearch.
+                  </p>
+                </EuiText>
+              </Fragment>
+            ),
+          },
+        ]
+      : [];
 
   const superSelectOptions = [
     ...baseOptions,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
@@ -3,8 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFormRow, EuiLink, EuiSpacer, EuiSuperSelect, EuiText } from '@elastic/eui';
-import React, { Fragment, useEffect, useState, useRef } from 'react';
+import {
+  EuiFormRow,
+  EuiLink,
+  EuiSpacer,
+  EuiSuperSelect,
+  EuiSuperSelectOption,
+  EuiText,
+} from '@elastic/eui';
+import React, { Fragment, useEffect, useState } from 'react';
 import {
   ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME,
   ACC_INDEX_TYPE_DOCUMENTATION_URL,
@@ -28,17 +35,9 @@ export const IndexTypeSelector = ({
   setAccelerationFormData,
   initiateColumnLoad,
 }: IndexTypeSelectorProps) => {
-  const [value, setValue] = useState('skipping');
-  // This is used to track if user changed the value
-  // If so, we skip changing it based on 'dataSourceType' in the effect below
-  const valueSetAlready = useRef(false);
-
-  useEffect(() => {
-    if (!valueSetAlready.current) {
-      const defaultSelectedOption = dataSourceType === 'SECURITYLAKE' ? 'materialized' : 'skipping';
-      updateState(defaultSelectedOption);
-    }
-  }, [dataSourceType]);
+  const [value, setValue] = useState<AccelerationIndexType>(
+    dataSourceType === 'SECURITYLAKE' ? 'materialized' : 'skipping'
+  );
 
   useEffect(() => {
     initiateColumnLoad(
@@ -48,22 +47,21 @@ export const IndexTypeSelector = ({
     );
   }, [accelerationFormData.dataTable]);
 
-  const updateState = (indexType: string) => {
+  const updateState = (indexType: AccelerationIndexType) => {
     setAccelerationFormData({
       ...accelerationFormData,
-      accelerationIndexType: indexType as AccelerationIndexType,
+      accelerationIndexType: indexType,
       accelerationIndexName:
         indexType === 'skipping' ? ACCELERATION_DEFUALT_SKIPPING_INDEX_NAME : '',
     });
     setValue(indexType);
   };
 
-  const onChangeSupeSelect = (indexType: string) => {
+  const onChangeSupeSelect = (indexType: AccelerationIndexType) => {
     updateState(indexType);
-    valueSetAlready.current = true;
   };
 
-  const baseOptions =
+  const baseOptions: Array<EuiSuperSelectOption<AccelerationIndexType>> =
     dataSourceType.toUpperCase() !== 'SECURITYLAKE'
       ? [
           {
@@ -83,7 +81,7 @@ export const IndexTypeSelector = ({
         ]
       : [];
 
-  const superSelectOptions = [
+  const superSelectOptions: Array<EuiSuperSelectOption<AccelerationIndexType>> = [
     ...baseOptions,
     {
       value: 'covering',

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
@@ -11,11 +11,11 @@ import {
   useLoadTablesToCache,
 } from '../../../../../../../../framework/catalog_cache/cache_loader';
 import { useToast } from '../../../../../../../common/toast';
-import { ObjectLoaderDataSourceType } from '../../../../../../../../../common/types/data_connections';
+import { DatasourceType } from '../../../../../../../../../common/types/data_connections';
 
 interface SelectorLoadDatabasesProps {
   dataSourceName: string;
-  dataSourceType: ObjectLoaderDataSourceType;
+  dataSourceType: DatasourceType;
   databaseName: string;
   loadTables: () => void;
   loadingComboBoxes: {

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/selector_helpers/load_objects.tsx
@@ -11,9 +11,11 @@ import {
   useLoadTablesToCache,
 } from '../../../../../../../../framework/catalog_cache/cache_loader';
 import { useToast } from '../../../../../../../common/toast';
+import { ObjectLoaderDataSourceType } from '../../../../../../../../../common/types/data_connections';
 
 interface SelectorLoadDatabasesProps {
   dataSourceName: string;
+  dataSourceType: ObjectLoaderDataSourceType;
   databaseName: string;
   loadTables: () => void;
   loadingComboBoxes: {
@@ -34,6 +36,7 @@ interface SelectorLoadDatabasesProps {
 
 export const SelectorLoadObjects = ({
   dataSourceName,
+  dataSourceType,
   databaseName,
   loadTables,
   loadingComboBoxes,
@@ -67,7 +70,7 @@ export const SelectorLoadObjects = ({
       tableStatus: true,
       accelerationsStatus: true,
     });
-    startLoadingTables({ dataSourceName, databaseName, dataSourceMDSId });
+    startLoadingTables({ dataSourceName, databaseName, dataSourceMDSId, dataSourceType });
     startLoadingAccelerations({ dataSourceName, dataSourceMDSId });
   };
 

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
@@ -23,6 +23,7 @@ import {
   CachedDataSourceStatus,
   CachedDatabase,
   CreateAccelerationForm,
+  ObjectLoaderDataSourceType,
 } from '../../../../../../../../common/types/data_connections';
 import { CatalogCacheManager } from '../../../../../../../framework/catalog_cache/cache_manager';
 import { useToast } from '../../../../../../common/toast';
@@ -51,6 +52,7 @@ interface DataSourceSelectorProps {
   http: CoreStart['http'];
   dataSourceFormProps: DataSourceFormProps;
   selectedDatasource: string;
+  selectedDataSourceType: ObjectLoaderDataSourceType;
   dataSourcesPreselected: boolean;
   tableFieldsLoading: boolean;
   dataSourceMDSId?: string;
@@ -61,6 +63,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
   http,
   dataSourceFormProps: { dataSourceFormData, setDataSourceFormData },
   selectedDatasource,
+  selectedDataSourceType,
   dataSourcesPreselected,
   tableFieldsLoading,
   dataSourceMDSId,
@@ -296,6 +299,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
               <EuiFlexItem grow={false}>
                 <SelectorLoadObjects
                   dataSourceName={dataSourceFormData.dataSource}
+                  dataSourceType={selectedDataSourceType}
                   databaseName={dataSourceFormData.database}
                   loadTables={loadTables}
                   loadingComboBoxes={loadingComboBoxes}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
@@ -57,17 +57,19 @@ interface DataSourceSelectorProps {
   tableFieldsLoading: boolean;
   dataSourceMDSId?: string;
   hideHeader?: boolean;
+  hideDataSourceDescription?: boolean;
 }
 
 export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
   http,
-  dataSourceFormProps: { dataSourceFormData, setDataSourceFormData },
+  dataSourceFormProps: { dataSourceFormData, formType, setDataSourceFormData },
   selectedDatasource,
   selectedDataSourceType,
   dataSourcesPreselected,
   tableFieldsLoading,
   dataSourceMDSId,
   hideHeader,
+  hideDataSourceDescription,
 }) => {
   const { setToast } = useToast();
   const [databases, setDatabases] = useState<Array<EuiComboBoxOptionOption<string>>>([]);
@@ -82,7 +84,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
     dataTable: false,
   });
 
-  const dataSourceDescription = (
+  const dataSourceDescription = hideDataSourceDescription ? null : (
     <EuiDescriptionList>
       <EuiDescriptionListTitle>Data source</EuiDescriptionListTitle>
       <EuiDescriptionListDescription>{dataSourceFormData.dataSource}</EuiDescriptionListDescription>
@@ -90,6 +92,9 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
   );
 
   const loadDataSource = () => {
+    if (formType === 'SetupIntegration') {
+      return;
+    }
     setLoadingComboBoxes({ ...loadingComboBoxes, dataSource: true });
     http
       .get(`${DATACONNECTIONS_BASE}/dataSourceMDSId=${dataSourceMDSId ?? ''}`)

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
@@ -23,7 +23,7 @@ import {
   CachedDataSourceStatus,
   CachedDatabase,
   CreateAccelerationForm,
-  ObjectLoaderDataSourceType,
+  DatasourceType,
 } from '../../../../../../../../common/types/data_connections';
 import { CatalogCacheManager } from '../../../../../../../framework/catalog_cache/cache_manager';
 import { useToast } from '../../../../../../common/toast';
@@ -52,7 +52,7 @@ interface DataSourceSelectorProps {
   http: CoreStart['http'];
   dataSourceFormProps: DataSourceFormProps;
   selectedDatasource: string;
-  selectedDataSourceType: ObjectLoaderDataSourceType;
+  selectedDataSourceType: DatasourceType;
   dataSourcesPreselected: boolean;
   tableFieldsLoading: boolean;
   dataSourceMDSId?: string;
@@ -101,7 +101,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
       .then((res) => {
         const isValidDataSource = res.some(
           (connection: any) =>
-            connection.connector.toUpperCase() === 'S3GLUE' &&
+            ['S3GLUE', 'SECURITYLAKE'].includes(connection.connector.toUpperCase()) &&
             connection.name === selectedDatasource
         );
 

--- a/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { DATA_SOURCE_TYPES } from '../../../../../../../common/constants/data_sources';
 import {
   CachedAcceleration,
+  DatasourceType,
   RenderAccelerationFlyoutParams,
 } from '../../../../../../../common/types/data_connections';
 import {
@@ -89,10 +90,12 @@ export const generateAccelerationOperationQuery = (
 
 export const CreateAccelerationFlyoutButton = ({
   dataSourceName,
+  dataSourceType,
   renderCreateAccelerationFlyout,
   handleRefresh,
 }: {
   dataSourceName: string;
+  dataSourceType: DatasourceType;
   renderCreateAccelerationFlyout: ({
     dataSource,
     databaseName,
@@ -108,6 +111,7 @@ export const CreateAccelerationFlyoutButton = ({
         onClick={() =>
           renderCreateAccelerationFlyout({
             dataSource: dataSourceName,
+            dataSourceType,
             handleRefresh,
           })
         }

--- a/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
+++ b/public/components/datasources/components/manage/associated_objects/modules/associated_objects_table.tsx
@@ -18,6 +18,7 @@ import {
 import {
   AssociatedObject,
   CachedAcceleration,
+  DatasourceType,
 } from '../../../../../../../common/types/data_connections';
 import {
   getRenderAccelerationDetailsFlyout,
@@ -36,9 +37,9 @@ import {
 
 interface AssociatedObjectsTableProps {
   datasourceName: string;
+  dataSourceType: DatasourceType;
   associatedObjects: AssociatedObject[];
   cachedAccelerations: CachedAcceleration[];
-  isS3ConnectionWithLakeFormation: boolean;
   handleRefresh: () => void;
 }
 
@@ -56,9 +57,9 @@ interface AssociatedTableFilter {
 
 export const AssociatedObjectsTable = ({
   datasourceName,
+  dataSourceType,
   associatedObjects,
   cachedAccelerations,
-  isS3ConnectionWithLakeFormation,
   handleRefresh,
 }: AssociatedObjectsTableProps) => {
   const [accelerationFilterOptions, setAccelerationFilterOptions] = useState<FilterOption[]>([]);
@@ -68,7 +69,7 @@ export const AssociatedObjectsTable = ({
     {
       field: 'name',
       name: i18n.translate('datasources.associatedObjectsTab.column.name', {
-        defaultMessage: isS3ConnectionWithLakeFormation ? 'Table' : 'Name',
+        defaultMessage: dataSourceType === 'SECURITYLAKE' ? 'Table' : 'Name',
       }),
       sortable: true,
       'data-test-subj': 'nameCell',
@@ -79,7 +80,7 @@ export const AssociatedObjectsTable = ({
               renderAssociatedObjectsDetailsFlyout({
                 tableDetail: item,
                 dataSourceName: datasourceName,
-                isS3ConnectionWithLakeFormation,
+                dataSourceType,
                 handleRefresh,
               });
             } else {
@@ -100,7 +101,7 @@ export const AssociatedObjectsTable = ({
     {
       field: 'accelerations',
       name: i18n.translate('datasources.associatedObjectsTab.column.accelerations', {
-        defaultMessage: isS3ConnectionWithLakeFormation ? 'Accelerations' : 'Associations',
+        defaultMessage: dataSourceType === 'SECURITYLAKE' ? 'Accelerations' : 'Associations',
       }),
       sortable: true,
       render: (accelerations: CachedAcceleration[] | AssociatedObject, obj: AssociatedObject) => {
@@ -129,7 +130,7 @@ export const AssociatedObjectsTable = ({
                 renderAssociatedObjectsDetailsFlyout({
                   tableDetail: obj,
                   dataSourceName: datasourceName,
-                  isS3ConnectionWithLakeFormation,
+                  dataSourceType,
                   handleRefresh,
                 })
               }
@@ -144,7 +145,7 @@ export const AssociatedObjectsTable = ({
                 renderAssociatedObjectsDetailsFlyout({
                   tableDetail: accelerations,
                   dataSourceName: datasourceName,
-                  isS3ConnectionWithLakeFormation,
+                  dataSourceType,
                   handleRefresh,
                 })
               }
@@ -176,6 +177,7 @@ export const AssociatedObjectsTable = ({
           onClick: (item: AssociatedObject) =>
             renderCreateAccelerationFlyout({
               dataSource: datasourceName,
+              dataSourceType,
               databaseName: item.database,
               tableName: item.tableName,
               handleRefresh,
@@ -214,7 +216,7 @@ export const AssociatedObjectsTable = ({
     },
   ] as Array<EuiTableFieldDataColumnType<AssociatedObject>>;
 
-  if (!isS3ConnectionWithLakeFormation) {
+  if (dataSourceType !== 'SECURITYLAKE') {
     columns.splice(1, 0, {
       field: 'type',
       name: i18n.translate('datasources.associatedObjectsTab.column.type', {
@@ -274,9 +276,10 @@ export const AssociatedObjectsTable = ({
     filters: searchFilters,
     box: {
       incremental: true,
-      placeholder: isS3ConnectionWithLakeFormation
-        ? ASSC_OBJ_TABLE_FOR_S3_WITH_LAKE_FORMATION_SEARCH_HINT
-        : ASSC_OBJ_TABLE_SEARCH_HINT,
+      placeholder:
+        dataSourceType === 'SECURITYLAKE'
+          ? ASSC_OBJ_TABLE_FOR_S3_WITH_LAKE_FORMATION_SEARCH_HINT
+          : ASSC_OBJ_TABLE_SEARCH_HINT,
       schema: {
         fields: { name: { type: 'string' }, database: { type: 'string' } },
       },

--- a/public/components/datasources/components/manage/connection_details.tsx
+++ b/public/components/datasources/components/manage/connection_details.tsx
@@ -4,7 +4,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText, EuiHorizontalRule } from '@elastic/eui';
-import React, { useState } from 'react';
+import React from 'react';
 import { EuiPanel } from '@elastic/eui';
 import { ConnectionManagementCallout } from './connection_management_callout';
 import { PrometheusProperties, S3GlueProperties } from './data_connection';
@@ -113,7 +113,7 @@ export const ConnectionDetails = (props: ConnectionDetailProps) => {
       <EuiPanel>
         <ConnectionConfigurationHeader />
         <EuiHorizontalRule />
-        {connector === 'S3GLUE' ? (
+        {connector === 'S3GLUE' || connector === 'SECURITYLAKE' ? (
           <S3ConnectionConfigurationView />
         ) : (
           <PrometheusConnectionConfigurationView />

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -30,6 +30,7 @@ import {
 import {
   DatasourceDetails,
   PrometheusProperties,
+  StartLoadingParams,
 } from '../../../../../common/types/data_connections';
 import {
   useLoadAccelerationsToCache,
@@ -85,7 +86,12 @@ export const DataConnection = (props: { dataSource: string }) => {
     databasesLoadStatus,
     startLoadingDatabases,
     tablesLoadStatus,
-    startLoadingTables,
+    startLoadingTables: (loadingParams: StartLoadingParams) => {
+      startLoadingTables({
+        ...loadingParams,
+        dataSourceType: isS3ConnectionWithLakeFormation ? 'SecurityLake' : 'Other',
+      });
+    },
     accelerationsLoadStatus,
     startLoadingAccelerations,
   };

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -49,7 +49,6 @@ import {
   InstallIntegrationFlyout,
   InstalledIntegrationsTable,
 } from './integrations/installed_integrations_table';
-import { checkIsConnectionWithLakeFormation } from '../../utils/helpers';
 
 const renderCreateAccelerationFlyout = getRenderCreateAccelerationFlyout();
 
@@ -63,9 +62,6 @@ export const DataConnection = (props: { dataSource: string }) => {
     properties: { 'prometheus.uri': 'placeholder' },
     status: 'ACTIVE',
   });
-  const [isS3ConnectionWithLakeFormation, setIsS3ConnectionWithLakeFormation] = useState<boolean>(
-    false
-  );
   const [hasAccess, setHasAccess] = useState(true);
   const { http, chrome, application } = coreRefs;
   const [selectedDatabase, setSelectedDatabase] = useState<string>('');
@@ -89,7 +85,7 @@ export const DataConnection = (props: { dataSource: string }) => {
     startLoadingTables: (loadingParams: StartLoadingParams) => {
       startLoadingTables({
         ...loadingParams,
-        dataSourceType: isS3ConnectionWithLakeFormation ? 'SecurityLake' : 'Other',
+        dataSourceType: datasourceDetails.connector,
       });
     },
     accelerationsLoadStatus,
@@ -101,10 +97,6 @@ export const DataConnection = (props: { dataSource: string }) => {
   );
   const [refreshIntegrationsFlag, setRefreshIntegrationsFlag] = useState(false);
   const refreshInstances = () => setRefreshIntegrationsFlag((prev) => !prev);
-
-  useEffect(() => {
-    setIsS3ConnectionWithLakeFormation(checkIsConnectionWithLakeFormation(datasourceDetails));
-  }, [datasourceDetails]);
 
   useEffect(() => {
     const searchDataSourcePattern = new RegExp(`flint_${escapeRegExp(datasourceDetails.name)}_.*`);
@@ -134,12 +126,11 @@ export const DataConnection = (props: { dataSource: string }) => {
       closeFlyout={() => setShowIntegrationsFlyout(false)}
       datasourceType={datasourceDetails.connector}
       datasourceName={datasourceDetails.name}
-      isS3ConnectionWithLakeFormation={isS3ConnectionWithLakeFormation}
     />
   ) : null;
 
   const onclickAccelerationsCard = () => {
-    renderCreateAccelerationFlyout({ dataSource });
+    renderCreateAccelerationFlyout({ dataSource, dataSourceType: datasourceDetails.connector });
   };
 
   const onclickDiscoverCard = () => {
@@ -242,55 +233,54 @@ export const DataConnection = (props: { dataSource: string }) => {
     },
   ];
 
-  const conditionalTabs =
-    datasourceDetails.connector === 'S3GLUE'
-      ? [
-          {
-            id: 'associated_objects',
-            name: isS3ConnectionWithLakeFormation ? 'Tables' : 'Associated Objects',
-            disabled: false,
-            content: (
-              <AssociatedObjectsTab
-                datasource={datasourceDetails}
-                cacheLoadingHooks={cacheLoadingHooks}
-                selectedDatabase={selectedDatabase}
-                setSelectedDatabase={setSelectedDatabase}
-              />
-            ),
-          },
-          {
-            id: 'acceleration_table',
-            name: 'Accelerations',
-            disabled: false,
-            content: (
-              <AccelerationTable
-                dataSourceName={dataSource}
-                cacheLoadingHooks={cacheLoadingHooks}
-                isS3ConnectionWithLakeFormation={isS3ConnectionWithLakeFormation}
-              />
-            ),
-          },
-          {
-            id: 'installed_integrations',
-            name: 'Installed Integrations',
-            disabled: false,
-            content: (
-              <InstalledIntegrationsTable
-                integrations={dataSourceIntegrations}
-                datasourceType={datasourceDetails.connector}
-                datasourceName={datasourceDetails.name}
-                isS3ConnectionWithLakeFormation={isS3ConnectionWithLakeFormation}
-                refreshInstances={refreshInstances}
-              />
-            ),
-          },
-        ]
-      : [];
+  const conditionalTabs = ['S3GLUE', 'SECURITYLAKE'].includes(datasourceDetails.connector)
+    ? [
+        {
+          id: 'associated_objects',
+          name: datasourceDetails.connector === 'SECURITYLAKE' ? 'Tables' : 'Associated Objects',
+          disabled: false,
+          content: (
+            <AssociatedObjectsTab
+              datasource={datasourceDetails}
+              cacheLoadingHooks={cacheLoadingHooks}
+              selectedDatabase={selectedDatabase}
+              setSelectedDatabase={setSelectedDatabase}
+            />
+          ),
+        },
+        {
+          id: 'acceleration_table',
+          name: 'Accelerations',
+          disabled: false,
+          content: (
+            <AccelerationTable
+              dataSourceName={dataSource}
+              dataSourceType={datasourceDetails.connector}
+              cacheLoadingHooks={cacheLoadingHooks}
+            />
+          ),
+        },
+        {
+          id: 'installed_integrations',
+          name: 'Installed Integrations',
+          disabled: false,
+          content: (
+            <InstalledIntegrationsTable
+              integrations={dataSourceIntegrations}
+              datasourceType={datasourceDetails.connector}
+              datasourceName={datasourceDetails.name}
+              refreshInstances={refreshInstances}
+            />
+          ),
+        },
+      ]
+    : [];
 
   const tabs = [...conditionalTabs, ...genericTabs];
 
   const QueryOrAccelerateData = () => {
     switch (datasourceDetails.connector) {
+      case 'SECURITYLAKE':
       case 'S3GLUE':
         return <DefaultDatasourceCards />;
       case 'PROMETHEUS':
@@ -390,6 +380,7 @@ export const DataConnection = (props: { dataSource: string }) => {
 
   const DatasourceOverview = () => {
     switch (datasourceDetails.connector) {
+      case 'SECURITYLAKE':
       case 'S3GLUE':
         return <S3DatasourceOverview />;
       case 'PROMETHEUS':

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -27,6 +27,7 @@ import { AvailableIntegrationsTable } from '../../../../integrations/components/
 import { INTEGRATIONS_BASE } from '../../../../../../common/constants/shared';
 import { AvailableIntegrationsList } from '../../../../integrations/components/available_integration_overview_page';
 import { DatasourceType } from '../../../../../../common/types/data_connections';
+import { isS3Connection } from '../../../utils/helpers';
 
 interface IntegrationInstanceTableEntry {
   id: string;
@@ -41,6 +42,8 @@ interface IntegrationInstanceTableEntry {
 
 const labelFromDataSourceType = (dsType: DatasourceType): string | null => {
   switch (dsType) {
+    case 'SECURITYLAKE':
+      return 'Amazon Security Lake';
     case 'S3GLUE':
       return 'Flint S3';
     case 'PROMETHEUS':
@@ -128,7 +131,6 @@ const NoInstalledIntegrations = ({ toggleFlyout }: { toggleFlyout: () => void })
 export interface InstallIntegrationFlyoutProps {
   datasourceType: DatasourceType;
   datasourceName: string;
-  isS3ConnectionWithLakeFormation?: boolean;
   closeFlyout: () => void;
   refreshInstances?: () => void;
 }
@@ -136,7 +138,6 @@ export interface InstallIntegrationFlyoutProps {
 export const InstallIntegrationFlyout = ({
   datasourceType,
   datasourceName,
-  isS3ConnectionWithLakeFormation,
   closeFlyout,
   refreshInstances,
 }: InstallIntegrationFlyoutProps) => {
@@ -155,9 +156,8 @@ export const InstallIntegrationFlyout = ({
     });
   }, []);
 
-  const integrationLabelToCheck = isS3ConnectionWithLakeFormation
-    ? 'Security Lake'
-    : labelFromDataSourceType(datasourceType);
+  const integrationLabelToCheck =
+    datasourceType === 'SECURITYLAKE' ? 'Security Lake' : labelFromDataSourceType(datasourceType);
 
   const integrationsFilteredByLabel = {
     hits: availableIntegrations.hits.filter((config) =>
@@ -187,10 +187,10 @@ export const InstallIntegrationFlyout = ({
           unsetIntegration={() => setInstallingIntegration(null)}
           renderType="flyout"
           forceConnection={
-            datasourceType === 'S3GLUE'
+            isS3Connection(datasourceType)
               ? {
                   name: datasourceName,
-                  type: isS3ConnectionWithLakeFormation ? 'securityLake' : 's3',
+                  type: datasourceType.toLowerCase() === 'securitylake' ? 'securityLake' : 's3',
                 }
               : undefined
           }
@@ -211,13 +211,11 @@ export const InstalledIntegrationsTable = ({
   integrations,
   datasourceType,
   datasourceName,
-  isS3ConnectionWithLakeFormation,
   refreshInstances,
 }: {
   integrations: IntegrationInstanceResult[];
   datasourceType: DatasourceType;
   datasourceName: string;
-  isS3ConnectionWithLakeFormation?: boolean;
   refreshInstances: () => void;
 }) => {
   const [query, setQuery] = useState('');
@@ -268,7 +266,6 @@ export const InstalledIntegrationsTable = ({
           closeFlyout={() => setShowAvailableFlyout(false)}
           datasourceType={datasourceType}
           datasourceName={datasourceName}
-          isS3ConnectionWithLakeFormation={isS3ConnectionWithLakeFormation}
           refreshInstances={refreshInstances}
         />
       ) : null}

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -29,6 +29,7 @@ import { AvailableIntegrationsList } from '../../../../integrations/components/a
 import { DatasourceType } from '../../../../../../common/types/data_connections';
 
 interface IntegrationInstanceTableEntry {
+  id: string;
   name: string;
   locator: {
     name: string;
@@ -79,6 +80,7 @@ const instanceToTableEntry = (
   instance: IntegrationInstanceResult
 ): IntegrationInstanceTableEntry => {
   return {
+    id: instance.id,
     name: instance.name,
     locator: { name: instance.name, id: instance.id },
     status: instance.status,
@@ -128,7 +130,7 @@ export interface InstallIntegrationFlyoutProps {
   datasourceName: string;
   isS3ConnectionWithLakeFormation?: boolean;
   closeFlyout: () => void;
-  refreshInstances: () => void;
+  refreshInstances?: () => void;
 }
 
 export const InstallIntegrationFlyout = ({
@@ -153,9 +155,13 @@ export const InstallIntegrationFlyout = ({
     });
   }, []);
 
-  const s3FilteredIntegrations = {
+  const integrationLabelToCheck = isS3ConnectionWithLakeFormation
+    ? 'Security Lake'
+    : labelFromDataSourceType(datasourceType);
+
+  const integrationsFilteredByLabel = {
     hits: availableIntegrations.hits.filter((config) =>
-      config.labels?.includes(labelFromDataSourceType(datasourceType) ?? '')
+      config.labels?.includes(integrationLabelToCheck ?? '')
     ),
   };
 
@@ -171,7 +177,7 @@ export const InstallIntegrationFlyout = ({
       {installingIntegration === null ? (
         <AvailableIntegrationsTable
           loading={false}
-          data={s3FilteredIntegrations}
+          data={integrationsFilteredByLabel}
           isCardView={true}
           setInstallingIntegration={setInstallingIntegration}
         />
@@ -184,10 +190,7 @@ export const InstallIntegrationFlyout = ({
             datasourceType === 'S3GLUE'
               ? {
                   name: datasourceName,
-                  type: 's3',
-                  properties: {
-                    lakeFormationEnabled: isS3ConnectionWithLakeFormation,
-                  },
+                  type: isS3ConnectionWithLakeFormation ? 'securityLake' : 's3',
                 }
               : undefined
           }
@@ -195,7 +198,7 @@ export const InstallIntegrationFlyout = ({
             setIsInstalling(installing);
             if (success) {
               closeFlyout();
-              refreshInstances();
+              refreshInstances?.();
             }
           }}
         />

--- a/public/components/datasources/components/manage/manage_data_connections_table.tsx
+++ b/public/components/datasources/components/manage/manage_data_connections_table.tsx
@@ -37,7 +37,6 @@ import S3Logo from '../../icons/s3-logo.svg';
 import SecurityLakeLogo from '../../icons/security-lake-logo.svg';
 import { DataConnectionsHeader } from '../data_connections_header';
 import { redirectToExplorerS3 } from './associated_objects/utils/associated_objects_tab_utils';
-import { checkIsConnectionWithLakeFormation } from '../../utils/helpers';
 import { InstallIntegrationFlyout } from './integrations/installed_integrations_table';
 import { DataConnectionsDescription } from './manage_data_connections_description';
 
@@ -45,7 +44,6 @@ interface DataConnection {
   connectionType: DatasourceType;
   name: string;
   dsStatus: DatasourceStatus;
-  isConnectionWithLakeFormation: boolean;
 }
 
 export const ManageDataConnectionsTable = (props: HomeProps) => {
@@ -87,7 +85,6 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
               name,
               connectionType: connector,
               dsStatus: status,
-              isConnectionWithLakeFormation: checkIsConnectionWithLakeFormation(dataSourceDetails),
             };
           }
         );
@@ -142,7 +139,7 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
       onClick: (datasource: DataConnection) => {
         if (datasource.connectionType === 'PROMETHEUS') {
           application!.navigateToApp(observabilityMetricsID);
-        } else if (datasource.connectionType === 'S3GLUE') {
+        } else if (['S3GLUE', 'SECURITYLAKE'].includes(datasource.connectionType)) {
           redirectToExplorerS3(datasource.name);
         }
       },
@@ -155,7 +152,10 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
       type: 'icon',
       available: (datasource: DataConnection) => datasource.connectionType !== 'PROMETHEUS',
       onClick: (datasource: DataConnection) => {
-        renderCreateAccelerationFlyout({ dataSource: datasource.name });
+        renderCreateAccelerationFlyout({
+          dataSource: datasource.name,
+          dataSourceType: datasource.connectionType,
+        });
       },
       'data-test-subj': 'action-accelerate',
     },
@@ -171,7 +171,6 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
             closeFlyout={() => setShowIntegrationsFlyout(false)}
             datasourceType={datasource.connectionType}
             datasourceName={datasource.name}
-            isS3ConnectionWithLakeFormation={datasource.isConnectionWithLakeFormation}
           />
         );
         setShowIntegrationsFlyout(true);
@@ -192,8 +191,10 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
 
   const icon = (record: DataConnection) => {
     switch (record.connectionType) {
+      case 'SECURITYLAKE':
+        return <EuiIcon type={SecurityLakeLogo} />;
       case 'S3GLUE':
-        return <EuiIcon type={record.isConnectionWithLakeFormation ? SecurityLakeLogo : S3Logo} />;
+        return <EuiIcon type={S3Logo} />;
       case 'PROMETHEUS':
         return <EuiIcon type={PrometheusLogo} />;
       default:
@@ -228,9 +229,9 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
           case 'PROMETHEUS':
             return 'Prometheus';
           case 'S3GLUE':
-            return connection.isConnectionWithLakeFormation
-              ? 'Amazon Security Lake'
-              : 'Amazon S3 with AWS Glue Data Catalog';
+            return 'Amazon S3 with AWS Glue Data Catalog';
+          case 'SECURITYLAKE':
+            return 'Amazon Security Lake';
           default:
             return '-';
         }
@@ -261,17 +262,14 @@ export const ManageDataConnectionsTable = (props: HomeProps) => {
     },
   };
 
-  const entries = data.map(
-    ({ name, connectionType, dsStatus, isConnectionWithLakeFormation }: DataConnection) => {
-      return {
-        connectionType,
-        name,
-        dsStatus,
-        data: { name, connectionType },
-        isConnectionWithLakeFormation,
-      };
-    }
-  );
+  const entries = data.map(({ name, connectionType, dsStatus }: DataConnection) => {
+    return {
+      connectionType,
+      name,
+      dsStatus,
+      data: { name, connectionType },
+    };
+  });
 
   const renderCreateAccelerationFlyout = getRenderCreateAccelerationFlyout();
 

--- a/public/components/datasources/utils/helpers.ts
+++ b/public/components/datasources/utils/helpers.ts
@@ -3,12 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { S3GlueProperties } from 'common/types/data_connections';
-import { DatasourceDetails } from '../components/manage/data_connection';
+import { DatasourceType } from '../../../../common/types/data_connections';
 
-export function checkIsConnectionWithLakeFormation({
-  connector,
-  properties,
-}: DatasourceDetails): boolean {
-  return connector === 'S3GLUE' && !!(properties as S3GlueProperties)['glue.lakeformation.enabled'];
+export function isS3Connection(dataSourceType: DatasourceType): boolean {
+  return ['s3glue', 'securitylake'].includes(dataSourceType?.toLowerCase());
 }

--- a/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
+++ b/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
@@ -30,7 +30,7 @@ import {
   CachedDataSourceStatus,
   CachedDatabase,
   CachedTable,
-  ObjectLoaderDataSourceType,
+  DatasourceType,
 } from '../../../../../common/types/data_connections';
 import { isCatalogCacheFetching } from '../../../datasources/components/manage/associated_objects/utils/associated_objects_tab_utils';
 import { DirectQueryLoadingStatus } from '../../../../../common/types/explorer';
@@ -41,7 +41,7 @@ import { AssociatedObjectsTabEmpty } from '../../../datasources/components/manag
 
 export interface TablesFlyoutProps {
   dataSourceName: string;
-  dataSourceType: ObjectLoaderDataSourceType;
+  dataSourceType: DatasourceType;
   resetFlyout: () => void;
 }
 

--- a/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
+++ b/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
@@ -30,6 +30,7 @@ import {
   CachedDataSourceStatus,
   CachedDatabase,
   CachedTable,
+  ObjectLoaderDataSourceType,
 } from '../../../../../common/types/data_connections';
 import { isCatalogCacheFetching } from '../../../datasources/components/manage/associated_objects/utils/associated_objects_tab_utils';
 import { DirectQueryLoadingStatus } from '../../../../../common/types/explorer';
@@ -40,6 +41,7 @@ import { AssociatedObjectsTabEmpty } from '../../../datasources/components/manag
 
 export interface TablesFlyoutProps {
   dataSourceName: string;
+  dataSourceType: ObjectLoaderDataSourceType;
   resetFlyout: () => void;
 }
 
@@ -48,7 +50,11 @@ interface TableItemType {
   type: string;
 }
 
-export const TablesFlyout = ({ dataSourceName, resetFlyout }: TablesFlyoutProps) => {
+export const TablesFlyout = ({
+  dataSourceName,
+  dataSourceType,
+  resetFlyout,
+}: TablesFlyoutProps) => {
   const { setToast } = useToast();
   const {
     loadStatus: databasesLoadStatus,
@@ -140,7 +146,7 @@ export const TablesFlyout = ({ dataSourceName, resetFlyout }: TablesFlyoutProps)
           databaseCache.status === CachedDataSourceStatus.Failed) &&
         !isCatalogCacheFetching(tablesLoadStatus)
       ) {
-        startLoadingTables({ dataSourceName, databaseName: selectedDatabase });
+        startLoadingTables({ dataSourceName, databaseName: selectedDatabase, dataSourceType });
         setIsObjectsLoading(true);
       } else if (databaseCache.status === CachedDataSourceStatus.Updated) {
         setCachedTables(databaseCache.tables);

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -36,7 +36,7 @@ import React, {
   useState,
 } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
-import { checkIsConnectionWithLakeFormation } from 'public/components/datasources/utils/helpers';
+import { checkIsConnectionWithLakeFormation } from '../../datasources/utils/helpers';
 import { LogExplorerRouterContext } from '..';
 import {
   DEFAULT_DATA_SOURCE_TYPE,

--- a/public/components/event_analytics/explorer/no_results.tsx
+++ b/public/components/event_analytics/explorer/no_results.tsx
@@ -26,18 +26,15 @@ import { selectQueries } from '../redux/slices/query_slice';
 import { selectSearchMetaData } from '../redux/slices/search_meta_data_slice';
 import { DATA_SOURCE_TYPES, QUERY_LANGUAGE } from '../../../../common/constants/data_sources';
 import { CatalogCacheManager } from '../../../framework/catalog_cache/cache_manager';
-import {
-  CachedDataSourceStatus,
-  ObjectLoaderDataSourceType,
-} from '../../../../common/types/data_connections';
+import { CachedDataSourceStatus, DatasourceType } from '../../../../common/types/data_connections';
 import { getRenderLogExplorerTablesFlyout } from '../../../plugin';
 
 export interface NoResultsProps {
   tabId: string;
-  objectLoaderDataSourceType: ObjectLoaderDataSourceType;
+  dataSourceConnectionType: DatasourceType;
 }
 
-export const NoResults = ({ tabId, objectLoaderDataSourceType }: NoResultsProps) => {
+export const NoResults = ({ tabId, dataSourceConnectionType }: NoResultsProps) => {
   // get the queries isLoaded, if it exists AND is true = show no res
   const queryInfo = useSelector(selectQueries)[tabId];
   const summaryData = useSelector(selectQueryAssistantSummarization)[tabId];
@@ -107,7 +104,7 @@ export const NoResults = ({ tabId, objectLoaderDataSourceType }: NoResultsProps)
               To start exploring this datasource, enter a query or{' '}
               <EuiLink
                 onClick={() => {
-                  renderTablesFlyout(datasourceName, objectLoaderDataSourceType);
+                  renderTablesFlyout(datasourceName, dataSourceConnectionType);
                 }}
               >
                 view databases and tables.
@@ -135,7 +132,9 @@ export const NoResults = ({ tabId, objectLoaderDataSourceType }: NoResultsProps)
                     <p>Show a list of tables within a database</p>
                     <EuiSpacer size="s" />
                     <CreatedCodeBlock
-                      code={`SHOW TABLE EXTENDED IN ${datasourceName}.<database> LIKE '*'`}
+                      code={`SHOW ${
+                        dataSourceConnectionType === 'SECURITYLAKE' ? 'TABLES' : 'TABLE EXTENDED'
+                      } IN ${datasourceName}.<database> LIKE '*'`}
                     />
                   </EuiFlexItem>
                   <EuiFlexItem>

--- a/public/components/event_analytics/explorer/no_results.tsx
+++ b/public/components/event_analytics/explorer/no_results.tsx
@@ -26,10 +26,18 @@ import { selectQueries } from '../redux/slices/query_slice';
 import { selectSearchMetaData } from '../redux/slices/search_meta_data_slice';
 import { DATA_SOURCE_TYPES, QUERY_LANGUAGE } from '../../../../common/constants/data_sources';
 import { CatalogCacheManager } from '../../../framework/catalog_cache/cache_manager';
-import { CachedDataSourceStatus } from '../../../../common/types/data_connections';
+import {
+  CachedDataSourceStatus,
+  ObjectLoaderDataSourceType,
+} from '../../../../common/types/data_connections';
 import { getRenderLogExplorerTablesFlyout } from '../../../plugin';
 
-export const NoResults = ({ tabId }: any) => {
+export interface NoResultsProps {
+  tabId: string;
+  objectLoaderDataSourceType: ObjectLoaderDataSourceType;
+}
+
+export const NoResults = ({ tabId, objectLoaderDataSourceType }: NoResultsProps) => {
   // get the queries isLoaded, if it exists AND is true = show no res
   const queryInfo = useSelector(selectQueries)[tabId];
   const summaryData = useSelector(selectQueryAssistantSummarization)[tabId];
@@ -99,7 +107,7 @@ export const NoResults = ({ tabId }: any) => {
               To start exploring this datasource, enter a query or{' '}
               <EuiLink
                 onClick={() => {
-                  renderTablesFlyout(datasourceName);
+                  renderTablesFlyout(datasourceName, objectLoaderDataSourceType);
                 }}
               >
                 view databases and tables.

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration_inputs.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration_inputs.test.tsx.snap
@@ -203,37 +203,17 @@ exports[`Integration Setup Inputs Renders the S3 connector form as expected 1`] 
   </EuiFormRow>
   <EuiSpacer />
   <IntegrationWorkflowsInputs
-    integration={
-      Object {
-        "assets": Array [
-          Object {
-            "extension": "ndjson",
-            "name": "sample",
-            "type": "savedObjectBundle",
-            "version": "1.0.1",
-          },
-        ],
-        "components": Array [
-          Object {
-            "name": "logs",
-            "version": "1.0.0",
-          },
-        ],
-        "license": "Apache-2.0",
-        "name": "sample",
-        "type": "logs",
-        "version": "2.0.0",
-        "workflows": Array [
-          Object {
-            "description": "This is a test workflow.",
-            "enabled_by_default": true,
-            "label": "Workflow 1",
-            "name": "workflow1",
-          },
-        ],
-      }
-    }
     updateConfig={[Function]}
+    workflows={
+      Array [
+        Object {
+          "description": "This is a test workflow.",
+          "enabled_by_default": true,
+          "label": "Workflow 1",
+          "name": "workflow1",
+        },
+      ]
+    }
   />
   <EuiSpacer />
   <EuiSpacer />
@@ -443,37 +423,17 @@ exports[`Integration Setup Inputs Renders the S3 connector form without workflow
   </EuiFormRow>
   <EuiSpacer />
   <IntegrationWorkflowsInputs
-    integration={
-      Object {
-        "assets": Array [
-          Object {
-            "extension": "ndjson",
-            "name": "sample",
-            "type": "savedObjectBundle",
-            "version": "1.0.1",
-          },
-        ],
-        "components": Array [
-          Object {
-            "name": "logs",
-            "version": "1.0.0",
-          },
-        ],
-        "license": "Apache-2.0",
-        "name": "sample",
-        "type": "logs",
-        "version": "2.0.0",
-        "workflows": Array [
-          Object {
-            "description": "This is a test workflow.",
-            "enabled_by_default": true,
-            "label": "Workflow 1",
-            "name": "workflow1",
-          },
-        ],
-      }
-    }
     updateConfig={[Function]}
+    workflows={
+      Array [
+        Object {
+          "description": "This is a test workflow.",
+          "enabled_by_default": true,
+          "label": "Workflow 1",
+          "name": "workflow1",
+        },
+      ]
+    }
   />
   <EuiSpacer />
   <EuiSpacer />
@@ -2208,7 +2168,7 @@ exports[`Integration Setup Inputs Renders the workflows inputs 1`] = `
     fullWidth={false}
     hasChildLabel={true}
     hasEmptyLabelSpace={false}
-    isInvalid={false}
+    isInvalid={true}
     labelType="label"
   >
     <div
@@ -2219,161 +2179,26 @@ exports[`Integration Setup Inputs Renders the workflows inputs 1`] = `
         className="euiFormRow__fieldWrapper"
       >
         <SetupWorkflowSelector
+          aria-describedby="random_html_id-error-0"
           id="random_html_id"
-          integration={
-            Object {
-              "assets": Array [
-                Object {
-                  "extension": "ndjson",
-                  "name": "sample",
-                  "type": "savedObjectBundle",
-                  "version": "1.0.1",
-                },
-              ],
-              "components": Array [
-                Object {
-                  "name": "logs",
-                  "version": "1.0.0",
-                },
-              ],
-              "license": "Apache-2.0",
-              "name": "sample",
-              "type": "logs",
-              "version": "2.0.0",
-              "workflows": Array [
-                Object {
-                  "description": "This is a test workflow.",
-                  "enabled_by_default": true,
-                  "label": "Workflow 1",
-                  "name": "workflow1",
-                },
-              ],
-            }
-          }
           onBlur={[Function]}
           onFocus={[Function]}
           toggleWorkflow={[Function]}
-          useWorkflows={
-            Array [
-              Array [
-                "workflow1",
-                true,
-              ],
-            ]
-          }
+          useWorkflows={Array []}
+        />
+        <EuiFormErrorText
+          className="euiFormRow__text"
+          id="random_html_id-error-0"
+          key="Must select at least one workflow."
         >
-          <EuiCheckableCard
-            checkableType="checkbox"
-            checked={true}
-            id="workflow-checkbox-workflow1"
-            key="workflow1"
-            label="Workflow 1"
-            onChange={[Function]}
-            value="workflow1"
+          <div
+            aria-live="polite"
+            className="euiFormErrorText euiFormRow__text"
+            id="random_html_id-error-0"
           >
-            <_EuiSplitPanelOuter
-              className="euiCheckableCard euiCheckableCard-isChecked"
-              direction="row"
-              hasBorder={true}
-              responsive={false}
-            >
-              <EuiPanel
-                className="euiSplitPanel euiSplitPanel--row euiCheckableCard euiCheckableCard-isChecked"
-                grow={false}
-                hasBorder={true}
-                paddingSize="none"
-              >
-                <div
-                  className="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--hasBorder euiPanel--flexGrowZero euiSplitPanel euiSplitPanel--row euiCheckableCard euiCheckableCard-isChecked"
-                >
-                  <_EuiSplitPanelInner
-                    color="primary"
-                    grow={false}
-                    onClick={[Function]}
-                  >
-                    <EuiPanel
-                      borderRadius="none"
-                      className="euiSplitPanel__inner"
-                      color="primary"
-                      element="div"
-                      grow={false}
-                      hasBorder={false}
-                      hasShadow={false}
-                      onClick={[Function]}
-                    >
-                      <div
-                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--primary euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiPanel--isClickable euiSplitPanel__inner"
-                        onClick={[Function]}
-                      >
-                        <EuiCheckbox
-                          checked={true}
-                          compressed={false}
-                          disabled={false}
-                          id="workflow-checkbox-workflow1"
-                          indeterminate={false}
-                          onChange={[Function]}
-                          value="workflow1"
-                        >
-                          <div
-                            className="euiCheckbox euiCheckbox--noLabel"
-                          >
-                            <input
-                              checked={true}
-                              className="euiCheckbox__input"
-                              disabled={false}
-                              id="workflow-checkbox-workflow1"
-                              onChange={[Function]}
-                              type="checkbox"
-                              value="workflow1"
-                            />
-                            <div
-                              className="euiCheckbox__square"
-                            />
-                          </div>
-                        </EuiCheckbox>
-                      </div>
-                    </EuiPanel>
-                  </_EuiSplitPanelInner>
-                  <_EuiSplitPanelInner>
-                    <EuiPanel
-                      borderRadius="none"
-                      className="euiSplitPanel__inner"
-                      color="transparent"
-                      element="div"
-                      hasBorder={false}
-                      hasShadow={false}
-                    >
-                      <div
-                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiSplitPanel__inner"
-                      >
-                        <label
-                          aria-describedby="workflow-checkbox-workflow1-details"
-                          className="euiCheckableCard__label"
-                          htmlFor="workflow-checkbox-workflow1"
-                        >
-                          Workflow 1
-                        </label>
-                        <div
-                          className="euiCheckableCard__children"
-                          id="workflow-checkbox-workflow1-details"
-                        >
-                          This is a test workflow.
-                        </div>
-                      </div>
-                    </EuiPanel>
-                  </_EuiSplitPanelInner>
-                </div>
-              </EuiPanel>
-            </_EuiSplitPanelOuter>
-          </EuiCheckableCard>
-          <EuiSpacer
-            size="s"
-          >
-            <div
-              className="euiSpacer euiSpacer--s"
-            />
-          </EuiSpacer>
-        </SetupWorkflowSelector>
+            Must select at least one workflow.
+          </div>
+        </EuiFormErrorText>
       </div>
     </div>
   </EuiFormRow>

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -25,10 +25,11 @@ import { addIntegrationRequest } from './create_integration_helpers';
 import { SetupIntegrationFormInputs } from './setup_integration_inputs';
 import { CONSOLE_PROXY, INTEGRATIONS_BASE } from '../../../../common/constants/shared';
 import { SetupIntegrationInputsForSecurityLake } from './setup_integration_inputs_security_lake';
+import { IntegrationConnectionType } from '../../../../common/types/integrations';
 
 export interface IntegrationSetupInputs {
   displayName: string;
-  connectionType: string;
+  connectionType: IntegrationConnectionType;
   connectionDataSource: string;
   connectionLocation: string;
   checkpointLocation: string;
@@ -335,10 +336,7 @@ export function SetupIntegrationForm({
   unsetIntegration?: () => void;
   forceConnection?: {
     name: string;
-    type: string;
-    properties?: {
-      lakeFormationEnabled?: boolean;
-    };
+    type: IntegrationConnectionType;
   };
   setIsInstalling?: (isInstalling: boolean, success?: boolean) => void;
 }) {
@@ -376,9 +374,10 @@ export function SetupIntegrationForm({
   const updateConfig = (updates: Partial<IntegrationSetupInputs>) =>
     setConfig(Object.assign({}, integConfig, updates));
 
-  const IntegrationInputFormComponent = forceConnection?.properties?.lakeFormationEnabled
-    ? SetupIntegrationInputsForSecurityLake
-    : SetupIntegrationFormInputs;
+  const IntegrationInputFormComponent =
+    forceConnection?.type === 'securityLake' || integConfig.connectionType === 'securityLake'
+      ? SetupIntegrationInputsForSecurityLake
+      : SetupIntegrationFormInputs;
 
   const content = (
     <>

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -216,7 +216,12 @@ export function IntegrationConnectionInputs({
       >
         <EuiSelect
           options={integrationConnectionSelectorItems.filter((item) => {
-            if (item.value === 's3' || item.value === 'securityLake') {
+            if (item.value === 'securityLake') {
+              return (
+                integration.assets.some((asset) => asset.type === 'query') &&
+                integration.workflows?.some((workflow) => workflow.name.includes('security-lake'))
+              );
+            } else if (item.value === 's3') {
               return integration.assets.some((asset) => asset.type === 'query');
             } else if (item.value === 'index') {
               return integration.assets.some((asset) => asset.type === 'savedObjectBundle');

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -20,7 +20,6 @@ import { coreRefs } from '../../../framework/core_refs';
 import { CONSOLE_PROXY, DATACONNECTIONS_BASE } from '../../../../common/constants/shared';
 import { IntegrationConfigProps, IntegrationSetupInputs } from './setup_integration';
 import { IntegrationConnectionType } from '../../../../common/types/integrations';
-import { checkIsConnectionWithLakeFormation } from '../../datasources/utils/helpers';
 
 // TODO support localization
 const INTEGRATION_CONNECTION_DATA_SOURCE_TYPES: Map<
@@ -101,7 +100,7 @@ const suggestDataSources = async (
       const filterCondition =
         type === 's3'
           ? (item: any) => item.connector === 'S3GLUE'
-          : (item: any) => checkIsConnectionWithLakeFormation(item);
+          : (item: any) => item.connector === 'SECURITYLAKE';
 
       return (
         result?.filter(filterCondition).map((item) => {
@@ -274,19 +273,17 @@ export function IntegrationQueryInputs({
   config,
   updateConfig,
   integration,
-  isS3ConnectionWithLakeFormation,
 }: {
   config: IntegrationSetupInputs;
   updateConfig: (updates: Partial<IntegrationSetupInputs>) => void;
   integration: IntegrationConfig;
-  isS3ConnectionWithLakeFormation?: boolean;
 }) {
   const [isBucketBlurred, setIsBucketBlurred] = useState(false);
   const [isCheckpointBlurred, setIsCheckpointBlurred] = useState(false);
 
   return (
     <>
-      {!isS3ConnectionWithLakeFormation && (
+      {config.connectionType !== 'securityLake' && (
         <>
           <EuiFormRow
             label="Spark Table Name"
@@ -323,7 +320,7 @@ export function IntegrationQueryInputs({
       <EuiFormRow
         label={`S3 Checkpoint Location`}
         helpText={
-          isS3ConnectionWithLakeFormation
+          config.connectionType === 'securityLake'
             ? 'The checkpoint location for caching intermediary results.'
             : 'The Checkpoint location must be a unique directory and not the same as the Data ' +
               'location. It will be used for caching intermediary results.'

--- a/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
+++ b/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
@@ -110,7 +110,7 @@ export const SetupIntegrationInputsForSecurityLake = ({
           setDataSourceFormData,
         }}
         selectedDatasource={config.connectionDataSource}
-        selectedDataSourceType="SecurityLake"
+        selectedDataSourceType="SECURITYLAKE"
         dataSourcesPreselected={false}
         tableFieldsLoading={false}
         hideHeader={true}
@@ -123,7 +123,6 @@ export const SetupIntegrationInputsForSecurityLake = ({
         config={config}
         updateConfig={updateConfig}
         integration={integration}
-        isS3ConnectionWithLakeFormation={true}
       />
       {securityLakeWorkflows && (
         <>

--- a/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
+++ b/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
@@ -80,6 +80,7 @@ export const SetupIntegrationInputsForSecurityLake = ({
               setDataSourceFormData,
             }}
             selectedDatasource={config.connectionDataSource}
+            selectedDataSourceType="SecurityLake"
             dataSourcesPreselected={false}
             tableFieldsLoading={false}
             hideHeader={true}

--- a/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
+++ b/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector';
 import { IntegrationConfigProps } from './setup_integration';
 import {
+  IntegrationConnectionInputs,
   IntegrationDetailsInputs,
   IntegrationQueryInputs,
   IntegrationWorkflowsInputs,
@@ -29,6 +30,7 @@ export const SetupIntegrationInputsForSecurityLake = ({
   updateConfig,
   integration,
   setupCallout,
+  lockConnectionType,
 }: IntegrationConfigProps) => {
   const http = coreRefs.http!;
   const [dataSourceFormData, setDataSourceFormData] = useState<BaseDataSourceForm>({
@@ -38,12 +40,30 @@ export const SetupIntegrationInputsForSecurityLake = ({
     formErrors: {},
   });
 
+  const [securityLakeWorkflows, setSecurityLakeWorkflows] = useState<
+    IntegrationWorkflow[] | undefined
+  >(undefined);
+
   useEffect(() => {
     updateConfig({
       connectionDatabaseName: dataSourceFormData.database,
       connectionTableName: dataSourceFormData.dataTable,
     });
   }, [dataSourceFormData]);
+
+  useEffect(() => {
+    setDataSourceFormData({
+      ...dataSourceFormData,
+      dataSource: config.connectionDataSource,
+    });
+  }, [config.connectionDataSource]);
+
+  useEffect(() => {
+    // TODO: Refactor the filter condition to use `applicable_data_sources` #1855
+    setSecurityLakeWorkflows(
+      integration.workflows?.filter((workflow) => workflow.name.includes('security-lake'))
+    );
+  }, integration.workflows);
 
   return (
     <>
@@ -65,59 +85,71 @@ export const SetupIntegrationInputsForSecurityLake = ({
         integration={integration}
       />
       <EuiSpacer />
-      {config.connectionType === 's3' ? (
+      <EuiText>
+        <h3>Integration data location</h3>
+      </EuiText>
+
+      {!lockConnectionType && (
         <>
-          <EuiText>
-            <h3>Integration data location</h3>
-          </EuiText>
-          <EuiSpacer size="s" />
-
-          <DataSourceSelector
-            http={http!}
-            dataSourceFormProps={{
-              formType: 'SetupIntegration',
-              dataSourceFormData,
-              setDataSourceFormData,
-            }}
-            selectedDatasource={config.connectionDataSource}
-            selectedDataSourceType="SecurityLake"
-            dataSourcesPreselected={false}
-            tableFieldsLoading={false}
-            hideHeader={true}
-          />
-
-          <EuiSpacer size="m" />
-
-          <IntegrationQueryInputs
+          <EuiSpacer />
+          <IntegrationConnectionInputs
             config={config}
             updateConfig={updateConfig}
             integration={integration}
-            isS3ConnectionWithLakeFormation={true}
+            lockConnectionType={lockConnectionType}
           />
-          {integration.workflows ? (
-            <>
-              <EuiSpacer />
-              <EuiText>
-                <h3>Included resources</h3>
-              </EuiText>
-              <EuiFormRow>
-                <EuiText grow={false} size="xs">
-                  <p>
-                    This integration offers resources compatible with your data source. These can
-                    include dashboards, visualizations, indexes, and queries. Select at least one of
-                    the following options.
-                  </p>
-                </EuiText>
-              </EuiFormRow>
-              <EuiSpacer />
-              <IntegrationWorkflowsInputs updateConfig={updateConfig} integration={integration} />
-            </>
-          ) : null}
-          {/* Bottom bar will overlap content if there isn't some space at the end */}
-          <EuiSpacer />
-          <EuiSpacer />
         </>
-      ) : null}
+      )}
+
+      <EuiSpacer size="s" />
+      <DataSourceSelector
+        http={http!}
+        dataSourceFormProps={{
+          formType: 'SetupIntegration',
+          dataSourceFormData,
+          setDataSourceFormData,
+        }}
+        selectedDatasource={config.connectionDataSource}
+        selectedDataSourceType="SecurityLake"
+        dataSourcesPreselected={false}
+        tableFieldsLoading={false}
+        hideHeader={true}
+        hideDataSourceDescription={!lockConnectionType}
+      />
+
+      <EuiSpacer size="m" />
+
+      <IntegrationQueryInputs
+        config={config}
+        updateConfig={updateConfig}
+        integration={integration}
+        isS3ConnectionWithLakeFormation={true}
+      />
+      {securityLakeWorkflows && (
+        <>
+          <EuiSpacer />
+          <EuiText>
+            <h3>Included resources</h3>
+          </EuiText>
+          <EuiFormRow>
+            <EuiText grow={false} size="xs">
+              <p>
+                This integration offers resources compatible with your data source. These can
+                include dashboards, visualizations, indexes, and queries. Select at least one of the
+                following options.
+              </p>
+            </EuiText>
+          </EuiFormRow>
+          <EuiSpacer />
+          <IntegrationWorkflowsInputs
+            updateConfig={updateConfig}
+            workflows={securityLakeWorkflows}
+          />
+        </>
+      )}
+      {/* Bottom bar will overlap content if there isn't some space at the end */}
+      <EuiSpacer />
+      <EuiSpacer />
     </>
   );
 };

--- a/public/framework/catalog_cache/cache_loader.tsx
+++ b/public/framework/catalog_cache/cache_loader.tsx
@@ -16,6 +16,7 @@ import {
   CachedDataSourceStatus,
   CachedTable,
   LoadCacheType,
+  ObjectLoaderDataSourceType,
   StartLoadingParams,
 } from '../../../common/types/data_connections';
 import { DirectQueryLoadingStatus, DirectQueryRequest } from '../../../common/types/explorer';
@@ -255,7 +256,8 @@ export const createLoadQuery = (
   loadCacheType: LoadCacheType,
   dataSourceName: string,
   databaseName?: string,
-  tableName?: string
+  tableName?: string,
+  dataSourceType?: ObjectLoaderDataSourceType
 ) => {
   let query;
   switch (loadCacheType) {
@@ -263,7 +265,9 @@ export const createLoadQuery = (
       query = `SHOW SCHEMAS IN ${addBackticksIfNeeded(dataSourceName)}`;
       break;
     case 'tables':
-      query = `SHOW TABLE EXTENDED IN ${addBackticksIfNeeded(
+      const showTableQueryBase =
+        dataSourceType === 'SecurityLake' ? 'SHOW TABLE' : 'SHOW TABLE EXTENDED';
+      query = `${showTableQueryBase} IN ${addBackticksIfNeeded(
         dataSourceName
       )}.${addBackticksIfNeeded(databaseName!)} LIKE '*'`;
       break;
@@ -316,6 +320,7 @@ export const useLoadToCache = (loadCacheType: LoadCacheType) => {
 
   const startLoading = ({
     dataSourceName,
+    dataSourceType,
     dataSourceMDSId,
     databaseName,
     tableName,
@@ -328,7 +333,13 @@ export const useLoadToCache = (loadCacheType: LoadCacheType) => {
 
     let requestPayload: DirectQueryRequest = {
       lang: 'sql',
-      query: createLoadQuery(loadCacheType, dataSourceName, databaseName, tableName),
+      query: createLoadQuery(
+        loadCacheType,
+        dataSourceName,
+        databaseName,
+        tableName,
+        dataSourceType
+      ),
       datasource: dataSourceName,
     };
 

--- a/public/framework/catalog_cache/cache_loader.tsx
+++ b/public/framework/catalog_cache/cache_loader.tsx
@@ -11,12 +11,12 @@ import {
 } from '../../../common/constants/data_sources';
 import {
   AsyncPollingResult,
-  CachedAccelerations,
+  CachedAcceleration,
   CachedColumn,
   CachedDataSourceStatus,
   CachedTable,
+  DatasourceType,
   LoadCacheType,
-  ObjectLoaderDataSourceType,
   StartLoadingParams,
 } from '../../../common/types/data_connections';
 import { DirectQueryLoadingStatus, DirectQueryRequest } from '../../../common/types/explorer';
@@ -147,7 +147,7 @@ export const updateAccelerationsToCache = (
 
   const combinedData = combineSchemaAndDatarows(pollingResult.schema, pollingResult.datarows);
 
-  const newAccelerations: CachedAccelerations[] = combinedData.map((row: any) => ({
+  const newAccelerations: CachedAcceleration[] = combinedData.map((row: any) => ({
     flintIndexName: row.flint_index_name,
     type: row.kind === 'mv' ? 'materialized' : row.kind,
     database: row.database,
@@ -257,7 +257,7 @@ export const createLoadQuery = (
   dataSourceName: string,
   databaseName?: string,
   tableName?: string,
-  dataSourceType?: ObjectLoaderDataSourceType
+  dataSourceType?: DatasourceType
 ) => {
   let query;
   switch (loadCacheType) {
@@ -266,7 +266,7 @@ export const createLoadQuery = (
       break;
     case 'tables':
       const showTableQueryBase =
-        dataSourceType === 'SecurityLake' ? 'SHOW TABLE' : 'SHOW TABLE EXTENDED';
+        dataSourceType?.toLowerCase() === 'securitylake' ? 'SHOW TABLES' : 'SHOW TABLE EXTENDED';
       query = `${showTableQueryBase} IN ${addBackticksIfNeeded(
         dataSourceName
       )}.${addBackticksIfNeeded(databaseName!)} LIKE '*'`;

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -57,6 +57,7 @@ import {
 } from '../common/constants/shared';
 import { QueryManager } from '../common/query_manager';
 import {
+  ObjectLoaderDataSourceType,
   RenderAccelerationDetailsFlyoutParams,
   RenderAccelerationFlyoutParams,
   RenderAssociatedObjectsDetailsFlyoutParams,
@@ -157,7 +158,9 @@ export const [
 export const [
   getRenderLogExplorerTablesFlyout,
   setRenderLogExplorerTablesFlyout,
-] = createGetterSetter<(dataSourceName: string) => void>('renderLogExplorerTablesFlyout');
+] = createGetterSetter<
+  (dataSourceName: string, dataSourceType: ObjectLoaderDataSourceType) => void
+>('renderLogExplorerTablesFlyout');
 
 export class ObservabilityPlugin
   implements
@@ -547,11 +550,15 @@ export class ObservabilityPlugin
     };
     setRenderCreateAccelerationFlyout(renderCreateAccelerationFlyout);
 
-    const renderLogExplorerTablesFlyout = (dataSourceName: string) => {
+    const renderLogExplorerTablesFlyout = (
+      dataSourceName: string,
+      dataSourceType: ObjectLoaderDataSourceType
+    ) => {
       const createLogExplorerTablesFlyout = core.overlays.openFlyout(
         toMountPoint(
           <TablesFlyout
             dataSourceName={dataSourceName}
+            dataSourceType={dataSourceType}
             resetFlyout={() => createLogExplorerTablesFlyout.close()}
           />
         )

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -57,7 +57,7 @@ import {
 } from '../common/constants/shared';
 import { QueryManager } from '../common/query_manager';
 import {
-  ObjectLoaderDataSourceType,
+  DatasourceType,
   RenderAccelerationDetailsFlyoutParams,
   RenderAccelerationFlyoutParams,
   RenderAssociatedObjectsDetailsFlyoutParams,
@@ -148,6 +148,7 @@ export const [
 ] = createGetterSetter<
   ({
     dataSource,
+    dataSourceType,
     dataSourceMDSId,
     databaseName,
     tableName,
@@ -158,9 +159,9 @@ export const [
 export const [
   getRenderLogExplorerTablesFlyout,
   setRenderLogExplorerTablesFlyout,
-] = createGetterSetter<
-  (dataSourceName: string, dataSourceType: ObjectLoaderDataSourceType) => void
->('renderLogExplorerTablesFlyout');
+] = createGetterSetter<(dataSourceName: string, dataSourceType: DatasourceType) => void>(
+  'renderLogExplorerTablesFlyout'
+);
 
 export class ObservabilityPlugin
   implements
@@ -511,7 +512,7 @@ export class ObservabilityPlugin
       dataSourceName,
       handleRefresh,
       dataSourceMDSId,
-      isS3ConnectionWithLakeFormation,
+      dataSourceType,
     }: RenderAssociatedObjectsDetailsFlyoutParams) => {
       const associatedObjectsDetailsFlyout = core.overlays.openFlyout(
         toMountPoint(
@@ -521,7 +522,7 @@ export class ObservabilityPlugin
             resetFlyout={() => associatedObjectsDetailsFlyout.close()}
             handleRefresh={handleRefresh}
             dataSourceMDSId={dataSourceMDSId}
-            isS3ConnectionWithLakeFormation={isS3ConnectionWithLakeFormation}
+            dataSourceType={dataSourceType}
           />
         )
       );
@@ -530,6 +531,7 @@ export class ObservabilityPlugin
 
     const renderCreateAccelerationFlyout = ({
       dataSource,
+      dataSourceType,
       databaseName,
       tableName,
       handleRefresh,
@@ -539,6 +541,7 @@ export class ObservabilityPlugin
         toMountPoint(
           <CreateAcceleration
             selectedDatasource={dataSource}
+            selectedDatasourceType={dataSourceType}
             resetFlyout={() => createAccelerationFlyout.close()}
             databaseName={databaseName}
             tableName={tableName}
@@ -552,7 +555,7 @@ export class ObservabilityPlugin
 
     const renderLogExplorerTablesFlyout = (
       dataSourceName: string,
-      dataSourceType: ObjectLoaderDataSourceType
+      dataSourceType: DatasourceType
     ) => {
       const createLogExplorerTablesFlyout = core.overlays.openFlyout(
         toMountPoint(


### PR DESCRIPTION
### Description
This PR 
- Updates the query used for fetching table for security lake since `EXTENDED` keyword is not supported
- Add a new connection `Security Lake` type for integrations that have at least one workflow for security lake data sources.
- Filters integrations based on the data source

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
