### PR TITLE
[Backport 2.16] 2037 to 2.16 Trace Analytics bugfix for breadcrumbs and id pathing

### DIFF
--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -104,12 +104,14 @@ export function ServiceView(props: ServiceViewProps) {
   useEffect(() => {
     if (page !== 'serviceFlyout')
       setNavBreadCrumbs(
-        [props.parentBreadcrumb],
         [
+          props.parentBreadcrumb,
           {
             text: 'Trace analytics',
-            href: '#/',
+            href: '#/services',
           },
+        ],
+        [
           {
             text: 'Services',
             href: '#/services',

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -233,12 +233,14 @@ export function TraceView(props: TraceViewProps) {
 
   useEffect(() => {
     setNavBreadCrumbs(
-      [props.parentBreadcrumb],
       [
+        props.parentBreadcrumb,
         {
           text: 'Trace analytics',
-          href: '#/',
+          href: '#/services',
         },
+      ],
+      [
         {
           text: 'Traces',
           href: '#/traces',

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -123,7 +123,7 @@ export const Home = (props: HomeProps) => {
   let defaultRoute = props.defaultRoute ?? '/services';
   const currentHash = window.location.hash.split('#')[1] || '';
 
-  if (currentHash === '/traces' || currentHash === '/services') {
+  if (currentHash.startsWith('/traces') || currentHash.startsWith('/services')) {
     defaultRoute = currentHash;
   }
 
@@ -196,10 +196,14 @@ export const Home = (props: HomeProps) => {
   }, [mode]);
 
   const serviceBreadcrumbs = [
-    {
-      text: 'Trace analytics',
-      href: '#/services',
-    },
+    ...(!isNavGroupEnabled
+      ? [
+          {
+            text: 'Trace analytics',
+            href: '#/services',
+          },
+        ]
+      : []),
     {
       text: 'Services',
       href: '#/services',
@@ -207,10 +211,14 @@ export const Home = (props: HomeProps) => {
   ];
 
   const traceBreadcrumbs = [
-    {
-      text: 'Trace analytics',
-      href: '#/services',
-    },
+    ...(!isNavGroupEnabled
+      ? [
+          {
+            text: 'Trace analytics',
+            href: '#/services',
+          },
+        ]
+      : []),
     {
       text: 'Traces',
       href: '#/traces',


### PR DESCRIPTION
### Description
[Bug] Trace Analytics bugfix for breadcrumbs and id pathing
https://github.com/opensearch-project/dashboards-observability/pull/2037

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
