### PR TITLE
Refactor of Trace analytics to remove duplicated checks.

### DIFF
--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -371,6 +371,8 @@ export const filtersToDsl = (
   page?: string,
   appConfigs: FilterType[] = []
 ) => {
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
   const DSL: any = {
     query: {
       bool: {
@@ -429,15 +431,15 @@ export const filtersToDsl = (
       let filterQuery = {};
       let field = filter.field;
       if (field === 'latency') {
-        if (mode === 'data_prepper') {
+        if (isDataPrepper) {
           field = 'traceGroupFields.durationInNanos';
-        } else if (mode === 'jaeger') {
+        } else if (isJaeger) {
           field = 'duration';
         }
       } else if (field === 'error') {
-        if (mode === 'data_prepper') {
+        if (isDataPrepper) {
           field = 'traceGroupFields.statusCode';
-        } else if (mode === 'jaeger') {
+        } else if (isJaeger) {
           field = 'tag.error';
         }
       }

--- a/public/components/trace_analytics/components/dashboard/dashboard_content.tsx
+++ b/public/components/trace_analytics/components/dashboard/dashboard_content.tsx
@@ -64,6 +64,8 @@ export function DashboardContent(props: DashboardProps) {
   const [loading, setLoading] = useState(false);
   const [showTimeoutToast, setShowTimeoutToast] = useState(false);
   const { setToast } = useToast();
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
 
   useEffect(() => {
     if (showTimeoutToast === true && (!toasts || toasts.length === 0)) {
@@ -91,8 +93,7 @@ export function DashboardContent(props: DashboardProps) {
   useEffect(() => {
     if (
       !redirect &&
-      ((mode === 'data_prepper' && dataPrepperIndicesExist) ||
-        (mode === 'jaeger' && jaegerIndicesExist))
+      ((isDataPrepper && dataPrepperIndicesExist) || (isJaeger && jaegerIndicesExist))
     )
       refresh();
   }, [
@@ -140,7 +141,7 @@ export function DashboardContent(props: DashboardProps) {
       appConfigs
     );
     const fixedInterval = minFixedInterval(startTime, endTime);
-    if (mode === 'jaeger') {
+    if (isJaeger) {
       handleJaegerDashboardRequest(
         http,
         DSL,
@@ -175,7 +176,7 @@ export function DashboardContent(props: DashboardProps) {
         dataSourceMDSId[0].id,
         setPercentileMap
       ).finally(() => setLoading(false));
-    } else if (mode === 'data_prepper') {
+    } else if (isDataPrepper) {
       handleDashboardRequest(
         http,
         DSL,
@@ -276,10 +277,9 @@ export function DashboardContent(props: DashboardProps) {
 
   return (
     <>
-      {(mode === 'data_prepper' && dataPrepperIndicesExist) ||
-      (mode === 'jaeger' && jaegerIndicesExist) ? (
+      {(isDataPrepper && dataPrepperIndicesExist) || (isJaeger && jaegerIndicesExist) ? (
         <div>
-          {mode === 'data_prepper' ? (
+          {isDataPrepper ? (
             <>
               <DashboardTable
                 items={tableItems}

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -70,6 +70,8 @@ export function ServiceView(props: ServiceViewProps) {
   >('latency');
   const [redirect, setRedirect] = useState(false);
   const [actionsMenuPopover, setActionsMenuPopover] = useState(false);
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
 
   const refresh = () => {
     const DSL = filtersToDsl(
@@ -87,7 +89,7 @@ export function ServiceView(props: ServiceViewProps) {
       mode,
       props.dataSourceMDSId[0].id
     );
-    if (mode === 'data_prepper') {
+    if (isDataPrepper) {
       handleServiceMapRequest(
         props.http,
         DSL,
@@ -132,7 +134,7 @@ export function ServiceView(props: ServiceViewProps) {
   const redirectToServiceTraces = () => {
     if (setCurrentSelectedService) setCurrentSelectedService('');
     setRedirect(true);
-    const filterField = mode === 'data_prepper' ? 'serviceName' : 'process.serviceName';
+    const filterField = isDataPrepper ? 'serviceName' : 'process.serviceName';
     props.addFilter({
       field: filterField,
       operator: 'is',
@@ -162,7 +164,7 @@ export function ServiceView(props: ServiceViewProps) {
     {
       id: 0,
       items: [
-        ...(mode === 'data_prepper'
+        ...(isDataPrepper
           ? [
               {
                 name: 'View logs',
@@ -272,7 +274,7 @@ export function ServiceView(props: ServiceViewProps) {
                     {props.serviceName || '-'}
                   </EuiText>
                 </EuiFlexItem>
-                {mode === 'data_prepper' ? (
+                {isDataPrepper ? (
                   <EuiFlexItem grow={false}>
                     <EuiText className="overview-title">Number of connected services</EuiText>
                     <EuiText size="s" className="overview-content">
@@ -284,7 +286,7 @@ export function ServiceView(props: ServiceViewProps) {
                 ) : (
                   <EuiFlexItem />
                 )}
-                {mode === 'data_prepper' ? (
+                {isDataPrepper ? (
                   <EuiFlexItem grow={false}>
                     <EuiText className="overview-title">Connected services</EuiText>
                     <EuiText size="s" className="overview-content">
@@ -397,13 +399,13 @@ export function ServiceView(props: ServiceViewProps) {
       processTimeStamp(props.startTime, mode),
       processTimeStamp(props.endTime, mode)
     );
-    if (mode === 'data_prepper') {
+    if (isDataPrepper) {
       spanDSL.query.bool.must.push({
         term: {
           serviceName: props.serviceName,
         },
       });
-    } else if (mode === 'jaeger') {
+    } else if (isJaeger) {
       spanDSL.query.bool.must.push({
         term: {
           'process.serviceName': props.serviceName,
@@ -483,7 +485,7 @@ export function ServiceView(props: ServiceViewProps) {
       <EuiSpacer size="xl" />
       {overview}
 
-      {mode === 'data_prepper' ? (
+      {isDataPrepper ? (
         <>
           <EuiSpacer />
           <ServiceMetrics

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -58,6 +58,8 @@ export function ServicesContent(props: ServicesProps) {
   const [isServiceTrendEnabled, setIsServiceTrendEnabled] = useState(false);
   const [serviceTrends, setServiceTrends] = useState<ServiceTrends>({});
   const searchBarRef = useRef<{ updateQuery: (newQuery: string) => void }>(null);
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
 
   useEffect(() => {
     chrome.setBreadcrumbs([parentBreadcrumb, ...childBreadcrumbs]);
@@ -83,8 +85,7 @@ export function ServicesContent(props: ServicesProps) {
     setFilteredService(newFilteredService);
     if (
       !redirect &&
-      ((mode === 'data_prepper' && dataPrepperIndicesExist) ||
-        (mode === 'jaeger' && jaegerIndicesExist))
+      ((isDataPrepper && dataPrepperIndicesExist) || (isJaeger && jaegerIndicesExist))
     )
       refresh(newFilteredService);
   }, [
@@ -163,7 +164,7 @@ export function ServicesContent(props: ServicesProps) {
 
   const addServicesGroupFilter = () => {
     const groupFilter = selectedItems.map(
-      (row) => (mode === 'jaeger' ? 'process.serviceName: ' : 'serviceName: ') + row.name
+      (row) => (isJaeger ? 'process.serviceName: ' : 'serviceName: ') + row.name
     );
     const filterQuery = groupFilter.join(' OR ');
     const newQuery = query ? `(${query}) AND (${filterQuery})` : `(${filterQuery})`;
@@ -207,7 +208,7 @@ export function ServicesContent(props: ServicesProps) {
         serviceTrends={serviceTrends}
       />
       <EuiSpacer size="m" />
-      {mode === 'data_prepper' && dataPrepperIndicesExist ? (
+      {isDataPrepper && dataPrepperIndicesExist ? (
         <ServiceMap
           addFilter={addFilter}
           serviceMap={serviceMap}

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -67,6 +67,8 @@ export function ServicesTable(props: ServicesTableProps) {
     setIsServiceTrendEnabled,
     serviceTrends,
   } = props;
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
 
   const selectionValue = {
     onSelectionChange: (selections: any[]) => setSelectedItems(selections),
@@ -74,7 +76,7 @@ export function ServicesTable(props: ServicesTableProps) {
 
   const nameColumnAction = (serviceName: string) => {
     addFilter({
-      field: mode === 'jaeger' ? 'process.serviceName' : 'serviceName',
+      field: isJaeger ? 'process.serviceName' : 'serviceName',
       operator: 'is',
       value: serviceName,
       inverted: false,
@@ -101,7 +103,7 @@ export function ServicesTable(props: ServicesTableProps) {
                 </EuiButtonEmpty>
               </EuiToolTip>
             </EuiFlexItem>
-            {mode === 'data_prepper' && (
+            {isDataPrepper && (
               <EuiFlexItem>
                 <EuiButtonEmpty
                   size="xs"
@@ -177,7 +179,7 @@ export function ServicesTable(props: ServicesTableProps) {
             />
           ),
         },
-        ...(mode === 'data_prepper'
+        ...(isDataPrepper
           ? [
               {
                 field: 'number_of_connected_services',
@@ -190,7 +192,7 @@ export function ServicesTable(props: ServicesTableProps) {
               },
             ]
           : []),
-        ...(mode === 'data_prepper'
+        ...(isDataPrepper
           ? [
               {
                 field: 'connected_services',
@@ -221,7 +223,7 @@ export function ServicesTable(props: ServicesTableProps) {
                   onClick={() => {
                     setRedirect(true);
                     addFilter({
-                      field: mode === 'jaeger' ? 'process.serviceName' : 'serviceName',
+                      field: isJaeger ? 'process.serviceName' : 'serviceName',
                       operator: 'is',
                       value: row.name,
                       inverted: false,
@@ -268,10 +270,7 @@ export function ServicesTable(props: ServicesTableProps) {
         {titleBar}
         <EuiSpacer size="m" />
         <EuiHorizontalRule margin="none" />
-        {!(
-          (mode === 'data_prepper' && dataPrepperIndicesExist) ||
-          (mode === 'jaeger' && jaegerIndicesExist)
-        ) ? (
+        {!((isDataPrepper && dataPrepperIndicesExist) || (isJaeger && jaegerIndicesExist)) ? (
           <MissingConfigurationMessage mode={mode} />
         ) : items?.length > 0 ? (
           <EuiInMemoryTable

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -83,6 +83,7 @@ export function SpanDetailFlyout(props: {
   setCurrentSpan?: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const { mode } = props;
+  const isDataPrepper = mode === 'data_prepper';
   const [span, setSpan] = useState<any>({});
 
   useEffect(() => {
@@ -141,16 +142,14 @@ export function SpanDetailFlyout(props: {
         getSpanValue(span, mode, 'PARENT_SPAN_ID') ? (
           <EuiFlexGroup gutterSize="xs" style={{ marginTop: -4, marginBottom: -4 }}>
             <EuiFlexItem grow={false}>
-              <EuiCopy
-                textToCopy={mode === 'data_prepper' ? span.parentSpanId : span.references[0].spanID}
-              >
+              <EuiCopy textToCopy={isDataPrepper ? span.parentSpanId : span.references[0].spanID}>
                 {(copy) => (
                   <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
                 )}
               </EuiCopy>
             </EuiFlexItem>
             <EuiFlexItem data-test-subj="parentSpanId">
-              {mode === 'data_prepper' ? span.parentSpanId : span.references[0].spanID}
+              {isDataPrepper ? span.parentSpanId : span.references[0].spanID}
             </EuiFlexItem>
           </EuiFlexGroup>
         ) : (
@@ -171,7 +170,7 @@ export function SpanDetailFlyout(props: {
         getSpanFieldKey(mode, 'DURATION'),
         'Duration',
         `${
-          mode === 'data_prepper'
+          isDataPrepper
             ? round(nanoToMilliSec(Math.max(0, span.durationInNanos)), 2)
             : round(microToMilliSec(Math.max(0, span.duration)), 2)
         } ms`
@@ -179,7 +178,7 @@ export function SpanDetailFlyout(props: {
       getListItem(
         getSpanFieldKey(mode, 'START_TIME'),
         'Start time',
-        mode === 'data_prepper'
+        isDataPrepper
           ? moment(span.startTime).format(TRACE_ANALYTICS_DATE_FORMAT)
           : moment(round(microToMilliSec(Math.max(0, span.startTime)), 2)).format(
               TRACE_ANALYTICS_DATE_FORMAT
@@ -188,7 +187,7 @@ export function SpanDetailFlyout(props: {
       getListItem(
         getSpanFieldKey(mode, 'END_TIME'),
         'End time',
-        mode === 'data_prepper'
+        isDataPrepper
           ? moment(span.endTime).format(TRACE_ANALYTICS_DATE_FORMAT)
           : moment(round(microToMilliSec(Math.max(0, span.startTime + span.duration)), 2)).format(
               TRACE_ANALYTICS_DATE_FORMAT
@@ -197,7 +196,7 @@ export function SpanDetailFlyout(props: {
       getListItem(
         getSpanFieldKey(mode, 'ERRORS'),
         'Errors',
-        (mode === 'data_prepper' ? span['status.code'] === 2 : span.tag?.error) ? (
+        (isDataPrepper ? span['status.code'] === 2 : span.tag?.error) ? (
           <EuiText color="danger" size="s" style={{ fontWeight: 700 }}>
             Yes
           </EuiText>
@@ -310,7 +309,7 @@ export function SpanDetailFlyout(props: {
                 <h2>Span detail</h2>
               </EuiTitle>
             </EuiFlexItem>
-            {mode === 'data_prepper' && (
+            {isDataPrepper && (
               <EuiFlexItem>
                 <EuiButtonEmpty size="xs" onClick={redirectToExplorer}>
                   View associated logs

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -36,6 +36,7 @@ export function SpanDetailPanel(props: {
   setData?: (data: { gantt: any[]; table: any[]; ganttMaxX: number }) => void;
 }) {
   const { mode } = props;
+  const isJaeger = mode === 'jaeger';
   const storedFilters = sessionStorage.getItem('TraceAnalyticsSpanFilters');
   const fromApp = props.page === 'app';
   const [spanFilters, setSpanFilters] = useState<Array<{ field: string; value: any }>>(
@@ -96,40 +97,39 @@ export function SpanDetailPanel(props: {
   }, 150);
 
   const spanFiltersToDSL = () => {
-    const spanDSL: any =
-      mode === 'jaeger'
-        ? {
-            query: {
-              bool: {
-                must: [
-                  {
-                    term: {
-                      traceID: props.traceId,
-                    },
+    const spanDSL: any = isJaeger
+      ? {
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    traceID: props.traceId,
                   },
-                ],
-                filter: [],
-                should: [],
-                must_not: [],
-              },
+                },
+              ],
+              filter: [],
+              should: [],
+              must_not: [],
             },
-          }
-        : {
-            query: {
-              bool: {
-                must: [
-                  {
-                    term: {
-                      traceId: props.traceId,
-                    },
+          },
+        }
+      : {
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    traceId: props.traceId,
                   },
-                ],
-                filter: [],
-                should: [],
-                must_not: [],
-              },
+                },
+              ],
+              filter: [],
+              should: [],
+              must_not: [],
             },
-          };
+          },
+        };
     spanFilters.map(({ field, value }) => {
       if (value != null) {
         spanDSL.query.bool.must.push({
@@ -241,7 +241,7 @@ export function SpanDetailPanel(props: {
     () => (
       <SpanDetailTable
         http={props.http}
-        hiddenColumns={mode === 'jaeger' ? ['traceID', 'traceGroup'] : ['traceId', 'traceGroup']}
+        hiddenColumns={isJaeger ? ['traceID', 'traceGroup'] : ['traceId', 'traceGroup']}
         DSL={DSL}
         mode={mode}
         openFlyout={(spanId: string) => {

--- a/public/components/trace_analytics/components/traces/span_detail_table.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_table.tsx
@@ -42,6 +42,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
     }>,
   });
   const { mode } = props;
+  const isJaeger = mode === 'jaeger';
   const [items, setItems] = useState<any>([]);
   const [total, setTotal] = useState(0);
 
@@ -67,7 +68,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
   }, [total]);
 
   const columns: EuiDataGridColumn[] = [
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'spanID',
@@ -80,7 +81,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'Span ID',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'references',
@@ -93,7 +94,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'Parent span ID',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'traceID',
@@ -106,7 +107,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'Trace ID',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? []
       : [
           {
@@ -114,7 +115,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'Trace group',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'process',
@@ -127,7 +128,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'Service',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'operationName',
@@ -140,7 +141,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'Operation',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'duration',
@@ -157,7 +158,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
       id: 'startTime',
       display: 'Start time',
     },
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'jaegerEndTime',
@@ -170,7 +171,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
             display: 'End time',
           },
         ]),
-    ...(mode === 'jaeger'
+    ...(isJaeger
       ? [
           {
             id: 'tag',
@@ -223,7 +224,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
         case 'duration':
           return `${round(microToMilliSec(Math.max(0, value)), 2)} ms`;
         case 'startTime':
-          return mode === 'jaeger'
+          return isJaeger
             ? moment(round(microToMilliSec(Math.max(0, value)), 2)).format(
                 TRACE_ANALYTICS_DATE_FORMAT
               )
@@ -281,8 +282,8 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
         columnVisibility={{ visibleColumns, setVisibleColumns }}
         rowCount={total}
         renderCellValue={renderCellValue}
-        sorting={mode === 'jaeger' ? undefined : { columns: tableParams.sortingColumns, onSort }}
-        toolbarVisibility={mode === 'jaeger' ? false : true}
+        sorting={isJaeger ? undefined : { columns: tableParams.sortingColumns, onSort }}
+        toolbarVisibility={isJaeger ? false : true}
         pagination={{
           pageIndex: tableParams.page,
           pageSize: tableParams.size,

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -48,6 +48,7 @@ interface TraceViewProps extends TraceAnalyticsCoreDeps {
 
 export function TraceView(props: TraceViewProps) {
   const { mode } = props;
+  const isDataPrepper = mode === 'data_prepper';
   const page = 'traceView';
   const renderTitle = (traceId: string) => {
     return (
@@ -95,7 +96,7 @@ export function TraceView(props: TraceViewProps) {
                   </EuiFlexGroup>
                 )}
               </EuiFlexItem>
-              {mode === 'data_prepper' ? (
+              {isDataPrepper ? (
                 <EuiFlexItem grow={false}>
                   <EuiText className="overview-title">Trace group name</EuiText>
                   <EuiText size="s" className="overview-content">
@@ -300,7 +301,7 @@ export function TraceView(props: TraceViewProps) {
             ) : null}
           </EuiPanel>
           <EuiSpacer />
-          {mode === 'data_prepper' ? (
+          {isDataPrepper ? (
             <ServiceMap
               addFilter={undefined}
               serviceMap={traceFilteredServiceMap}

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -43,6 +43,8 @@ export function TracesContent(props: TracesProps) {
   const [redirect, setRedirect] = useState(true);
   const [loading, setLoading] = useState(false);
   const [trigger, setTrigger] = useState<'open' | 'closed'>('closed');
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
 
   const DataSourceMenu = dataSourceManagement?.ui?.getDataSourceMenu<DataSourceViewConfig>();
   useEffect(() => {
@@ -60,8 +62,7 @@ export function TracesContent(props: TracesProps) {
   useEffect(() => {
     if (
       !redirect &&
-      ((mode === 'data_prepper' && dataPrepperIndicesExist) ||
-        (mode === 'jaeger' && jaegerIndicesExist))
+      ((isDataPrepper && dataPrepperIndicesExist) || (isJaeger && jaegerIndicesExist))
     )
       refresh();
   }, [filters, appConfigs, redirect, mode, dataPrepperIndicesExist, jaegerIndicesExist]);
@@ -138,7 +139,7 @@ export function TracesContent(props: TracesProps) {
       <EuiPanel>
         <EuiAccordion
           id="accordion1"
-          buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
+          buttonContent={isDataPrepper ? 'Trace Groups' : 'Service and Operations'}
           forceState={trigger}
           onToggle={onToggle}
           data-test-subj="trace-groups-service-operation-accordian"

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -51,11 +51,12 @@ export function TracesTable(props: TracesTableProps) {
     );
   };
 
-  const columns = useMemo(
-    () => {
-      if (mode === 'data_prepper') {
-        return(
-      [
+  const isDataPrepper = mode === 'data_prepper';
+  const isJaeger = mode === 'jaeger';
+
+  const columns = useMemo(() => {
+    if (isDataPrepper) {
+      return [
         {
           field: 'trace_id',
           name: 'Trace ID',
@@ -65,7 +66,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) => (
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
-                <EuiLink data-test-subj='trace-link' onClick={() => traceIdColumnAction(item)}>
+                <EuiLink data-test-subj="trace-link" onClick={() => traceIdColumnAction(item)}>
                   {item.length < 24 ? (
                     item
                   ) : (
@@ -99,11 +100,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) =>
             item ? (
               <EuiText size="s">
-                {item.length < 36 ? (
-                  item
-                ) : (
-                  <div title={item}>{truncate(item, { length: 36 })}</div>
-                )}
+                {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
               </EuiText>
             ) : (
               '-'
@@ -152,79 +149,76 @@ export function TracesTable(props: TracesTableProps) {
           sortable: true,
           render: (item) => (item === 0 || item ? item : '-'),
         },
-      ] as Array<EuiTableFieldDataColumnType<any>>)
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     } else {
-      return (
-        [
-          {
-            field: 'trace_id',
-            name: 'Trace ID',
-            align: 'left',
-            sortable: true,
-            truncateText: true,
-            render: (item) => (
-              <EuiFlexGroup gutterSize="s" alignItems="center">
-                <EuiFlexItem grow={10}>
-                  <EuiLink onClick={() => traceIdColumnAction(item)}>
-                    {item.length < 24 ? (
-                      item
-                    ) : (
-                      <div title={item}>{truncate(item, { length: 24 })}</div>
-                    )}
-                  </EuiLink>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiCopy textToCopy={item}>
-                    {(copy) => (
-                      <EuiButtonIcon
-                        aria-label="Copy trace id"
-                        iconType="copyClipboard"
-                        onClick={copy}
-                      >
-                        Click to copy
-                      </EuiButtonIcon>
-                    )}
-                  </EuiCopy>
-                </EuiFlexItem>
-                <EuiFlexItem grow={3} />
-              </EuiFlexGroup>
+      return [
+        {
+          field: 'trace_id',
+          name: 'Trace ID',
+          align: 'left',
+          sortable: true,
+          truncateText: true,
+          render: (item) => (
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={10}>
+                <EuiLink onClick={() => traceIdColumnAction(item)}>
+                  {item.length < 24 ? (
+                    item
+                  ) : (
+                    <div title={item}>{truncate(item, { length: 24 })}</div>
+                  )}
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCopy textToCopy={item}>
+                  {(copy) => (
+                    <EuiButtonIcon
+                      aria-label="Copy trace id"
+                      iconType="copyClipboard"
+                      onClick={copy}
+                    >
+                      Click to copy
+                    </EuiButtonIcon>
+                  )}
+                </EuiCopy>
+              </EuiFlexItem>
+              <EuiFlexItem grow={3} />
+            </EuiFlexGroup>
+          ),
+        },
+        {
+          field: 'latency',
+          name: 'Latency (ms)',
+          align: 'right',
+          sortable: true,
+          truncateText: true,
+        },
+        {
+          field: 'error_count',
+          name: 'Errors',
+          align: 'right',
+          sortable: true,
+          render: (item) =>
+            item == null ? (
+              '-'
+            ) : item > 0 ? (
+              <EuiText color="danger" size="s">
+                Yes
+              </EuiText>
+            ) : (
+              'No'
             ),
-          },
-          {
-            field: 'latency',
-            name: 'Latency (ms)',
-            align: 'right',
-            sortable: true,
-            truncateText: true,
-          },
-          {
-            field: 'error_count',
-            name: 'Errors',
-            align: 'right',
-            sortable: true,
-            render: (item) =>
-              item == null ? (
-                '-'
-              ) : item > 0 ? (
-                <EuiText color="danger" size="s">
-                  Yes
-                </EuiText>
-              ) : (
-                'No'
-              ),
-          },
-          {
-            field: 'last_updated',
-            name: 'Last updated',
-            align: 'left',
-            sortable: true,
-            render: (item) => (item === 0 || item ? item : '-'),
-          },
-        ] as Array<EuiTableFieldDataColumnType<any>>)
+        },
+        {
+          field: 'last_updated',
+          name: 'Last updated',
+          align: 'left',
+          sortable: true,
+          render: (item) => (item === 0 || item ? item : '-'),
+        },
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     }
-    },
-    [items]
-  );
+  }, [items]);
 
   const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
 
@@ -235,7 +229,7 @@ export function TracesTable(props: TracesTableProps) {
     },
   });
 
-  const onTableChange = async ({ currPage, sort }: { currPage: any; sort: any }) => {
+  const onTableChange = async ({ sort }: { sort: any }) => {
     if (typeof sort?.field !== 'string') return;
 
     // maps table column key to DSL aggregation name
@@ -270,8 +264,11 @@ export function TracesTable(props: TracesTableProps) {
         {titleBar}
         <EuiSpacer size="m" />
         <EuiHorizontalRule margin="none" />
-        {!((mode === 'data_prepper' && props.dataPrepperIndicesExist) || (mode === 'jaeger' && props.jaegerIndicesExist)) ? (
-          <MissingConfigurationMessage mode={mode}/>
+        {!(
+          (isDataPrepper && props.dataPrepperIndicesExist) ||
+          (isJaeger && props.jaegerIndicesExist)
+        ) ? (
+          <MissingConfigurationMessage mode={mode} />
         ) : items?.length > 0 ? (
           <EuiInMemoryTable
             tableLayout="auto"

--- a/public/components/trace_analytics/requests/queries/services_queries.ts
+++ b/public/components/trace_analytics/requests/queries/services_queries.ts
@@ -18,6 +18,7 @@ export const getServicesQuery = (
   serviceName: string | undefined,
   DSL?: any
 ) => {
+  const isJaeger = mode === 'jaeger';
   const query = {
     size: 0,
     query: {
@@ -31,20 +32,20 @@ export const getServicesQuery = (
     aggs: {
       service: {
         terms: {
-          field: mode === 'jaeger' ? 'process.serviceName' : 'serviceName',
+          field: isJaeger ? 'process.serviceName' : 'serviceName',
           size: 10000,
         },
         aggs: {
           trace_count: {
             cardinality: {
-              field: mode === 'jaeger' ? 'traceID' : 'traceId',
+              field: isJaeger ? 'traceID' : 'traceId',
             },
           },
         },
       },
     },
   };
-  if (mode === 'jaeger') {
+  if (isJaeger) {
     if (serviceName) {
       query.query.bool.must.push({
         term: {

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -233,37 +233,33 @@ const hitsToSpanDetailData = async (hits: any, colorMap: any, mode: TraceAnalyti
     table: [],
     ganttMaxX: 0,
   };
+  const isJaeger = mode === 'jaeger';
+
   if (hits.length === 0) return data;
 
-  const minStartTime =
-    mode === 'jaeger'
-      ? microToMilliSec(hits[hits.length - 1].sort[0])
-      : nanoToMilliSec(hits[hits.length - 1].sort[0]);
+  const minStartTime = isJaeger
+    ? microToMilliSec(hits[hits.length - 1].sort[0])
+    : nanoToMilliSec(hits[hits.length - 1].sort[0]);
   let maxEndTime = 0;
 
   hits.forEach((hit: any) => {
-    const startTime =
-      mode === 'jaeger'
-        ? microToMilliSec(hit.sort[0]) - minStartTime
-        : nanoToMilliSec(hit.sort[0]) - minStartTime;
-    const duration =
-      mode === 'jaeger'
-        ? round(microToMilliSec(hit._source.duration), 2)
-        : round(nanoToMilliSec(hit._source.durationInNanos), 2);
-    const serviceName =
-      mode === 'jaeger'
-        ? get(hit, ['_source', 'process']).serviceName
-        : get(hit, ['_source', 'serviceName']);
-    const name =
-      mode === 'jaeger' ? get(hit, '_source.operationName') : get(hit, '_source.name');
-    const error =
-      mode === 'jaeger'
-        ? hit._source.tag?.['error'] === true
-          ? ' \u26a0 Error'
-          : ''
-        : hit._source['status.code'] === 2
+    const startTime = isJaeger
+      ? microToMilliSec(hit.sort[0]) - minStartTime
+      : nanoToMilliSec(hit.sort[0]) - minStartTime;
+    const duration = isJaeger
+      ? round(microToMilliSec(hit._source.duration), 2)
+      : round(nanoToMilliSec(hit._source.durationInNanos), 2);
+    const serviceName = isJaeger
+      ? get(hit, ['_source', 'process']).serviceName
+      : get(hit, ['_source', 'serviceName']);
+    const name = isJaeger ? get(hit, '_source.operationName') : get(hit, '_source.name');
+    const error = isJaeger
+      ? hit._source.tag?.['error'] === true
         ? ' \u26a0 Error'
-        : '';
+        : ''
+      : hit._source['status.code'] === 2
+      ? ' \u26a0 Error'
+      : '';
     const uniqueLabel = `${serviceName} <br>${name} ` + uuid();
     maxEndTime = Math.max(maxEndTime, startTime + duration);
 
@@ -288,7 +284,7 @@ const hitsToSpanDetailData = async (hits: any, colorMap: any, mode: TraceAnalyti
         orientation: BarOrientation.horizontal,
         hoverinfo: 'none',
         showlegend: false,
-        spanId: mode === 'jaeger' ? hit._source.spanID : hit._source.spanId,
+        spanId: isJaeger ? hit._source.spanID : hit._source.spanId,
       },
       {
         x: [duration],
@@ -303,7 +299,7 @@ const hitsToSpanDetailData = async (hits: any, colorMap: any, mode: TraceAnalyti
         type: 'bar',
         orientation: BarOrientation.horizontal,
         hovertemplate: '%{x}<extra></extra>',
-        spanId: mode === 'jaeger' ? hit._source.spanID : hit._source.spanId,
+        spanId: isJaeger ? hit._source.spanID : hit._source.spanId,
       }
     );
   });


### PR DESCRIPTION
Refactor of Trace analytics to improve readability by reducing duplicated checks.

### Description
Files/calls using <mode === 'data_prepper'> and <mode === 'jaeger'> multiple times replaced with isDataPrepper and isJaeger to improve readability.

Also removed currPage argument from onTableChange in /trace_analytics/components/traces/traces_table.tsx call  as it was not used in the function and was throwing an error.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
