### PR TITLE
Fix direct url load for trace analytics

### DIFF
--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -120,13 +120,11 @@ export const Home = (props: HomeProps) => {
 
   const [dataSourceMDSId, setDataSourceMDSId] = useState([{ id: '', label: '' }]);
   const [currentSelectedService, setCurrentSelectedService] = useState('');
-  let defaultRoute = '';
-  const currentHash = window.location.hash.split('#')[1];
+  let defaultRoute = props.defaultRoute ?? '/services';
+  const currentHash = window.location.hash.split('#')[1] || '';
 
   if (currentHash === '/traces' || currentHash === '/services') {
     defaultRoute = currentHash;
-  } else {
-    defaultRoute = props.defaultRoute ?? '/services';
   }
 
   const { chrome } = props;

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -120,7 +120,15 @@ export const Home = (props: HomeProps) => {
 
   const [dataSourceMDSId, setDataSourceMDSId] = useState([{ id: '', label: '' }]);
   const [currentSelectedService, setCurrentSelectedService] = useState('');
-  const { defaultRoute = '/services' } = props;
+  let defaultRoute = '';
+  const currentHash = window.location.hash.split('#')[1];
+
+  if (currentHash === '/traces' || currentHash === '/services') {
+    defaultRoute = currentHash;
+  } else {
+    defaultRoute = props.defaultRoute ?? '/services';
+  }
+
   const { chrome } = props;
   const isNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
 

--- a/public/components/trace_analytics/trace_side_nav.tsx
+++ b/public/components/trace_analytics/trace_side_nav.tsx
@@ -30,7 +30,7 @@ export function TraceSideBar(props: { children: React.ReactNode }) {
     {
       name: 'Trace analytics',
       id: 1,
-      href: '#/',
+      href: '#/services',
       items: [
         {
           name: 'Services',


### PR DESCRIPTION
### Description
Loading trace analytics directly via URL defaults to services page even when `/traces` path is added in the URL. 

Example: 
```
http://host:port/app/observability-traces#/services -> Loads services as expected.
http://host:port/app/observability-traces#/traces -> Doesn't load traces page, rather loads services page. 
``` 

### Issues Resolved
Fixes the default route path when URL has the required hash and overrides the one in props. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
