### PR TITLE
Fix dead links

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration_request.md
+++ b/.github/ISSUE_TEMPLATE/integration_request.md
@@ -16,7 +16,7 @@ Describe the integration resource log protocol you are interesting in [ [`access
 
 **What is the integration target protocol ?**
 
-Describe the target protocol you are interested to ingest [ for example [`logs.mapping`](https://github.com/opensearch-project/opensearch-catalog/blob/main/schema/observability/logs/logs.mapping) , [`http.mapping`](https://github.com/opensearch-project/opensearch-catalog/blob/main/schema/observability/logs/http.mapping) ]
+Describe the target protocol you are interested to ingest [ for example [`logs.mapping`](https://github.com/opensearch-project/opensearch-catalog/blob/c40d1e87199528d3853c0c3fa308524c76ac6c2c/schema/observability/logs/logs-1.0.0.mapping) , [`http.mapping`](https://github.com/opensearch-project/opensearch-catalog/blob/c40d1e87199528d3853c0c3fa308524c76ac6c2c/schema/observability/logs/http-1.0.0.mapping) ]
 
 **Which agents would you use to ship this data ?**
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,3 @@
 opensearch-dashboards
 kubernetes.default.svc.cluster.local
-observability.playground.opensearch.org/auth.*
+observability.playground.opensearch.org

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,3 @@
 opensearch-dashboards
 kubernetes.default.svc.cluster.local
+observability.playground.opensearch.org/auth.*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+opensearch-dashboards
+kubernetes.default.svc.cluster.local

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Observability is collection of plugins and applications that let you visualize d
 [cypress-test-badge]: https://img.shields.io/badge/Cypress%20tests-in%20progress-yellow
 [cypress-test-link]: https://github.com/opensearch-project/opensearch-build/issues/1124
 [cypress-code-badge]: https://img.shields.io/badge/Cypress%20code-blue
-[cypress-code-link]: https://github.com/opensearch-project/dashboards-observability/blob/main/dashboards-observability/.cypress/CYPRESS_TESTS.md
+[cypress-code-link]: https://github.com/opensearch-project/dashboards-observability/blob/main/.cypress/CYPRESS_TESTS.md
 [opensearch-it-badge]: https://img.shields.io/badge/OpenSearch%20Plugin%20IT%20tests-in%20progress-yellow
 [opensearch-it-link]: https://github.com/opensearch-project/opensearch-build/issues/1124
 [opensearch-it-code-badge]: https://img.shields.io/badge/OpenSearch%20IT%20code-blue

--- a/public/components/notebooks/docs/dev/Build_Documentation.md
+++ b/public/components/notebooks/docs/dev/Build_Documentation.md
@@ -2,7 +2,7 @@
 
 ## Setup OpenSearch & OpenSearch Dashboards dev environment and use the plugin with Zeppelin
 
-- Please follow [README.md](../../../../../../DEVELOPER_GUIDE.md) for build instructions.
+- Please follow [README.md](../../../../../DEVELOPER_GUIDE.md) for build instructions.
 
 - Start OpenSearch Dashboards
 

--- a/public/components/notebooks/docs/dev/Build_Documentation.md
+++ b/public/components/notebooks/docs/dev/Build_Documentation.md
@@ -4,10 +4,6 @@
 
 - Please follow [README.md](../../../../../../DEVELOPER_GUIDE.md) for build instructions.
 
-- **[Optional] If using Zeppelin Backend Adaptor:**
-  - Setup Zeppelin as mentioned in [Apache Zeppelin Setup: Zeppelin Backend Adaptor](./Zeppelin_backend_adaptor.md#apache-zeppelin-setup)
-  - Edit [this line](https://github.com/opensearch-project/dashboards-notebooks/blob/dev/common/index.ts#L19) to `SELECTED_BACKEND = 'ZEPPELIN';`
-  - Edit [this line](https://github.com/opensearch-project/dashboards-notebooks/blob/dev/common/index.ts#L21) for adding Zeppelin endpoint `zeppelinURL = 'http://localhost:8080';`
 - Start OpenSearch Dashboards
 
 - More on [Usage of Plugin](./Usage_Documentation.md)

--- a/public/components/notebooks/docs/dev/OpenSearch-Dashboards-Notebooks-Design-Proposal.md
+++ b/public/components/notebooks/docs/dev/OpenSearch-Dashboards-Notebooks-Design-Proposal.md
@@ -138,7 +138,7 @@ OpenSearch Dashboards Notebooks enable data-driven, interactive data analytics a
   - Zeppelin Backend will provide one stop shop for interpreters, runtime-environments and storage adaptors
 - Cons:
   - Users will not be free to customize Zeppelin Backend runtime-environment/storage adaptors
-  - Need to develop a new storage adaptor for Zeppelin to store notebooks as OpenSearch indices [POC details](../poc/docs/Zeppelin_OpenSearch_Storage.md)
+  - Need to develop a new storage adaptor for Zeppelin to store notebooks as OpenSearch indices
   - Difficult to maintain releases, as we have to sync version currency/patches to Zeppelin code repository
 
 **4.4.2 Version 2:** In this architecture, Backends are switchable with two options of Default backend (Markdown, Visualization support) or Apache Zeppelin Backend (25+ interpreter support)

--- a/public/components/notebooks/docs/dev/OpenSearch-Dashboards-Notebooks-Design-Proposal.md
+++ b/public/components/notebooks/docs/dev/OpenSearch-Dashboards-Notebooks-Design-Proposal.md
@@ -200,7 +200,6 @@ OpenSearch Dashboards Notebooks enable data-driven, interactive data analytics a
    3. Once a backend service is connected all the interpreters, environments and data sources provided by the service are automatically extended in notebooks
    4. Uses [Hapi Wreck](https://hapi.dev/module/wreck/) to connect a backend service with a HTTP endpoint
    5. Example Adaptor: **Zeppelin Backend Server**
-      ![Zeppelin Server](images/zeppelin_architecture.png)
       - Open source, provided by [Apache Zeppelin](http://zeppelin.apache.org/)
       - Provides all communication to and from a notebook & supports 25+ interpreters
       - Connects via a HTTP endpoint to the Plugin backend
@@ -242,9 +241,7 @@ OpenSearch Dashboards Notebooks enable data-driven, interactive data analytics a
 
 ### **7.1** POC: [Embeddable API & Usage](../poc/docs/OpenSearch Dashboards_Embeddable_Documentation.md)
 
-### **7.2** POC: [Zeppelin OpenSearch Storage](../poc/docs/Zeppelin_OpenSearch_Storage.md)
-
-### **7.3** Screenshots:
+### **7.2** Screenshots:
 
 - **Default Backend**
 
@@ -273,6 +270,4 @@ OpenSearch Dashboards Notebooks enable data-driven, interactive data analytics a
 
 ## 8. References
 
-### **8.1** [More Zeppelin and Backend Adaptor](Zeppelin_backend_adaptor.md)
-
-### **8.2** [Nteract.io](https://nteract.io/) React components: [components.nteract.io](https://components.nteract.io/)
+### **8.1** [Nteract.io](https://nteract.io/) React components: [components.nteract.io](https://components.nteract.io/)

--- a/public/components/notebooks/docs/dev/Usage_Documentation.md
+++ b/public/components/notebooks/docs/dev/Usage_Documentation.md
@@ -36,5 +36,5 @@ NOTE: Please select a paragraph before using these buttons
 
 ## Import Example Notebooks
 
-- Import sample notebooks from [example_notebooks folder](https://github.com/opensearch-project/dashboards-notebooks/tree/dev) based on your backend
+- Import sample notebooks from [example_notebooks folder](https://github.com/opensearch-project/dashboards-observability/tree/1944d0b7de350de01b31c894868ab05165ad25bc/public/components/notebooks/docs/example_notebooks) based on your backend
 - A notebook from one backend is incompatible to the other

--- a/server/adaptors/integrations/__data__/repository/amazon_elb/info/INGESTION.md
+++ b/server/adaptors/integrations/__data__/repository/amazon_elb/info/INGESTION.md
@@ -10,7 +10,7 @@ This is a brief overview of a sample ingestion pipeline for the AWS ELB integrat
 
 ### OpenSearch and FluentBit Setup
 
-1. Look at [docker-compose.yaml](<[docker-compose.yaml](https://github.com/opensearch-project/data-prepper/blob/93d06db5cad280e2e4c53e12dfb47c7cbaa7b364/examples/log-ingestion/docker-compose.yaml)https://github.com/opensearch-project/data-prepper/blob/93d06db5cad280e2e4c53e12dfb47c7cbaa7b364/examples/log-ingestion/docker-compose.yaml>) to create FluentBit and OpenSearch Docker images and run them in the `opensearch-net` Docker network.
+1. Look at [docker-compose.yaml](https://github.com/opensearch-project/data-prepper/blob/d2aa114f538da2f05d887b9c1ad4b77486267776/examples/log-ingestion/docker-compose.yaml) to create FluentBit and OpenSearch Docker images and run them in the `opensearch-net` Docker network.
 2. Create the FluentBit as follows:
 
 ```

--- a/server/adaptors/integrations/__data__/repository/amazon_elb/info/README.md
+++ b/server/adaptors/integrations/__data__/repository/amazon_elb/info/README.md
@@ -28,4 +28,4 @@ AWS ELB access logs integration includes dashboards, visualisations, queries and
 
 ### Dashboard
 
-<img width="1267" alt="dashboard1" src="https://github.com/danieldong51/dashboards-observability/assets/58446449/aaae3758-80c8-410e-b542-6ad78284425e">
+![ELB Dashboard](../static/dashboard1.png)

--- a/server/adaptors/integrations/__data__/repository/amazon_rds/assets/README.md
+++ b/server/adaptors/integrations/__data__/repository/amazon_rds/assets/README.md
@@ -1,6 +1,6 @@
 # AWS RDS Integration Assets
 
-API: http://osd:5601/api/saved_objects/_import?overwrite=true
+API: http://opensearch-dashboards:5601/api/saved_objects/_import?overwrite=true
 
 - [Assets](aws_rds-1.0.0.ndjson)
 

--- a/server/adaptors/integrations/__data__/repository/amazon_rds/info/README.md
+++ b/server/adaptors/integrations/__data__/repository/amazon_rds/info/README.md
@@ -24,6 +24,6 @@ AWS RDS integration includes dashboards, visualizations, queries, and index mapp
 
 The Dashboard uses the index alias `logs-aws-rds` for shortening the index name - be advised.
 
-![](../static/dashboard_rds1.png)
+![](../static/dashboard.png)
 
 This integration provides you with a comprehensive view of your RDS instances, enabling you to monitor performance and resources effectively, troubleshoot problems quickly, and make data-driven decisions.

--- a/server/adaptors/integrations/__data__/repository/amazon_s3/info/README.md
+++ b/server/adaptors/integrations/__data__/repository/amazon_s3/info/README.md
@@ -16,4 +16,4 @@ AWS S3 integration includes dashboards, visualizations, queries, and an index ma
 
 The Dashboard uses the index alias `logs-aws-s3` for shortening the index name - be advised.
 
-![AWS S3 Dashboard](../static/dashboard_s3.png)
+![AWS S3 Dashboard](../static/dashboard.png)

--- a/server/adaptors/integrations/__data__/repository/amazon_vpc_flow/assets/README.md
+++ b/server/adaptors/integrations/__data__/repository/amazon_vpc_flow/assets/README.md
@@ -1,6 +1,6 @@
 # AWS VPC Flow Logs Integration Assets
 
-API: http://osd:5601/api/saved_objects/_import?overwrite=true
+API: http://opensearch-dashboards:5601/api/saved_objects/_import?overwrite=true
 
 - [Assets](aws_vpc_flow-1.0.0.ndjson)
 

--- a/server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md
+++ b/server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md
@@ -20,9 +20,6 @@ The main service is open to user interactions:
 _**The shopping App**_
 ![](https://opentelemetry.io/docs/demo/screenshots/frontend-1.png)
 
-_**The feature flag**_
-![](https://opentelemetry.io/docs/demo/screenshots/feature-flag-ui.png)
-
 _**The load generator**_
 ![](https://opentelemetry.io/docs/demo/screenshots/load-generator-ui.png)
 

--- a/server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md
+++ b/server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md
@@ -12,15 +12,9 @@ The purpose of this demo is to demonstrate the different capabilities of OpenSea
 ### Services
 [OTEL DEMO](https://opentelemetry.io/docs/demo/services/) Describes the list of services that are composing the Astronomy Shop.
 
-The main services that are open to user interactions:
+The main service is open to user interactions:
 
 - [Dashboards](https://observability.playground.opensearch.org/)
-
-- [Demo Proxy](https://observability.playground.demo-proxy.opensearch.org/)
-
-- [Demo loader](https://observability.playground.demo-loader.opensearch.org/)
-
-- [Demo feature-flag](https://observability.playground.demo-feature-flag.opensearch.org/)
 
 ### Screenshots
 _**The shopping App**_


### PR DESCRIPTION
### Description
Fixes dead links for the Lychee link checker. This isn't a lossless conversion:
- Where possible, outdated links were updated.
- Some links seemed fully defunct, these were removed outright, sometimes involving deleting docs sections that seemed outdated. e.g. many of the Zeppelin doc links and several links in the OTEL services integration.
- Example links (to OSD instances or in one case to a local k8s cluster) were added to the lycheeignore rules.
  - There's also a playground link that causes a "too many redirects" error and also was ignored.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
