### PR TITLE
[navigation]feat: remove useless registration of Notebook to analytics nav group

### DIFF
--- a/public/plugin_nav.tsx
+++ b/public/plugin_nav.tsx
@@ -71,13 +71,6 @@ export function registerAllPluginNavGroups(core: CoreSetup<AppPluginStartDepende
       order: 400,
     },
   ]);
-  core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.analytics, [
-    {
-      id: observabilityNotebookID,
-      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
-      order: 400,
-    },
-  ]);
 
   core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
     {


### PR DESCRIPTION
### Description
Notebook is registered under analytics nav group by accident, this PR is to fix that. Notebook will still be visible under observability nav group.
#### Before fix
![image](https://github.com/user-attachments/assets/01f17791-2c65-4ab8-9709-5be8debfe766)

#### After fix
![image](https://github.com/user-attachments/assets/73a1af7d-8af3-434b-a5d0-457e37dbc739)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
