### PR TITLE
[Backport 2.x] Minor bug fixes for trace analytics v2 (#1894)

### DIFF
--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map_scale.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map_scale.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`Service map scale component renders service map scale plot 1`] = `
             "zeroline": false,
           },
           "yaxis": Object {
+            "color": "0,0,0",
             "fixedrange": true,
             "range": Array [
               0,
@@ -197,6 +198,7 @@ exports[`Service map scale component renders service map scale plot 1`] = `
               "zeroline": false,
             },
             "yaxis": Object {
+              "color": "0,0,0",
               "fixedrange": true,
               "range": Array [
                 0,

--- a/public/components/trace_analytics/components/common/plots/service_map_scale.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map_scale.tsx
@@ -7,6 +7,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { BarOrientation } from '../../../../../../common/constants/shared';
+import { uiSettingsService } from '../../../../../../common/utils';
 import { Plt } from '../../../../visualizations/plotly/plot';
 import unmatchedNode from '../../../images/unmatched_node.png';
 import { getServiceMapScaleColor } from '../helper_functions';
@@ -88,6 +89,7 @@ export function ServiceMapScale(props: {
           showticklabels: true,
           tickvals: props.ticks,
           ticktexts: props.ticks,
+          color: uiSettingsService.get('theme:darkMode') ? '255,255,255' : '0,0,0',
         },
         margin: {
           l: 0,

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -1933,9 +1933,12 @@ exports[`Services table component renders jaeger services table 1`] = `
                                         className="euiFlexItem euiFlexItem--flexGrowZero"
                                         onClick={[Function]}
                                       >
-                                        <EuiLink>
+                                        <EuiLink
+                                          data-test-subj="service-flyout-action-btnundefined"
+                                        >
                                           <button
                                             className="euiLink euiLink--primary"
+                                            data-test-subj="service-flyout-action-btnundefined"
                                             disabled={false}
                                             type="button"
                                           >
@@ -4176,9 +4179,12 @@ exports[`Services table component renders services table 1`] = `
                                         className="euiFlexItem euiFlexItem--flexGrowZero"
                                         onClick={[Function]}
                                       >
-                                        <EuiLink>
+                                        <EuiLink
+                                          data-test-subj="service-flyout-action-btnundefined"
+                                        >
                                           <button
                                             className="euiLink euiLink--primary"
+                                            data-test-subj="service-flyout-action-btnundefined"
                                             disabled={false}
                                             type="button"
                                           >

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -127,7 +127,7 @@ export function ServicesTable(props: ServicesTableProps) {
           sortable: true,
           render: (item: any) => (
             <EuiLink data-test-subj="service-link" onClick={() => nameColumnAction(item)}>
-              {item.length < 24 ? item : <div title={item}>{_.truncate(item, { length: 24 })}</div>}
+              {item.length < 24 ? item : <div title={item}>{truncate(item, { length: 24 })}</div>}
             </EuiLink>
           ),
         },
@@ -245,7 +245,7 @@ export function ServicesTable(props: ServicesTableProps) {
           render: (_item: any, row: any) => (
             <EuiFlexGroup justifyContent="center">
               <EuiFlexItem grow={false} onClick={() => setCurrentSelectedService(row.name)}>
-                <EuiLink>
+                <EuiLink data-test-subj={'service-flyout-action-btn' + row.itemId}>
                   <EuiIcon type="inspect" color="primary" />
                 </EuiLink>
               </EuiFlexItem>

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -156,7 +156,7 @@ export const Home = (props: HomeProps) => {
 
   useEffect(() => {
     if (mode === 'data_prepper') fetchAttributesFields();
-  }, []);
+  }, [mode]);
 
   const serviceBreadcrumbs = [
     {


### PR DESCRIPTION
### Description
* Update the theming in dark mode for scale of the service map
* Add data test-subj for cypress
* Update truncate usage to use imported lodash
* Add mode dependency to attributefilter useEffect
* update test snapshots

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/1820

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
