### PR TITLE
Add 'check for version' link in the integration details page

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
@@ -37,22 +37,81 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                 </h4>
               </div>
             </EuiText>
-            <EuiSpacer
-              size="m"
+            <EuiFlexGroup
+              direction="column"
             >
               <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiText
-              size="m"
-            >
-              <div
-                className="euiText euiText--medium"
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
               >
-                1.0.1
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiFlexGroup
+                      alignItems="flexEnd"
+                      justifyContent="spaceBetween"
+                      responsive={false}
+                    >
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexEnd euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      >
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                1.0.1
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiText
+                              size="xs"
+                            >
+                              <div
+                                className="euiText euiText--extraSmall"
+                              >
+                                <EuiLink
+                                  href="https://github.com/opensearch-project/opensearch-catalog/releases"
+                                >
+                                  <a
+                                    className="euiLink euiLink--primary"
+                                    href="https://github.com/opensearch-project/opensearch-catalog/releases"
+                                    rel="noreferrer"
+                                  >
+                                    Check for new versions
+                                  </a>
+                                </EuiLink>
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  />
+                </EuiFlexItem>
               </div>
-            </EuiText>
+            </EuiFlexGroup>
           </div>
         </EuiFlexItem>
         <EuiFlexItem>
@@ -68,13 +127,6 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                 </h4>
               </div>
             </EuiText>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
             <EuiBadgeGroup>
               <div
                 className="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
@@ -95,13 +147,6 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                 </h4>
               </div>
             </EuiText>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
             <EuiLink
               external={true}
               href="https://github.com/"
@@ -163,13 +208,6 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                 </h4>
               </div>
             </EuiText>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
             <EuiText
               size="m"
             >
@@ -196,13 +234,6 @@ exports[`Available Integration Table View Test Renders nginx integration table v
             </h4>
           </div>
         </EuiText>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
         <EuiText
           size="m"
         >

--- a/public/components/integrations/components/integration_details_panel.tsx
+++ b/public/components/integrations/components/integration_details_panel.tsx
@@ -16,12 +16,8 @@ import {
 } from '@elastic/eui';
 import React from 'react';
 
-export function IntegrationDetails(props: any) {
+export function IntegrationDetails(props: { integration: IntegrationConfig }) {
   const config = props.integration;
-  let screenshots;
-  if (config.statics.gallery) {
-    screenshots = config.statics.gallery;
-  }
 
   return (
     <EuiPanel data-test-subj={`${config.name}-details`}>
@@ -34,14 +30,38 @@ export function IntegrationDetails(props: any) {
           <EuiText>
             <h4>Version</h4>
           </EuiText>
-          <EuiSpacer size="m" />
-          <EuiText size="m">{config.version}</EuiText>
+          {/*
+          For the link, we have the slightly odd constraint to have it go to the end of the version
+          space while being horizontally next to the version (i.e. no direct EuiText). It should be
+          smaller, while aligning to the bottom of the line, but not the bottom of the entire flex
+          area, for a nice subscript effect.
+
+          The end result is a bit of flex magic: make two vertical boxes with the second one empty
+          and growing, then in the top one put two horizontal boxes with space-between, aligning to
+          the bottom.
+          */}
+          <EuiFlexGroup direction="column">
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup justifyContent="spaceBetween" alignItems="flexEnd" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="m">{config.version}</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs">
+                    <EuiLink href="https://github.com/opensearch-project/opensearch-catalog/releases">
+                      Check for new versions
+                    </EuiLink>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem />
+          </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText>
             <h4>Category</h4>
           </EuiText>
-          <EuiSpacer size="m" />
           <EuiBadgeGroup>
             {config.labels?.map((label: string) => {
               return <EuiBadge>{label}</EuiBadge>;
@@ -52,7 +72,6 @@ export function IntegrationDetails(props: any) {
           <EuiText>
             <h4>Contributer</h4>
           </EuiText>
-          <EuiSpacer size="m" />
           <EuiLink href={config.sourceUrl} external={true} target="blank">
             {config.author}
           </EuiLink>
@@ -61,7 +80,6 @@ export function IntegrationDetails(props: any) {
           <EuiText>
             <h4>License</h4>
           </EuiText>
-          <EuiSpacer size="m" />
           <EuiText size="m">{config.license}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -69,7 +87,6 @@ export function IntegrationDetails(props: any) {
         <EuiText>
           <h4>Description</h4>
         </EuiText>
-        <EuiSpacer size="m" />
         <EuiText size="m">{config.description}</EuiText>
       </EuiFlexItem>
     </EuiPanel>


### PR DESCRIPTION
### Description
Adds a 'check for version' link that directs the user to the releases page for opensearch-catalog. This makes it easier to discover new content, without users needing to know ahead of time that the catalog exists. (To do: make this dynamic so external integration authors can insert their own links.)

Before:
<img width="496" alt="Screenshot 2024-06-06 at 3 57 44 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/31739405/f7ce2890-7c96-4703-9bc7-dc72062ae8e7">

After:
<img width="497" alt="Screenshot 2024-06-06 at 3 57 08 PM" src="https://github.com/opensearch-project/dashboards-observability/assets/31739405/a94443a1-b697-4b2d-8317-45052bc7b9bf">

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
