### PR TITLE
[Bug fix] Trace analytics scroll bar reset

### DIFF
--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -15,7 +15,7 @@ import {
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
 import { Plt } from '../../../visualizations/plotly/plot';
 import { TraceAnalyticsMode } from '../../home';
@@ -187,7 +187,19 @@ export function SpanDetailPanel(props: {
 
   const [currentSpan, setCurrentSpan] = useState('');
 
+  const spanContainerRef = useRef<HTMLDivElement | null>(null);
+  const prevScrollPositionRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (spanContainerRef.current) {
+      setTimeout(() => {
+        spanContainerRef.current.scrollTop = prevScrollPositionRef.current || 0;
+      }, 0);
+    }
+  }, [currentSpan]);
+
   const onClick = (event: any) => {
+    const currentScrollPosition = spanContainerRef.current?.scrollTop || 0;
     if (!event?.points) return;
     const point = event.points[0];
     if (fromApp) {
@@ -195,6 +207,7 @@ export function SpanDetailPanel(props: {
     } else {
       setCurrentSpan(point.data.spanId);
     }
+    prevScrollPositionRef.current = currentScrollPosition;
   };
 
   const renderFilters = useMemo(() => {
@@ -279,7 +292,7 @@ export function SpanDetailPanel(props: {
           </>
         )}
         <EuiHorizontalRule margin="m" />
-        <div style={{ overflowY: 'auto', maxHeight: 500 }}>
+        <div style={{ overflowY: 'auto', maxHeight: 500 }} ref={spanContainerRef}>
           {toggleIdSelected === 'timeline' ? (
             <Plt
               data={data.gantt}

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -15,7 +15,7 @@ import {
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
 import { Plt } from '../../../visualizations/plotly/plot';
 import { TraceAnalyticsMode } from '../../home';
@@ -187,15 +187,18 @@ export function SpanDetailPanel(props: {
 
   const [currentSpan, setCurrentSpan] = useState('');
 
-  const onClick = (event: any) => {
-    if (!event?.points) return;
-    const point = event.points[0];
-    if (fromApp) {
-      props.openSpanFlyout(point.data.spanId);
-    } else {
-      setCurrentSpan(point.data.spanId);
-    }
-  };
+  const onClick = useCallback(
+    (event: any) => {
+      if (!event?.points) return;
+      const point = event.points[0];
+      if (fromApp) {
+        props.openSpanFlyout(point.data.spanId);
+      } else {
+        setCurrentSpan(point.data.spanId);
+      }
+    },
+    [props.openSpanFlyout, setCurrentSpan, fromApp]
+  );
 
   const renderFilters = useMemo(() => {
     return spanFilters.map(({ field, value }) => (
@@ -212,15 +215,15 @@ export function SpanDetailPanel(props: {
     ));
   }, [spanFilters]);
 
-  const onHover = () => {
+  const onHover = useCallback(() => {
     const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
     dragLayer.style.cursor = 'pointer';
-  };
+  }, []);
 
-  const onUnhover = () => {
+  const onUnhover = useCallback(() => {
     const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
     dragLayer.style.cursor = '';
-  };
+  }, []);
 
   const toggleOptions = [
     {
@@ -264,7 +267,7 @@ export function SpanDetailPanel(props: {
         onUnhoverHandler={onUnhover}
       />
     ),
-    [data.gantt, layout]
+    [data.gantt, layout, onClick, onHover, onUnhover]
   );
 
   return (

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -15,7 +15,7 @@ import {
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
 import { Plt } from '../../../visualizations/plotly/plot';
 import { TraceAnalyticsMode } from '../../home';
@@ -187,19 +187,7 @@ export function SpanDetailPanel(props: {
 
   const [currentSpan, setCurrentSpan] = useState('');
 
-  const spanContainerRef = useRef<HTMLDivElement | null>(null);
-  const prevScrollPositionRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (spanContainerRef.current) {
-      setTimeout(() => {
-        spanContainerRef.current.scrollTop = prevScrollPositionRef.current || 0;
-      }, 0);
-    }
-  }, [currentSpan]);
-
   const onClick = (event: any) => {
-    const currentScrollPosition = spanContainerRef.current?.scrollTop || 0;
     if (!event?.points) return;
     const point = event.points[0];
     if (fromApp) {
@@ -207,7 +195,6 @@ export function SpanDetailPanel(props: {
     } else {
       setCurrentSpan(point.data.spanId);
     }
-    prevScrollPositionRef.current = currentScrollPosition;
   };
 
   const renderFilters = useMemo(() => {
@@ -267,6 +254,19 @@ export function SpanDetailPanel(props: {
     [DSL, setCurrentSpan]
   );
 
+  const ganttChart = useMemo(
+    () => (
+      <Plt
+        data={data.gantt}
+        layout={layout}
+        onClickHandler={onClick}
+        onHoverHandler={onHover}
+        onUnhoverHandler={onUnhover}
+      />
+    ),
+    [data.gantt, layout]
+  );
+
   return (
     <>
       <EuiPanel data-test-subj="span-gantt-chart-panel">
@@ -292,18 +292,8 @@ export function SpanDetailPanel(props: {
           </>
         )}
         <EuiHorizontalRule margin="m" />
-        <div style={{ overflowY: 'auto', maxHeight: 500 }} ref={spanContainerRef}>
-          {toggleIdSelected === 'timeline' ? (
-            <Plt
-              data={data.gantt}
-              layout={layout}
-              onClickHandler={onClick}
-              onHoverHandler={onHover}
-              onUnhoverHandler={onUnhover}
-            />
-          ) : (
-            spanDetailTable
-          )}
+        <div style={{ overflowY: 'auto', maxHeight: 500 }}>
+          {toggleIdSelected === 'timeline' ? ganttChart : spanDetailTable}
         </div>
       </EuiPanel>
       {!!currentSpan && (


### PR DESCRIPTION
### Description
This change resets the scroll bar to the position it was at prior to opening the fly-out.

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/1916

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
