### PR TITLE
(query assist) revert removing backticks

### DIFF
--- a/server/routes/query_assist/routes.ts
+++ b/server/routes/query_assist/routes.ts
@@ -77,7 +77,6 @@ export function registerQueryAssistRoutes(router: IRouter) {
           .replace(/[\r\n]/g, ' ')
           .trim()
           .replace(/ISNOTNULL/g, 'isnotnull') // https://github.com/opensearch-project/sql/issues/2431
-          .replace(/`/g, '') // https://github.com/opensearch-project/dashboards-observability/issues/509, https://github.com/opensearch-project/dashboards-observability/issues/557
           .replace(/\bSPAN\(/g, 'span('); // https://github.com/opensearch-project/dashboards-observability/issues/759
         return response.ok({ body: ppl });
       } catch (error) {


### PR DESCRIPTION
### Description
The two issues #509, #557 mentioned are still there, but PPL requires certain fields (i.e. fields with `@`) to be surrounded by backticks, otherwise there will be a syntax error. This PR reverts the behavior to allow those queries.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
