### PR TITLE
[BUG] Traces and Spans tab Fix for application analytics

### DIFF
--- a/public/components/application_analytics/components/application.tsx
+++ b/public/components/application_analytics/components/application.tsx
@@ -327,6 +327,7 @@ export function Application(props: AppDetailProps) {
           endTime={appEndTime}
           setStartTime={setStartTimeForApp}
           setEndTime={setEndTimeForApp}
+          dataSourceMDSId={[{ id: '', label: '' }]}
         />
         <EuiSpacer size="m" />
         <EuiPanel>
@@ -339,6 +340,7 @@ export function Application(props: AppDetailProps) {
             DSL={spanDSL}
             setTotal={setTotalSpans}
             mode="data_prepper"
+            dataSourceMDSId={''}
           />
         </EuiPanel>
       </>
@@ -549,6 +551,7 @@ export function Application(props: AppDetailProps) {
             closeFlyout={closeSpanFlyout}
             addSpanFilter={addSpanFilter}
             mode="data_prepper"
+            dataSourceMDSId=""
           />
         )}
         {traceFlyoutId && (


### PR DESCRIPTION
### Description
the Traces and Span tab in application analytics was crashing as the MDS-ID was not being sent in to the traces page
![image](https://github.com/user-attachments/assets/d64f07f9-2eaa-425b-bb97-00f5cdb0d111)


### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/1931

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
