### PR TITLE
[Backport main] Adding attributefilter field to app analytics (#1943)

### DIFF
--- a/public/components/application_analytics/home.tsx
+++ b/public/components/application_analytics/home.tsx
@@ -4,40 +4,40 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import React, { ReactChild, useEffect, useState } from 'react';
-import { HashRouter, Route, RouteComponentProps, Switch } from 'react-router-dom';
-import DSLService from 'public/services/requests/dsl';
-import PPLService from 'public/services/requests/ppl';
-import SavedObjects from 'public/services/saved_objects/event_analytics/saved_objects';
-import TimestampUtils from 'public/services/timestamp/timestamp';
 import { EuiGlobalToastList, EuiLink } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty } from 'lodash';
+import React, { ReactChild, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { AppTable } from './components/app_table';
-import { Application } from './components/application';
-import { CreateApp } from './components/create';
-import { TraceAnalyticsComponentDeps, TraceAnalyticsCoreDeps } from '../trace_analytics/home';
-import { FilterType } from '../trace_analytics/components/common/filters/filters';
-import { handleDataPrepperIndicesExistRequest } from '../trace_analytics/requests/request_handler';
+import { HashRouter, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { ChromeBreadcrumb, NotificationsStart } from '../../../../../src/core/public';
 import { APP_ANALYTICS_API_PREFIX } from '../../../common/constants/application_analytics';
+import {
+  CUSTOM_PANELS_API_PREFIX,
+  CUSTOM_PANELS_DOCUMENTATION_URL,
+} from '../../../common/constants/custom_panels';
+import { observabilityApplicationsID } from '../../../common/constants/shared';
+import { QueryManager } from '../../../common/query_manager/ppl_query_manager';
 import {
   ApplicationRequestType,
   ApplicationType,
 } from '../../../common/types/application_analytics';
+import DSLService from '../../services/requests/dsl';
+import PPLService from '../../services/requests/ppl';
+import SavedObjects from '../../services/saved_objects/event_analytics/saved_objects';
+import TimestampUtils from '../../services/timestamp/timestamp';
+import { FilterType } from '../trace_analytics/components/common/filters/filters';
+import { TraceAnalyticsComponentDeps, TraceAnalyticsCoreDeps } from '../trace_analytics/home';
+import { handleDataPrepperIndicesExistRequest } from '../trace_analytics/requests/request_handler';
+import { AppTable } from './components/app_table';
+import { Application } from './components/application';
+import { CreateApp } from './components/create';
 import {
   calculateAvailability,
   fetchPanelsVizIdList,
   isNameValid,
   removeTabData,
 } from './helpers/utils';
-import {
-  CUSTOM_PANELS_API_PREFIX,
-  CUSTOM_PANELS_DOCUMENTATION_URL,
-} from '../../../common/constants/custom_panels';
-import { QueryManager } from '../../../common/query_manager/ppl_query_manager';
-import { observabilityApplicationsID } from '../../../common/constants/shared';
 
 export type AppAnalyticsCoreDeps = TraceAnalyticsCoreDeps;
 
@@ -142,6 +142,7 @@ export const Home = (props: HomeProps) => {
     mode: 'data_prepper',
     dataPrepperIndicesExist: indicesExist,
     dataSourcePluggables,
+    attributesFilterFields: [],
   };
 
   const setToast = (title: string, color = 'success', text?: ReactChild) => {
@@ -202,7 +203,7 @@ export const Home = (props: HomeProps) => {
     if (!isEmpty(savedVizIdsToDelete)) {
       savedObjects
         .deleteSavedObjectsList({ objectIdList: savedVizIdsToDelete })
-        .then((res) => {
+        .then((_res) => {
           deletePanelForApp(appPanelId);
         })
         .catch((err) => {
@@ -300,7 +301,7 @@ export const Home = (props: HomeProps) => {
       .put(`${APP_ANALYTICS_API_PREFIX}/rename`, {
         body: JSON.stringify(requestBody),
       })
-      .then((res) => {
+      .then((_res) => {
         setApplicationList((prevApplicationList) => {
           const newApplicationData = [...prevApplicationList];
           const renamedApplication = newApplicationData.find(


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>
(cherry picked from commit de8e0aa7f42f2643ccbbb16b7f3f6080cbe78254)

### Description
Fixes unable to load applications regression issue. More details in the original PR below. 
Backporting: https://github.com/opensearch-project/dashboards-observability/pull/1943

### Issues Resolved
Issue: https://github.com/opensearch-project/dashboards-observability/issues/1931

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
