### PR TITLE
Unregister observability datasource from old and new nav group

### DIFF
--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -32,9 +32,6 @@ import {
   observabilityApplicationsID,
   observabilityApplicationsPluginOrder,
   observabilityApplicationsTitle,
-  observabilityDataConnectionsID,
-  observabilityDataConnectionsPluginOrder,
-  observabilityDataConnectionsTitle,
   observabilityIntegrationsID,
   observabilityIntegrationsPluginOrder,
   observabilityIntegrationsTitle,
@@ -370,23 +367,6 @@ export class ObservabilityPlugin
     });
 
     registerAllPluginNavGroups(core);
-
-    core.application.register({
-      id: observabilityDataConnectionsID,
-      title: observabilityDataConnectionsTitle,
-      category: DEFAULT_APP_CATEGORIES.management,
-      order: observabilityDataConnectionsPluginOrder,
-      mount: appMountWithStartPage('dataconnections'),
-    });
-
-    setupDeps.managementOverview?.register({
-      id: observabilityDataConnectionsID,
-      title: observabilityDataConnectionsTitle,
-      order: 9070,
-      description: i18n.translate('observability.dataconnectionsDescription', {
-        defaultMessage: 'Manage compatible data connections with OpenSearch Dashboards.',
-      }),
-    });
 
     const embeddableFactory = new ObservabilityEmbeddableFactoryDefinition(async () => ({
       getAttributeService: (await core.getStartServices())[1].dashboard.getAttributeService,


### PR DESCRIPTION
### Description
Unregister observability datasource from old and new nav group

### Issues Resolved
* Relate https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7323

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
