### PR TITLE
[Look&Feel] Density and Consistency Improvements

### DIFF
--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -7,7 +7,7 @@
 import '../app_analytics.scss';
 import {
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFlexGroup,
@@ -141,14 +141,14 @@ export function AppTable(props: AppTableProps) {
   };
 
   const popoverButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="appAnalyticsActionsButton"
       iconType="arrowDown"
       iconSide="right"
       onClick={() => setIsActionsPopoverOpen(!isActionsPopoverOpen)}
     >
       Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const popoverItems: ReactElement[] = [
@@ -283,9 +283,9 @@ export function AppTable(props: AppTableProps) {
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton fill href="#/create">
+                    <EuiSmallButton fill href="#/create">
                       {createButtonText}
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>
@@ -323,12 +323,12 @@ export function AppTable(props: AppTableProps) {
                 <EuiSpacer size="m" />
                 <EuiFlexGroup justifyContent="center">
                   <EuiFlexItem grow={false}>
-                    <EuiButton fullWidth={false} href={`#/create`}>
+                    <EuiSmallButton fullWidth={false} href={`#/create`}>
                       {createButtonText}
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   {/* <EuiFlexItem grow={false}>
-                    <EuiButton fullWidth={false}>Add sample applications</EuiButton>
+                    <EuiSmallButton fullWidth={false}>Add sample applications</EuiSmallButton>
                   </EuiFlexItem> */}
                 </EuiFlexGroup>
                 <EuiSpacer size="xxl" />

--- a/public/components/application_analytics/components/config_components/log_config.tsx
+++ b/public/components/application_analytics/components/config_components/log_config.tsx
@@ -8,7 +8,7 @@ import {
   EuiText,
   EuiSpacer,
   EuiButton,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFlexItem,
   EuiBadge,
   EuiOverlayMask,
@@ -127,7 +127,7 @@ export const LogConfig = (props: LogConfigProps) => {
             </EuiCallOut>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Base Query"
               helpText="The default logs view in the application will be filtered by this query."
             >
@@ -157,7 +157,7 @@ export const LogConfig = (props: LogConfigProps) => {
                   PPL
                 </EuiBadge>
               </EuiFlexItem>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiAccordion>

--- a/public/components/application_analytics/components/config_components/service_config.tsx
+++ b/public/components/application_analytics/components/config_components/service_config.tsx
@@ -9,7 +9,7 @@ import {
   EuiBadge,
   EuiButton,
   EuiComboBox,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiOverlayMask,
   EuiSpacer,
   EuiText,
@@ -167,7 +167,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
         }}
         paddingSize="l"
       >
-        <EuiFormRow label="Services & entities">
+        <EuiCompressedFormRow label="Services & entities">
           <EuiComboBox
             aria-label="Select services and entities"
             placeholder="Select services and entities"
@@ -177,7 +177,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
             isClearable={false}
             data-test-subj="servicesEntitiesComboBox"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
         <ServiceMap
           serviceMap={serviceMap}

--- a/public/components/application_analytics/components/config_components/service_config.tsx
+++ b/public/components/application_analytics/components/config_components/service_config.tsx
@@ -8,7 +8,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFormRow,
   EuiOverlayMask,
   EuiSpacer,
@@ -168,7 +168,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
         paddingSize="l"
       >
         <EuiCompressedFormRow label="Services & entities">
-          <EuiComboBox
+          <EuiCompressedComboBox
             aria-label="Select services and entities"
             placeholder="Select services and entities"
             options={services}

--- a/public/components/application_analytics/components/config_components/trace_config.tsx
+++ b/public/components/application_analytics/components/config_components/trace_config.tsx
@@ -9,7 +9,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFormRow,
   EuiOverlayMask,
   EuiSpacer,
@@ -250,7 +250,7 @@ export const TraceConfig = (props: TraceConfigProps) => {
           label="Trace Groups"
           helpText="Select one or multiple trace groups, or type a custom one"
         >
-          <EuiComboBox
+          <EuiCompressedComboBox
             aria-label="Select trace groups"
             placeholder="Select or add trace groups"
             options={traceOptions}

--- a/public/components/application_analytics/components/config_components/trace_config.tsx
+++ b/public/components/application_analytics/components/config_components/trace_config.tsx
@@ -10,7 +10,7 @@ import {
   EuiBadge,
   EuiButton,
   EuiComboBox,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiOverlayMask,
   EuiSpacer,
   EuiText,
@@ -246,7 +246,7 @@ export const TraceConfig = (props: TraceConfigProps) => {
         }}
         paddingSize="l"
       >
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Trace Groups"
           helpText="Select one or multiple trace groups, or type a custom one"
         >
@@ -260,7 +260,7 @@ export const TraceConfig = (props: TraceConfigProps) => {
             isClearable={false}
             data-test-subj="traceGroupsComboBox"
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
         <DashboardTable
           items={traceItems}

--- a/public/components/application_analytics/components/configuration.tsx
+++ b/public/components/application_analytics/components/configuration.tsx
@@ -17,7 +17,7 @@ import {
   EuiPageContentBody,
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
   EuiSpacer,
   EuiText,
@@ -124,7 +124,7 @@ export const Configuration = (props: ConfigProps) => {
                   </EuiText>
                   <EuiSpacer size="m" />
                   {visWithAvailability.length > 0 ? (
-                    <EuiSelect
+                    <EuiCompressedSelect
                       options={visWithAvailability}
                       value={availabilityVisId}
                       onChange={onAvailabilityVisChange}

--- a/public/components/application_analytics/components/configuration.tsx
+++ b/public/components/application_analytics/components/configuration.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBreadcrumb,
-  EuiButton,
+  EuiSmallButton,
   EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
@@ -67,7 +67,7 @@ export const Configuration = (props: ConfigProps) => {
               <EuiPageContentHeaderSection>
                 <EuiFlexGroup gutterSize="s">
                   <EuiFlexItem>
-                    <EuiButton
+                    <EuiSmallButton
                       fill
                       data-test-subj="editApplicationButton"
                       onClick={() => {
@@ -75,7 +75,7 @@ export const Configuration = (props: ConfigProps) => {
                       }}
                     >
                       Edit
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>

--- a/public/components/application_analytics/components/create.tsx
+++ b/public/components/application_analytics/components/create.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiHorizontalRule,
   EuiPage,
   EuiPageBody,
@@ -199,20 +199,20 @@ export const CreateApp = (props: CreateAppProps) => {
             </EuiPageContentHeader>
             <EuiHorizontalRule />
             <EuiForm component="form">
-              <EuiFormRow label="Name" data-test-subj="nameFormRow">
+              <EuiCompressedFormRow label="Name" data-test-subj="nameFormRow">
                 <EuiFieldText
                   name="name"
                   value={name}
                   onChange={(e) => setNameWithStorage(e.target.value)}
                 />
-              </EuiFormRow>
-              <EuiFormRow label="Description" data-test-subj="descriptionFormRow">
+              </EuiCompressedFormRow>
+              <EuiCompressedFormRow label="Description" data-test-subj="descriptionFormRow">
                 <EuiFieldText
                   name="description"
                   value={description}
                   onChange={(e) => setDescriptionWithStorage(e.target.value)}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiForm>
           </EuiPageContent>
           <EuiSpacer />

--- a/public/components/application_analytics/components/create.tsx
+++ b/public/components/application_analytics/components/create.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -242,33 +242,33 @@ export const CreateApp = (props: CreateAppProps) => {
           <EuiSpacer />
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
-              <EuiButton data-test-subj="cancelCreateButton" onClick={onCancel}>
+              <EuiSmallButton data-test-subj="cancelCreateButton" onClick={onCancel}>
                 Cancel
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip position="top" content={missingField(false)}>
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="createButton"
                   isDisabled={isDisabled}
                   onClick={editMode ? onUpdate : () => onCreate('create')}
                   fill={editMode ? true : false}
                 >
                   {editMode ? 'Save' : 'Create'}
-                </EuiButton>
+                </EuiSmallButton>
               </EuiToolTip>
             </EuiFlexItem>
             {editMode || (
               <EuiFlexItem grow={false}>
                 <EuiToolTip position="top" content={missingField(true)}>
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj="createAndSetButton"
                     fill
                     isDisabled={isDisabled || !query}
                     onClick={() => onCreate('createSetAvailability')}
                   >
                     Create and Set Availability
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiToolTip>
               </EuiFlexItem>
             )}

--- a/public/components/application_analytics/components/create.tsx
+++ b/public/components/application_analytics/components/create.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -200,14 +200,14 @@ export const CreateApp = (props: CreateAppProps) => {
             <EuiHorizontalRule />
             <EuiForm component="form">
               <EuiCompressedFormRow label="Name" data-test-subj="nameFormRow">
-                <EuiFieldText
+                <EuiCompressedFieldText
                   name="name"
                   value={name}
                   onChange={(e) => setNameWithStorage(e.target.value)}
                 />
               </EuiCompressedFormRow>
               <EuiCompressedFormRow label="Description" data-test-subj="descriptionFormRow">
-                <EuiFieldText
+                <EuiCompressedFieldText
                   name="description"
                   value={description}
                   onChange={(e) => setDescriptionWithStorage(e.target.value)}

--- a/public/components/application_analytics/components/flyout_components/availability_info_flyout.tsx
+++ b/public/components/application_analytics/components/flyout_components/availability_info_flyout.tsx
@@ -11,7 +11,7 @@ import {
   EuiText,
   EuiCodeBlock,
   EuiFlyoutFooter,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import React from 'react';
 
@@ -55,7 +55,7 @@ export function AvailabilityInfoFlyout(props: AvailabilityInfoFlyoutProps) {
         </EuiText>
       </EuiFlyoutBody>
       <EuiFlyoutFooter>
-        <EuiButton onClick={closeFlyout}>Close</EuiButton>
+        <EuiSmallButton onClick={closeFlyout}>Close</EuiSmallButton>
       </EuiFlyoutFooter>
     </EuiFlyout>
   );

--- a/public/components/application_analytics/components/flyout_components/trace_detail_flyout.tsx
+++ b/public/components/application_analytics/components/flyout_components/trace_detail_flyout.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
+import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiText } from '@elastic/eui';
 import React from 'react';
 import { TraceAnalyticsComponentDeps } from '../../../../../public/components/trace_analytics/home';
 import { TraceDetailRender } from './trace_detail_render';
@@ -17,14 +17,19 @@ interface TraceFlyoutProps extends TraceAnalyticsComponentDeps {
 export function TraceDetailFlyout(props: TraceFlyoutProps) {
   const { traceId, http, closeTraceFlyout, openSpanFlyout } = props;
   const renderContent = (
-    <TraceDetailRender traceId={traceId} http={http} openSpanFlyout={openSpanFlyout} mode='data_prepper'/>
+    <TraceDetailRender
+      traceId={traceId}
+      http={http}
+      openSpanFlyout={openSpanFlyout}
+      mode="data_prepper"
+    />
   );
   return (
     <EuiFlyout data-test-subj="traceDetailFlyout" onClose={closeTraceFlyout} size="m">
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle data-test-subj="traceDetailFlyoutTitle">
+        <EuiText data-test-subj="traceDetailFlyoutTitle" size="s">
           <h2>Trace detail</h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>{renderContent}</EuiFlyoutBody>
     </EuiFlyout>

--- a/public/components/common/helpers/add_sample_modal.tsx
+++ b/public/components/common/helpers/add_sample_modal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiOverlayMask, EuiConfirmModal } from '@elastic/eui';
+import { EuiOverlayMask, EuiConfirmModal, EuiText } from '@elastic/eui';
 
 export const getSampleDataModal = (
   onCancel: (
@@ -22,10 +22,12 @@ export const getSampleDataModal = (
         confirmButtonText="Yes"
         defaultFocusedButton="confirm"
       >
-        <p>
-          Do you want to add sample data? This will also add Dashboards sample flights and logs
-          data if they have not been added.
-        </p>
+        <EuiText size="s">
+          <p>
+            Do you want to add sample data? This will also add Dashboards sample flights and logs
+            data if they have not been added.
+          </p>
+        </EuiText>
       </EuiConfirmModal>
     </EuiOverlayMask>
   );

--- a/public/components/common/helpers/delete_modal.tsx
+++ b/public/components/common/helpers/delete_modal.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import {
   EuiOverlayMask,
   EuiModal,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiForm,
@@ -66,7 +66,7 @@ export const DeleteModal = ({
 
         <EuiModalFooter>
           <EuiButtonEmpty onClick={onCancel}>Cancel</EuiButtonEmpty>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => onConfirm()}
             color="danger"
             fill
@@ -74,7 +74,7 @@ export const DeleteModal = ({
             data-test-subj="popoverModal__deleteButton"
           >
             Delete
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/components/common/helpers/delete_modal.tsx
+++ b/public/components/common/helpers/delete_modal.tsx
@@ -8,7 +8,7 @@ import {
   EuiOverlayMask,
   EuiModal,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiForm,
   EuiFormRow,
@@ -65,7 +65,7 @@ export const DeleteModal = ({
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={onCancel}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={onCancel}>Cancel</EuiSmallButtonEmpty>
           <EuiSmallButton
             onClick={() => onConfirm()}
             color="danger"

--- a/public/components/common/helpers/delete_modal.tsx
+++ b/public/components/common/helpers/delete_modal.tsx
@@ -11,7 +11,7 @@ import {
   EuiSmallButtonEmpty,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiModalBody,
   EuiModalFooter,
   EuiModalHeader,
@@ -52,7 +52,7 @@ export const DeleteModal = ({
           <EuiText>The action cannot be undone.</EuiText>
           <EuiSpacer />
           <EuiForm>
-            <EuiFormRow label={`To confirm deletion, enter "${deletePrompt}" in the text field`}>
+            <EuiCompressedFormRow label={`To confirm deletion, enter "${deletePrompt}" in the text field`}>
               <EuiFieldText
                 name="input"
                 placeholder={deletePrompt}
@@ -60,7 +60,7 @@ export const DeleteModal = ({
                 onChange={(e) => onChange(e)}
                 data-test-subj="popoverModal__deleteTextInput"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiModalBody>
 

--- a/public/components/common/helpers/delete_modal.tsx
+++ b/public/components/common/helpers/delete_modal.tsx
@@ -44,15 +44,21 @@ export const DeleteModal = ({
     <EuiOverlayMask>
       <EuiModal onClose={onCancel} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{title}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiText>{message}</EuiText>
-          <EuiText>The action cannot be undone.</EuiText>
+          <EuiText size="s">{message}</EuiText>
+          <EuiText size="s">The action cannot be undone.</EuiText>
           <EuiSpacer />
           <EuiForm>
-            <EuiCompressedFormRow label={`To confirm deletion, enter "${deletePrompt}" in the text field`}>
+            <EuiCompressedFormRow
+              label={`To confirm deletion, enter "${deletePrompt}" in the text field`}
+            >
               <EuiCompressedFieldText
                 name="input"
                 placeholder={deletePrompt}

--- a/public/components/common/helpers/delete_modal.tsx
+++ b/public/components/common/helpers/delete_modal.tsx
@@ -9,7 +9,7 @@ import {
   EuiModal,
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
   EuiModalBody,
@@ -53,7 +53,7 @@ export const DeleteModal = ({
           <EuiSpacer />
           <EuiForm>
             <EuiCompressedFormRow label={`To confirm deletion, enter "${deletePrompt}" in the text field`}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 name="input"
                 placeholder={deletePrompt}
                 value={value}

--- a/public/components/common/helpers/ppl_reference_flyout.tsx
+++ b/public/components/common/helpers/ppl_reference_flyout.tsx
@@ -16,7 +16,6 @@ import {
   EuiMarkdownFormat,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import { PPL_DOCUMENTATION_URL } from '../../../../common/constants/shared';
 import find from 'lodash/find';
@@ -50,9 +49,9 @@ export const PPLReferenceFlyout = ({ module, closeFlyout }: Props) => {
 
   const flyoutHeader = (
     <EuiFlyoutHeader hasBorder>
-      <EuiTitle size="m">
+      <EuiText size="s">
         <h2 id="pplReferenceFlyout">OpenSearch PPL Reference Manual</h2>
-      </EuiTitle>
+      </EuiText>
     </EuiFlyoutHeader>
   );
 

--- a/public/components/common/helpers/ppl_reference_flyout.tsx
+++ b/public/components/common/helpers/ppl_reference_flyout.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -84,7 +84,7 @@ export const PPLReferenceFlyout = ({ module, closeFlyout }: Props) => {
     <EuiFlyoutFooter>
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={closeFlyout}>Close</EuiButton>
+          <EuiSmallButton onClick={closeFlyout}>Close</EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlyoutFooter>

--- a/public/components/common/helpers/ppl_reference_flyout.tsx
+++ b/public/components/common/helpers/ppl_reference_flyout.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -60,7 +60,7 @@ export const PPLReferenceFlyout = ({ module, closeFlyout }: Props) => {
     <EuiFlyoutBody>
       <EuiFlexGroup component="span">
         <EuiFlexItem>
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Refer commands, functions and language structures"
             options={allOptionsStatic}
             selectedOptions={selectedOptions}

--- a/public/components/common/live_tail/live_tail_button.tsx
+++ b/public/components/common/live_tail/live_tail_button.tsx
@@ -5,7 +5,7 @@
 
 // Define pop over interval options for live tail button in your plugin
 
-import { EuiButton } from '@elastic/eui';
+import { EuiSmallButton } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { LiveTailProps } from 'common/types/explorer';
 
@@ -19,14 +19,14 @@ export const LiveTailButton = ({
 }: LiveTailProps) => {
   const liveButton = useMemo(() => {
     return (
-      <EuiButton
+      <EuiSmallButton
         iconType={isLiveTailOn ? 'stop' : 'clock'}
         iconSide="left"
         onClick={() => setIsLiveTailPopoverOpen(!isLiveTailPopoverOpen)}
         data-test-subj={dataTestSubj}
       >
         {liveTailName}
-      </EuiButton>
+      </EuiSmallButton>
     );
   }, [isLiveTailPopoverOpen, isLiveTailOn]);
   return liveButton;
@@ -37,14 +37,14 @@ export const StopLiveButton = (props: any) => {
 
   const stopButton = () => {
     return (
-      <EuiButton
+      <EuiSmallButton
         iconType="stop"
         onClick={() => StopLive()}
         color="danger"
         data-test-subj={dataTestSubj}
       >
         Stop
-      </EuiButton>
+      </EuiSmallButton>
     );
   };
   return stopButton();

--- a/public/components/common/search/autocomplete.tsx
+++ b/public/components/common/search/autocomplete.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { AutocompleteState, createAutocomplete } from '@algolia/autocomplete-core';
-import { EuiFieldText, EuiTextArea } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiTextArea } from '@elastic/eui';
 import $ from 'jquery';
 import DSLService from 'public/services/requests/dsl';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -134,7 +134,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     });
   }, depArray);
 
-  const TextArea = panelsFilter ? EuiFieldText : EuiTextArea;
+  const TextArea = panelsFilter ? EuiCompressedFieldText : EuiTextArea;
 
   return (
     <div className="aa-Autocomplete" {...autocomplete.getRootProps({ id: 'autocomplete-root' })}>

--- a/public/components/common/search/autocomplete.tsx
+++ b/public/components/common/search/autocomplete.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { AutocompleteState, createAutocomplete } from '@algolia/autocomplete-core';
-import { EuiCompressedFieldText, EuiTextArea } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedTextArea } from '@elastic/eui';
 import $ from 'jquery';
 import DSLService from 'public/services/requests/dsl';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -134,7 +134,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
     });
   }, depArray);
 
-  const TextArea = panelsFilter ? EuiCompressedFieldText : EuiTextArea;
+  const TextArea = panelsFilter ? EuiCompressedFieldText : EuiCompressedTextArea;
 
   return (
     <div className="aa-Autocomplete" {...autocomplete.getRootProps({ id: 'autocomplete-root' })}>

--- a/public/components/common/search/date_picker.tsx
+++ b/public/components/common/search/date_picker.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSuperDatePicker } from '@elastic/eui';
+import { EuiCompressedSuperDatePicker } from '@elastic/eui';
 import React from 'react';
 import { uiSettingsService } from '../../../../common/utils';
 import { IDatePickerProps } from './search';
@@ -14,7 +14,7 @@ export function DatePicker(props: IDatePickerProps) {
   const handleTimeChange = (e: any) => handleTimePickerChange([e.start, e.end]);
 
   return (
-    <EuiSuperDatePicker
+    <EuiCompressedSuperDatePicker
       data-test-subj="pplSearchDatePicker"
       start={startTime}
       end={endTime}

--- a/public/components/common/search/direct_search.tsx
+++ b/public/components/common/search/direct_search.tsx
@@ -8,6 +8,7 @@ import './search.scss';
 import '@algolia/autocomplete-theme-classic';
 import {
   EuiBadge,
+  EuiSmallButton,
   EuiButton,
   EuiButtonEmpty,
   EuiContextMenuItem,
@@ -144,7 +145,7 @@ export const DirectSearch = (props: any) => {
   }
 
   const Savebutton = (
-    <EuiButton
+    <EuiSmallButton
       iconSide="right"
       onClick={() => {
         setIsSavePanelOpen((staleState) => {
@@ -155,7 +156,7 @@ export const DirectSearch = (props: any) => {
       iconType="arrowDown"
     >
       Save
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const handleQueryLanguageChange = (lang: QUERY_LANGUAGE) => {
@@ -188,7 +189,7 @@ export const DirectSearch = (props: any) => {
   ];
 
   const languagePopOverButton = (
-    <EuiButton
+    <EuiSmallButton
       iconType="arrowDown"
       iconSide="right"
       onClick={onLanguagePopoverClick}
@@ -196,7 +197,7 @@ export const DirectSearch = (props: any) => {
       isDisabled={explorerSearchMetadata.isPolling}
     >
       {queryLang}
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const stopPollingWithStatus = (status: DirectQueryLoadingStatus | undefined) => {
@@ -409,7 +410,7 @@ export const DirectSearch = (props: any) => {
         </EuiFlexItem>
         <EuiFlexItem grow={false} />
         <EuiFlexItem className="euiFlexItem--flexGrowZero event-date-picker" grow={false}>
-          <EuiButton
+          <EuiSmallButton
             color="success"
             onClick={() => {
               onQuerySearch(queryLang);
@@ -418,7 +419,7 @@ export const DirectSearch = (props: any) => {
             isDisabled={explorerSearchMetadata.isPolling}
           >
             Search
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
 
         {showSaveButton && searchBarConfigs[selectedSubTabId]?.showSaveButton && (

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -6,6 +6,7 @@
 import '@algolia/autocomplete-theme-classic';
 import {
   EuiBadge,
+  EuiSmallButton,
   EuiButton,
   EuiButtonEmpty,
   EuiComboBox,
@@ -176,7 +177,7 @@ export const Search = (props: any) => {
   }
 
   const Savebutton = (
-    <EuiButton
+    <EuiSmallButton
       iconSide="right"
       onClick={() => {
         setIsSavePanelOpen((staleState) => {
@@ -187,7 +188,7 @@ export const Search = (props: any) => {
       iconType="arrowDown"
     >
       Save
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const liveButton = (
@@ -322,9 +323,9 @@ export const Search = (props: any) => {
   };
 
   const languagePopOverButton = (
-    <EuiButton iconType="arrowDown" iconSide="right" onClick={onLanguagePopoverClick} color="text">
+    <EuiSmallButton iconType="arrowDown" iconSide="right" onClick={onLanguagePopoverClick} color="text">
       {queryLang}
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const redirectToDiscover = () => {
@@ -462,7 +463,7 @@ export const Search = (props: any) => {
             {!showQueryArea && (
               <EuiFlexItem grow={false}>
                 <EuiToolTip position="bottom" content={needsUpdate ? 'Click to apply' : false}>
-                  <EuiButton
+                  <EuiSmallButton
                     color={needsUpdate ? 'success' : 'primary'}
                     iconType={needsUpdate ? 'kqlFunction' : 'play'}
                     fill
@@ -470,7 +471,7 @@ export const Search = (props: any) => {
                     data-test-subj="superDatePickerApplyTimeButton" // mimic actual timepicker button
                   >
                     {needsUpdate ? 'Update' : 'Run'}
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiToolTip>
               </EuiFlexItem>
             )}

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -9,7 +9,7 @@ import {
   EuiSmallButton,
   EuiButton,
   EuiButtonEmpty,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -373,7 +373,7 @@ export const Search = (props: any) => {
                 </EuiFlexItem>
                 {coreRefs.queryAssistEnabled && (
                   <EuiFlexItem>
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       placeholder="Select an index"
                       isClearable={false}
                       prepend={<EuiText>Index</EuiText>}

--- a/public/components/common/search/searchindex.tsx
+++ b/public/components/common/search/searchindex.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiComboBox } from '@elastic/eui';
+import { EuiCompressedComboBox } from '@elastic/eui';
 import React, { useState, useEffect, memo } from 'react';
 
 
@@ -50,7 +50,7 @@ export function SearchIndex(options: Fetch) {
   };
 
   return (
-    <EuiComboBox
+    <EuiCompressedComboBox
       placeholder="Select one or more index"
       options={indicesFromBackend}
       selectedOptions={selectedOptions}

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -342,9 +342,9 @@ export const CustomPanelTable = ({
         <EuiPageBody component="div">
           <EuiPageHeader>
             <EuiPageHeaderSection>
-              <EuiTitle size="l">
+              <EuiText size="s">
                 <h1>Observability dashboards</h1>
-              </EuiTitle>
+              </EuiText>
             </EuiPageHeaderSection>
           </EuiPageHeader>
           <EuiPageContent id="customPanelArea">
@@ -374,11 +374,15 @@ export const CustomPanelTable = ({
                       isOpen={isActionsPopoverOpen}
                       closePopover={() => setIsActionsPopoverOpen(false)}
                     >
-                      <EuiContextMenuPanel items={popoverItems()} />
+                      <EuiContextMenuPanel items={popoverItems()} size="s" />
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiSmallButton fill href="#/create" data-test-subj="customPanels__createNewPanels">
+                    <EuiSmallButton
+                      fill
+                      href="#/create"
+                      data-test-subj="customPanels__createNewPanels"
+                    >
                       Create Dashboard
                     </EuiSmallButton>
                   </EuiFlexItem>

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -9,7 +9,7 @@ import {
   EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -388,7 +388,7 @@ export const CustomPanelTable = ({
             <EuiHorizontalRule margin="m" />
             {customPanels.length > 0 ? (
               <>
-                <EuiFieldSearch
+                <EuiCompressedFieldSearch
                   fullWidth
                   data-test-subj="operationalPanelSearchBar"
                   placeholder="Search Observability Dashboard name"

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiBreadcrumb,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFieldSearch,
@@ -254,14 +254,14 @@ export const CustomPanelTable = ({
   };
 
   const popoverButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="operationalPanelsActionsButton"
       iconType="arrowDown"
       iconSide="right"
       onClick={() => setIsActionsPopoverOpen(!isActionsPopoverOpen)}
     >
       Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const popoverItems = (): ReactElement[] => [
@@ -378,9 +378,9 @@ export const CustomPanelTable = ({
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton fill href="#/create" data-test-subj="customPanels__createNewPanels">
+                    <EuiSmallButton fill href="#/create" data-test-subj="customPanels__createNewPanels">
                       Create Dashboard
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>
@@ -440,18 +440,18 @@ export const CustomPanelTable = ({
                 <EuiSpacer size="m" />
                 <EuiFlexGroup justifyContent="center">
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="customPanels__emptyCreateNewPanels"
                       fullWidth={false}
                       href="#/create"
                     >
                       Create Dashboard
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton fullWidth={false} onClick={() => addSampledata()}>
+                    <EuiSmallButton fullWidth={false} onClick={() => addSampledata()}>
                       Add samples
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer size="xxl" />

--- a/public/components/custom_panels/custom_panel_view.tsx
+++ b/public/components/custom_panels/custom_panel_view.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiBreadcrumb,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
@@ -454,47 +454,47 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
   };
 
   const cancelButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="cancelPanelButton"
       iconType="cross"
       color="danger"
       onClick={() => editPanel('cancel')}
     >
       Cancel
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const saveButton = (
-    <EuiButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
+    <EuiSmallButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
       Save
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const editButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="editPanelButton"
       iconType="pencil"
       onClick={() => editPanel('edit')}
       disabled={editDisabled}
     >
       Edit
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const addButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="addVisualizationButton"
       iconType="plusInCircle"
       onClick={onAddClick}
       isDisabled={addVizDisabled}
     >
       Add
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   // Panel Actions Button
   const panelActionsButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="panelActionContextMenu"
       iconType="arrowDown"
       iconSide="right"
@@ -502,7 +502,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
       disabled={addVizDisabled}
     >
       Dashboard Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   let flyout;

--- a/public/components/custom_panels/custom_panel_view.tsx
+++ b/public/components/custom_panels/custom_panel_view.tsx
@@ -21,9 +21,9 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiCompressedSuperDatePicker,
-  EuiTitle,
   OnTimeChangeProps,
   ShortDate,
+  EuiText,
 } from '@elastic/eui';
 import last from 'lodash/last';
 import isEmpty from 'lodash/isEmpty';
@@ -465,7 +465,11 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
   );
 
   const saveButton = (
-    <EuiSmallButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
+    <EuiSmallButton
+      data-test-subj="savePanelButton"
+      iconType="save"
+      onClick={() => editPanel('save')}
+    >
       Save
     </EuiSmallButton>
   );
@@ -612,9 +616,9 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
             {appPanel || (
               <>
                 <EuiPageHeaderSection>
-                  <EuiTitle size="l">
+                  <EuiText size="s">
                     <h1 data-test-subj="panelNameHeader">{openPanelName}</h1>
-                  </EuiTitle>
+                  </EuiText>
                   <EuiFlexItem>
                     <EuiSpacer size="s" />
                   </EuiFlexItem>
@@ -638,7 +642,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
                         isOpen={panelsMenuPopover}
                         closePopover={() => setPanelsMenuPopover(false)}
                       >
-                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} />
+                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} size="s" />
                       </EuiPopover>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/public/components/custom_panels/custom_panel_view.tsx
+++ b/public/components/custom_panels/custom_panel_view.tsx
@@ -20,7 +20,7 @@ import {
   EuiPageHeaderSection,
   EuiPopover,
   EuiSpacer,
-  EuiSuperDatePicker,
+  EuiCompressedSuperDatePicker,
   EuiTitle,
   OnTimeChangeProps,
   ShortDate,
@@ -683,7 +683,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiSuperDatePicker
+                <EuiCompressedSuperDatePicker
                   dateFormat={uiSettingsService.get('dateFormat')}
                   start={startTime}
                   end={endTime}

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -7,7 +7,7 @@
 
 import {
   EuiBreadcrumb,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
@@ -364,47 +364,47 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
   };
 
   const cancelButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="cancelPanelButton"
       iconType="cross"
       color="danger"
       onClick={() => editPanel('cancel')}
     >
       Cancel
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const saveButton = (
-    <EuiButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
+    <EuiSmallButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
       Save
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const editButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="editPanelButton"
       iconType="pencil"
       onClick={() => editPanel('edit')}
       disabled={editDisabled}
     >
       Edit
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const addButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="addVisualizationButton"
       iconType="plusInCircle"
       onClick={onAddClick}
       isDisabled={addVizDisabled}
     >
       Add
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   // Panel Actions Button
   const panelActionsButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="panelActionContextMenu"
       iconType="arrowDown"
       iconSide="right"
@@ -412,7 +412,7 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
       disabled={addVizDisabled}
     >
       Dashboard Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const addVisualizationToCurrentPanel = async ({

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -21,7 +21,7 @@ import {
   EuiPageHeaderSection,
   EuiPopover,
   EuiSpacer,
-  EuiSuperDatePicker,
+  EuiCompressedSuperDatePicker,
   EuiTitle,
   OnTimeChangeProps,
   ShortDate,
@@ -634,7 +634,7 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
                 />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiSuperDatePicker
+                <EuiCompressedSuperDatePicker
                   dateFormat={uiSettingsService.get('dateFormat')}
                   start={panel.timeRange.from}
                   end={panel.timeRange.to}

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -22,9 +22,9 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiCompressedSuperDatePicker,
-  EuiTitle,
   OnTimeChangeProps,
   ShortDate,
+  EuiText,
 } from '@elastic/eui';
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
 import last from 'lodash/last';
@@ -375,7 +375,11 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
   );
 
   const saveButton = (
-    <EuiSmallButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
+    <EuiSmallButton
+      data-test-subj="savePanelButton"
+      iconType="save"
+      onClick={() => editPanel('save')}
+    >
       Save
     </EuiSmallButton>
   );
@@ -562,9 +566,9 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
             {appPanel || (
               <>
                 <EuiPageHeaderSection>
-                  <EuiTitle size="l">
+                  <EuiText size="s">
                     <h1 data-test-subj="panelNameHeader">{panel?.title}</h1>
-                  </EuiTitle>
+                  </EuiText>
                   <EuiFlexItem>
                     <EuiSpacer size="s" />
                   </EuiFlexItem>
@@ -587,7 +591,7 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
                         isOpen={panelsMenuPopover}
                         closePopover={() => setPanelsMenuPopover(false)}
                       >
-                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} />
+                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} size="s" />
                       </EuiPopover>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/public/components/custom_panels/helpers/add_visualization_popover.tsx
+++ b/public/components/custom_panels/helpers/add_visualization_popover.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import { EuiSmallButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import React, { useState } from 'react';
 import {
   CREATE_TAB_PARAM,
@@ -67,7 +67,7 @@ export const AddVisualizationPopover = ({
   };
 
   const addVisualizationButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="addVisualizationButton"
       iconType="arrowDown"
       iconSide="right"
@@ -75,7 +75,7 @@ export const AddVisualizationPopover = ({
       onClick={onPopoverClick}
     >
       Add visualization
-    </EuiButton>
+    </EuiSmallButton>
   );
   return (
     <EuiPopover

--- a/public/components/custom_panels/helpers/add_visualization_popover.tsx
+++ b/public/components/custom_panels/helpers/add_visualization_popover.tsx
@@ -86,7 +86,7 @@ export const AddVisualizationPopover = ({
       panelPaddingSize="none"
       anchorPosition="downLeft"
     >
-      <EuiContextMenu initialPanelId={0} panels={getVizContextPanels()} />
+      <EuiContextMenu initialPanelId={0} panels={getVizContextPanels()} size="s" />
     </EuiPopover>
   );
 };

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -16,6 +16,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiSmallButton,
+  EuiText,
 } from '@elastic/eui';
 
 /*
@@ -71,7 +72,11 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={closeModal} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{titletxt}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{titletxt}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSmallButton,
 } from '@elastic/eui';
 
@@ -77,7 +77,7 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
         <EuiModalBody>
           <EuiForm>
             <EuiCompressedFormRow label={labelTxt} helpText={helpText}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="customModalFieldText"
                 name="input"
                 value={value}

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiSmallButton,
 } from '@elastic/eui';
@@ -76,14 +76,14 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
 
         <EuiModalBody>
           <EuiForm>
-            <EuiFormRow label={labelTxt} helpText={helpText}>
+            <EuiCompressedFormRow label={labelTxt} helpText={helpText}>
               <EuiFieldText
                 data-test-subj="customModalFieldText"
                 name="input"
                 value={value}
                 onChange={(e) => onChange(e)}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiModalBody>
 

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -15,7 +15,7 @@ import {
   EuiOverlayMask,
   EuiFormRow,
   EuiFieldText,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 
 /*
@@ -90,17 +90,17 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
         <EuiModalFooter>
           <EuiButtonEmpty onClick={closeModal}>{btn1txt}</EuiButtonEmpty>
           {optionalArgs === undefined ? (
-            <EuiButton data-test-subj="runModalButton" onClick={() => runModal(value)} fill>
+            <EuiSmallButton data-test-subj="runModalButton" onClick={() => runModal(value)} fill>
               {btn2txt}
-            </EuiButton>
+            </EuiSmallButton>
           ) : (
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="runModalButton"
               onClick={() => runModal(value, ...optionalArgs)}
               fill
             >
               {btn2txt}
-            </EuiButton>
+            </EuiSmallButton>
           )}
         </EuiModalFooter>
       </EuiModal>

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiForm,
   EuiModal,
   EuiModalBody,
@@ -88,7 +88,7 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={closeModal}>{btn1txt}</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={closeModal}>{btn1txt}</EuiSmallButtonEmpty>
           {optionalArgs === undefined ? (
             <EuiSmallButton data-test-subj="runModalButton" onClick={() => runModal(value)} fill>
               {btn2txt}

--- a/public/components/custom_panels/helpers/modal_containers.tsx
+++ b/public/components/custom_panels/helpers/modal_containers.tsx
@@ -11,7 +11,7 @@ import {
   EuiButtonEmpty,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,

--- a/public/components/custom_panels/helpers/modal_containers.tsx
+++ b/public/components/custom_panels/helpers/modal_containers.tsx
@@ -3,23 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from 'react';
-import {
-  EuiOverlayMask,
-  EuiConfirmModal,
-  EuiButton,
-  EuiButtonEmpty,
-  EuiFieldText,
-  EuiForm,
-  EuiCompressedFormRow,
-  EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiText,
-  EuiSpacer,
-} from '@elastic/eui';
+import React from 'react';
+import { EuiOverlayMask, EuiConfirmModal } from '@elastic/eui';
 import { CustomInputModal } from './custom_input_modal';
 
 /* The file contains helper functions for modal layouts

--- a/public/components/custom_panels/helpers/modal_containers.tsx
+++ b/public/components/custom_panels/helpers/modal_containers.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import {
   EuiOverlayMask,
   EuiConfirmModal,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiForm,

--- a/public/components/custom_panels/helpers/modal_containers.tsx
+++ b/public/components/custom_panels/helpers/modal_containers.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import {
   EuiOverlayMask,
   EuiConfirmModal,
-  EuiSmallButton,
+  EuiButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiForm,

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCodeBlock,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -379,7 +379,7 @@ export const VisualizationContainer = ({
               ) : (
                 <EuiPopover
                   button={
-                    <EuiButtonIcon
+                    <EuiSmallButtonIcon
                       aria-label="actionMenuButton"
                       iconType="boxesHorizontal"
                       onClick={onActionsMenuClick}

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiCodeBlock,
   EuiContextMenuItem,
@@ -145,9 +145,9 @@ export const VisualizationContainer = ({
           </EuiModalBody>
 
           <EuiModalFooter>
-            <EuiButton onClick={closeModal} fill>
+            <EuiSmallButton onClick={closeModal} fill>
               Close
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       );
@@ -169,9 +169,9 @@ export const VisualizationContainer = ({
           </EuiModalBody>
 
           <EuiModalFooter>
-            <EuiButton onClick={closeModal} fill>
+            <EuiSmallButton onClick={closeModal} fill>
               Close
-            </EuiButton>
+            </EuiSmallButton>
           </EuiModalFooter>
         </EuiModal>
       );
@@ -320,14 +320,14 @@ export const VisualizationContainer = ({
               <p>{isError.errorMessage}</p>
             </EuiText>
             {isError.hasOwnProperty('errorDetails') && isError.errorDetails !== '' ? (
-              <EuiButton
+              <EuiSmallButton
                 className="viz-error-btn"
                 color="danger"
                 onClick={() => showModal('errorModal')}
                 size="s"
               >
                 See error details
-              </EuiButton>
+              </EuiSmallButton>
             ) : (
               <></>
             )}

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -132,12 +132,16 @@ export const VisualizationContainer = ({
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <h1>{visualizationMetaData.name}</h1>
+              <EuiText size="s">
+                <h2>{visualizationMetaData.name}</h2>
+              </EuiText>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
 
           <EuiModalBody>
-            This PPL Query is generated in runtime from selected data source
+            <EuiText size="s">
+              This PPL Query is generated in runtime from selected data source
+            </EuiText>
             <EuiSpacer />
             <EuiCodeBlock language="html" isCopyable>
               {visualizationMetaData.query}
@@ -156,12 +160,14 @@ export const VisualizationContainer = ({
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <h1>{isError.errorMessage}</h1>
+              <EuiText size="s">
+                <h2>{isError.errorMessage}</h2>
+              </EuiText>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
 
           <EuiModalBody>
-            Error Details
+            <EuiText size="s">Error Details</EuiText>
             <EuiSpacer />
             <EuiCodeBlock language="html" isCopyable>
               {isError.errorDetails}
@@ -388,10 +394,12 @@ export const VisualizationContainer = ({
                   isOpen={isPopoverOpen}
                   closePopover={closeActionsMenu}
                   anchorPosition="downLeft"
+                  panelPaddingSize="none"
                 >
                   <EuiContextMenuPanel
                     items={popoverPanel}
                     data-test-subj="panelViz__popoverPanel"
+                    size="s"
                   />
                 </EuiPopover>
               )}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCallOut,
   EuiCodeBlock,
   EuiDatePicker,
@@ -306,7 +306,7 @@ export const VisaulizationFlyout = ({
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label="refreshPreview"
                 iconType="refresh"
                 onClick={onRefreshPreview}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -28,7 +28,6 @@ import {
   EuiSelectOption,
   EuiSpacer,
   EuiText,
-  EuiTitle,
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
@@ -133,12 +132,14 @@ export const VisaulizationFlyout = ({
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <h1>{isPreviewError.errorMessage}</h1>
+            <EuiText size="s">
+              <h2>{isPreviewError.errorMessage}</h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          Error Details
+          <EuiText size="s">Error Details</EuiText>
           <EuiSpacer />
           <EuiCodeBlock language="html" isCopyable>
             {isPreviewError.errorDetails}
@@ -267,11 +268,11 @@ export const VisaulizationFlyout = ({
 
   const flyoutHeader = (
     <EuiFlyoutHeader hasBorder>
-      <EuiTitle size="m">
+      <EuiText size="s">
         <h2 id="addVisualizationFlyout">
           {isFlyoutReplacement ? 'Replace visualization' : 'Select existing visualization'}
         </h2>
-      </EuiTitle>
+      </EuiText>
     </EuiFlyoutHeader>
   );
 

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiCallOut,
   EuiCodeBlock,
@@ -146,9 +146,9 @@ export const VisaulizationFlyout = ({
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButton onClick={closeModal} fill>
+          <EuiSmallButton onClick={closeModal} fill>
             Close
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     );
@@ -329,14 +329,14 @@ export const VisaulizationFlyout = ({
     <EuiFlyoutFooter>
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiButton data-test-subj="closeFlyoutButton" onClick={closeFlyout}>
+          <EuiSmallButton data-test-subj="closeFlyoutButton" onClick={closeFlyout}>
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton data-test-subj="addFlyoutButton" onClick={addVisualization} fill>
+          <EuiSmallButton data-test-subj="addFlyoutButton" onClick={addVisualization} fill>
             Add
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlyoutFooter>
@@ -391,9 +391,9 @@ export const VisaulizationFlyout = ({
                 </EuiText>
                 {isPreviewError.hasOwnProperty('errorDetails') &&
                 isPreviewError.errorDetails !== '' ? (
-                  <EuiButton color="danger" onClick={() => showModal('errorModal')} size="s">
+                  <EuiSmallButton color="danger" onClick={() => showModal('errorModal')} size="s">
                     See error details
-                  </EuiButton>
+                  </EuiSmallButton>
                 ) : (
                   <></>
                 )}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -24,7 +24,7 @@ import {
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
   EuiSpacer,
   EuiText,
@@ -291,7 +291,7 @@ export const VisaulizationFlyout = ({
         <>
           <EuiSpacer size="s" />
           <EuiCompressedFormRow label="Visualization name">
-            <EuiSelect
+            <EuiCompressedSelect
               hasNoInitialSelection
               onChange={(e) => onChangeSelection(e)}
               options={visualizationOptions}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiIcon,
   EuiLoadingChart,
   EuiModal,
@@ -235,7 +235,7 @@ export const VisaulizationFlyout = ({
       content="Picker is disabled. Please edit date/time from panel"
       display="block"
     >
-      <EuiFormRow label="Panel Time Range" fullWidth>
+      <EuiCompressedFormRow label="Panel Time Range" fullWidth>
         <EuiDatePickerRange
           className="date-picker-preview"
           fullWidth
@@ -261,7 +261,7 @@ export const VisaulizationFlyout = ({
             />
           }
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiToolTip>
   );
 
@@ -290,14 +290,14 @@ export const VisaulizationFlyout = ({
       <EuiFlyoutBody>
         <>
           <EuiSpacer size="s" />
-          <EuiFormRow label="Visualization name">
+          <EuiCompressedFormRow label="Visualization name">
             <EuiSelect
               hasNoInitialSelection
               onChange={(e) => onChangeSelection(e)}
               options={visualizationOptions}
               value={selectValue}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="l" />
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem grow={false}>

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCallOut,
   EuiCodeBlock,
   EuiDatePicker,
@@ -288,7 +288,7 @@ export const VisaulizationFlyoutSO = ({
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label="refreshPreview"
                 iconType="refresh"
                 onClick={onRefreshPreview}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -24,7 +24,7 @@ import {
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSelectOption,
   EuiSpacer,
   EuiText,
@@ -273,7 +273,7 @@ export const VisaulizationFlyoutSO = ({
         <>
           <EuiSpacer size="s" />
           <EuiCompressedFormRow label="Visualization name">
-            <EuiSelect
+            <EuiCompressedSelect
               hasNoInitialSelection
               onChange={(e) => onChangeSelection(e)}
               options={visualizationOptions}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiIcon,
   EuiLoadingChart,
   EuiModal,
@@ -210,7 +210,7 @@ export const VisaulizationFlyoutSO = ({
       content="Picker is disabled. Please edit date/time from panel"
       display="block"
     >
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Panel Time Range"
         fullWidth
         isInvalid={startDate > endDate}
@@ -243,7 +243,7 @@ export const VisaulizationFlyoutSO = ({
             />
           }
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiToolTip>
   );
 
@@ -272,14 +272,14 @@ export const VisaulizationFlyoutSO = ({
       <EuiFlyoutBody>
         <>
           <EuiSpacer size="s" />
-          <EuiFormRow label="Visualization name">
+          <EuiCompressedFormRow label="Visualization name">
             <EuiSelect
               hasNoInitialSelection
               onChange={(e) => onChangeSelection(e)}
               options={visualizationOptions}
               value={selectValue}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer size="l" />
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem grow={false}>

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiCallOut,
   EuiCodeBlock,
@@ -146,9 +146,9 @@ export const VisaulizationFlyoutSO = ({
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButton onClick={closeModal} fill>
+          <EuiSmallButton onClick={closeModal} fill>
             Close
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     );
@@ -311,14 +311,14 @@ export const VisaulizationFlyoutSO = ({
     <EuiFlyoutFooter>
       <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween">
         <EuiFlexItem grow={false}>
-          <EuiButton data-test-subj="closeFlyoutButton" onClick={closeFlyout}>
+          <EuiSmallButton data-test-subj="closeFlyoutButton" onClick={closeFlyout}>
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton data-test-subj="addFlyoutButton" onClick={addVisualization} fill>
+          <EuiSmallButton data-test-subj="addFlyoutButton" onClick={addVisualization} fill>
             Add
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlyoutFooter>
@@ -373,9 +373,9 @@ export const VisaulizationFlyoutSO = ({
                 </EuiText>
                 {isPreviewError.hasOwnProperty('errorDetails') &&
                 isPreviewError.errorDetails !== '' ? (
-                  <EuiButton color="danger" onClick={() => showModal('errorModal')} size="s">
+                  <EuiSmallButton color="danger" onClick={() => showModal('errorModal')} size="s">
                     See error details
-                  </EuiButton>
+                  </EuiSmallButton>
                 ) : (
                   <></>
                 )}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -28,7 +28,6 @@ import {
   EuiSelectOption,
   EuiSpacer,
   EuiText,
-  EuiTitle,
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
@@ -133,12 +132,14 @@ export const VisaulizationFlyoutSO = ({
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <h1>{isPreviewError.errorMessage}</h1>
+            <EuiText size="s">
+              <h2>{isPreviewError.errorMessage}</h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          Error Details
+          <EuiText size="s">Error Details</EuiText>
           <EuiSpacer />
           <EuiCodeBlock language="html" isCopyable>
             {isPreviewError.errorDetails}
@@ -249,11 +250,11 @@ export const VisaulizationFlyoutSO = ({
 
   const flyoutHeader = (
     <EuiFlyoutHeader hasBorder>
-      <EuiTitle size="m">
+      <EuiText size="s">
         <h2 id="addVisualizationFlyout">
           {isFlyoutReplacement ? 'Replace visualization' : 'Select existing visualization'}
         </h2>
-      </EuiTitle>
+      </EuiText>
     </EuiFlyoutHeader>
   );
 

--- a/public/components/datasources/components/manage/accelerations/acceleration_action_overlay.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_action_overlay.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiOverlayMask, EuiConfirmModal, EuiFormRow, EuiFieldText } from '@elastic/eui';
+import { EuiOverlayMask, EuiConfirmModal, EuiCompressedFormRow, EuiFieldText } from '@elastic/eui';
 import { CachedAcceleration } from '../../../../../../common/types/data_connections';
 import {
   ACC_DELETE_MSG,
@@ -79,13 +79,13 @@ export const AccelerationActionOverlay: React.FC<AccelerationActionOverlayProps>
       >
         <p>{description}</p>
         {actionType === 'vacuum' && (
-          <EuiFormRow label={`To confirm, type ${displayIndexName}`}>
+          <EuiCompressedFormRow label={`To confirm, type ${displayIndexName}`}>
             <EuiFieldText
               name="confirmationInput"
               value={confirmationInput}
               onChange={(e) => setConfirmationInput(e.target.value)}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </EuiConfirmModal>
     </EuiOverlayMask>

--- a/public/components/datasources/components/manage/accelerations/acceleration_action_overlay.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_action_overlay.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from 'react';
-import { EuiOverlayMask, EuiConfirmModal, EuiCompressedFormRow, EuiFieldText } from '@elastic/eui';
+import { EuiOverlayMask, EuiConfirmModal, EuiCompressedFormRow, EuiCompressedFieldText } from '@elastic/eui';
 import { CachedAcceleration } from '../../../../../../common/types/data_connections';
 import {
   ACC_DELETE_MSG,
@@ -80,7 +80,7 @@ export const AccelerationActionOverlay: React.FC<AccelerationActionOverlayProps>
         <p>{description}</p>
         {actionType === 'vacuum' && (
           <EuiCompressedFormRow label={`To confirm, type ${displayIndexName}`}>
-            <EuiFieldText
+            <EuiCompressedFieldText
               name="confirmationInput"
               value={confirmationInput}
               onChange={(e) => setConfirmationInput(e.target.value)}

--- a/public/components/datasources/components/manage/accelerations/acceleration_details_flyout.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_details_flyout.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyoutBody,
@@ -146,14 +146,14 @@ export const AccelerationDetailsFlyout = (props: AccelerationDetailsFlyoutProps)
 
   const DiscoverIcon = () => {
     return (
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         onClick={() => {
           onDiscoverIconClick(acceleration, dataSourceName);
           resetFlyout();
         }}
       >
         <EuiIcon type={'discoverApp'} size="m" />
-      </EuiButtonEmpty>
+      </EuiSmallButtonEmpty>
     );
   };
 
@@ -162,25 +162,25 @@ export const AccelerationDetailsFlyout = (props: AccelerationDetailsFlyoutProps)
       return null;
     }
     return (
-      <EuiButtonEmpty onClick={onSyncIconClickHandler}>
+      <EuiSmallButtonEmpty onClick={onSyncIconClickHandler}>
         <EuiIcon type="inputOutput" size="m" />
-      </EuiButtonEmpty>
+      </EuiSmallButtonEmpty>
     );
   };
 
   const DeleteIcon = () => {
     return (
-      <EuiButtonEmpty onClick={onDeleteIconClickHandler}>
+      <EuiSmallButtonEmpty onClick={onDeleteIconClickHandler}>
         <EuiIcon type="trash" size="m" />
-      </EuiButtonEmpty>
+      </EuiSmallButtonEmpty>
     );
   };
 
   const VacuumIcon = () => {
     return (
-      <EuiButtonEmpty onClick={onVacuumIconClickHandler}>
+      <EuiSmallButtonEmpty onClick={onVacuumIconClickHandler}>
         <EuiIcon type="broom" size="m" />
-      </EuiButtonEmpty>
+      </EuiSmallButtonEmpty>
     );
   };
 

--- a/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
+++ b/public/components/datasources/components/manage/accelerations/acceleration_table.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -143,7 +143,7 @@ export const AccelerationTable = ({
 
   const RefreshButton = () => {
     return (
-      <EuiButton
+      <EuiSmallButton
         onClick={handleRefresh}
         isLoading={
           isRefreshing ||
@@ -151,7 +151,7 @@ export const AccelerationTable = ({
         }
       >
         Refresh
-      </EuiButton>
+      </EuiSmallButton>
     );
   };
 

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -275,9 +275,9 @@ export const CreateAcceleration = ({
         <EuiFlyoutFooter>
           <EuiFlexGroup justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty iconType="cross" onClick={resetFlyout} flush="left">
+              <EuiSmallButtonEmpty iconType="cross" onClick={resetFlyout} flush="left">
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <CreateAccelerationButton

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration_button.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/create_acceleration_button.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton } from '@elastic/eui';
+import { EuiSmallButton } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { SANITIZE_QUERY_REGEX } from '../../../../../../../../common/constants/data_sources';
 import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
@@ -66,9 +66,9 @@ export const CreateAccelerationButton = ({
   }, [directqueryLoadStatus]);
 
   const createAccelerationBtn = (
-    <EuiButton onClick={createAcceleration} fill isLoading={isLoading}>
+    <EuiSmallButton onClick={createAcceleration} fill isLoading={isLoading}>
       {isLoading ? 'Creating acceleration' : 'Create acceleration'}
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   return createAccelerationBtn;

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/define_index_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/define_index_options.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -100,7 +100,7 @@ export const DefineIndexOptions = ({
           </EuiText>
         }
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           placeholder="Enter index name"
           value={accelerationFormData.accelerationIndexName}
           onChange={onChangeIndexName}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/define_index_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/define_index_options.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -51,9 +51,9 @@ export const DefineIndexOptions = ({
         </EuiFlexGroup>
       </EuiModalBody>
       <EuiModalFooter>
-        <EuiButton onClick={() => setModalComponent(<></>)} fill>
+        <EuiSmallButton onClick={() => setModalComponent(<></>)} fill>
           Close
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/define_index_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/define_index_options.tsx
@@ -8,7 +8,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiIconTip,
   EuiLink,
   EuiMarkdownFormat,
@@ -89,7 +89,7 @@ export const DefineIndexOptions = ({
 
   return (
     <>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Index name"
         helpText='Must be in lowercase letters, numbers and underscore. Spaces, commas, and characters -, :, ", *, +, /, \, |, ?, #, >, or < are not allowed. Prefix and suffix are added to the name of generated OpenSearch index.'
         isInvalid={hasError(accelerationFormData.formErrors, 'indexNameError')}
@@ -117,7 +117,7 @@ export const DefineIndexOptions = ({
             );
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       {modalComponent}
     </>
   );

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_advanced_settings.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_advanced_settings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiAccordion, EuiFieldNumber, EuiFormRow, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiAccordion, EuiFieldNumber, EuiCompressedFormRow, EuiSpacer, EuiText } from '@elastic/eui';
 import producer from 'immer';
 import React, { ChangeEvent, useState } from 'react';
 import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
@@ -56,7 +56,7 @@ export const IndexAdvancedSettings = ({
           setAccelerationFormData={setAccelerationFormData}
         />
       )}
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Number of primary shards"
         helpText="Specify the number of primary shards for the index. The number of primary shards cannot be changed after the index is created."
         isInvalid={hasError(accelerationFormData.formErrors, 'primaryShardsError')}
@@ -80,9 +80,9 @@ export const IndexAdvancedSettings = ({
           }}
           isInvalid={hasError(accelerationFormData.formErrors, 'primaryShardsError')}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       <EuiSpacer size="l" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Number of replicas"
         helpText="Specify the number of replicas each primary shard should have."
         isInvalid={hasError(accelerationFormData.formErrors, 'replicaShardsError')}
@@ -106,7 +106,7 @@ export const IndexAdvancedSettings = ({
           }}
           isInvalid={hasError(accelerationFormData.formErrors, 'replicaShardsError')}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiAccordion>
   );
 };

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_advanced_settings.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_advanced_settings.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiAccordion, EuiFieldNumber, EuiCompressedFormRow, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiAccordion, EuiCompressedFieldNumber, EuiCompressedFormRow, EuiSpacer, EuiText } from '@elastic/eui';
 import producer from 'immer';
 import React, { ChangeEvent, useState } from 'react';
 import { CreateAccelerationForm } from '../../../../../../../../common/types/data_connections';
@@ -62,7 +62,7 @@ export const IndexAdvancedSettings = ({
         isInvalid={hasError(accelerationFormData.formErrors, 'primaryShardsError')}
         error={accelerationFormData.formErrors.primaryShardsError}
       >
-        <EuiFieldNumber
+        <EuiCompressedFieldNumber
           placeholder="Number of primary shards"
           value={primaryShards}
           onChange={onChangePrimaryShards}
@@ -88,7 +88,7 @@ export const IndexAdvancedSettings = ({
         isInvalid={hasError(accelerationFormData.formErrors, 'replicaShardsError')}
         error={accelerationFormData.formErrors.replicaShardsError}
       >
-        <EuiFieldNumber
+        <EuiCompressedFieldNumber
           placeholder="Number of replicas"
           value={replicaCount}
           onChange={onChangeReplicaCount}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
@@ -4,8 +4,8 @@
  */
 
 import {
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiLink,
   EuiSelect,
@@ -183,7 +183,7 @@ export const IndexSettingOptions = ({
           isInvalid={hasError(accelerationFormData.formErrors, 'refreshIntervalError')}
           error={accelerationFormData.formErrors.refreshIntervalError}
         >
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             placeholder="Refresh increments"
             value={refreshWindow}
             onChange={onChangeRefreshWindow}
@@ -236,7 +236,7 @@ export const IndexSettingOptions = ({
             </EuiText>
           }
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             placeholder="s3://checkpoint/location"
             value={checkpoint}
             onChange={onChangeCheckpoint}
@@ -262,7 +262,7 @@ export const IndexSettingOptions = ({
           isInvalid={hasError(accelerationFormData.formErrors, 'watermarkDelayError')}
           error={accelerationFormData.formErrors.watermarkDelayError}
         >
-          <EuiFieldNumber
+          <EuiCompressedFieldNumber
             placeholder="Watermark delay interval"
             value={delayWindow}
             onChange={onChangeDelayWindow}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
@@ -6,7 +6,7 @@
 import {
   EuiFieldNumber,
   EuiFieldText,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSelect,
   EuiSpacer,
@@ -164,7 +164,7 @@ export const IndexSettingOptions = ({
           setAccelerationFormData={setAccelerationFormData}
         />
       )}
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Refresh type"
         helpText="Specify how often the index should refresh, which publishes the most recent changes and make them available for search."
       >
@@ -175,9 +175,9 @@ export const IndexSettingOptions = ({
           itemLayoutAlign="top"
           hasDividers
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       {refreshTypeSelected === 'autoInterval' && (
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Refresh increments"
           helpText="Specify how frequent the index gets updated when performing the refresh job."
           isInvalid={hasError(accelerationFormData.formErrors, 'refreshIntervalError')}
@@ -220,10 +220,10 @@ export const IndexSettingOptions = ({
               />
             }
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
       {refreshTypeSelected !== 'manual' && (
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Checkpoint location"
           helpText="The HDFS compatible file system location path for incremental refresh job checkpoint."
           isInvalid={hasError(accelerationFormData.formErrors, 'checkpointLocationError')}
@@ -253,10 +253,10 @@ export const IndexSettingOptions = ({
               );
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
       {accelerationFormData.accelerationIndexType === 'materialized' && (
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Watermark Delay"
           helpText="Data arrival delay for incremental refresh on a materialized view with aggregations"
           isInvalid={hasError(accelerationFormData.formErrors, 'watermarkDelayError')}
@@ -287,7 +287,7 @@ export const IndexSettingOptions = ({
               />
             }
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </>
   );

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_setting_options.tsx
@@ -8,9 +8,9 @@ import {
   EuiCompressedFieldText,
   EuiCompressedFormRow,
   EuiLink,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiText,
 } from '@elastic/eui';
 import producer from 'immer';
@@ -168,7 +168,7 @@ export const IndexSettingOptions = ({
         label="Refresh type"
         helpText="Specify how often the index should refresh, which publishes the most recent changes and make them available for search."
       >
-        <EuiSuperSelect
+        <EuiCompressedSuperSelect
           options={refreshOptions}
           valueOfSelected={refreshTypeSelected}
           onChange={onChangeRefreshType}
@@ -202,7 +202,7 @@ export const IndexSettingOptions = ({
               );
             }}
             append={
-              <EuiSelect
+              <EuiCompressedSelect
                 value={refreshInterval}
                 onChange={onChangeRefreshInterval}
                 options={ACCELERATION_REFRESH_TIME_INTERVAL}
@@ -280,7 +280,7 @@ export const IndexSettingOptions = ({
               );
             }}
             append={
-              <EuiSelect
+              <EuiCompressedSelect
                 value={delayInterval}
                 onChange={onChangeDelayInterval}
                 options={ACCELERATION_TIME_INTERVAL}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
@@ -7,7 +7,7 @@ import {
   EuiCompressedFormRow,
   EuiLink,
   EuiSpacer,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiSuperSelectOption,
   EuiText,
 } from '@elastic/eui';
@@ -131,7 +131,7 @@ export const IndexTypeSelector = ({
           </EuiText>
         }
       >
-        <EuiSuperSelect
+        <EuiCompressedSuperSelect
           options={superSelectOptions}
           valueOfSelected={value}
           onChange={onChangeSupeSelect}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/index_type_selector.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiSpacer,
   EuiSuperSelect,
@@ -120,7 +120,7 @@ export const IndexTypeSelector = ({
         <h3>Acceleration setting</h3>
       </EuiText>
       <EuiSpacer size="s" />
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Acceleration type"
         helpText="Select the type of acceleration according to your use case."
         labelAppend={
@@ -138,7 +138,7 @@ export const IndexTypeSelector = ({
           itemLayoutAlign="top"
           hasDividers
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 };

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/preview_sql_defintion.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiAccordion,
-  EuiButton,
+  EuiSmallButton,
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
@@ -103,9 +103,9 @@ export const PreviewSQLDefinition = ({
   };
 
   const queryWorkbenchButton = sqlWorkbenchPLuginExists ? (
-    <EuiButton iconSide="right" onClick={openInWorkbench}>
+    <EuiSmallButton iconSide="right" onClick={openInWorkbench}>
       Edit in Query Workbench
-    </EuiButton>
+    </EuiSmallButton>
   ) : (
     <></>
   );
@@ -132,18 +132,18 @@ export const PreviewSQLDefinition = ({
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             {isPreviewStale && isPreviewTriggered ? (
-              <EuiButton
+              <EuiSmallButton
                 iconType="kqlFunction"
                 iconSide="left"
                 color="success"
                 onClick={onClickPreview}
               >
                 Update preview
-              </EuiButton>
+              </EuiSmallButton>
             ) : (
-              <EuiButton color="success" onClick={onClickPreview}>
+              <EuiSmallButton color="success" onClick={onClickPreview}>
                 Generate preview
-              </EuiButton>
+              </EuiSmallButton>
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>{queryWorkbenchButton}</EuiFlexItem>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
@@ -11,7 +11,7 @@ import {
   EuiDescriptionListTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -219,7 +219,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
         <>
           {dataSourceDescription}
           <EuiSpacer size="m" />
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Database"
             helpText="Select the database that contains the tables you'd like to use."
             isInvalid={hasError(dataSourceFormData.formErrors, 'databaseError')}
@@ -263,8 +263,8 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
-          </EuiFormRow>
-          <EuiFormRow
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow
             label="Table"
             helpText={
               tableFieldsLoading
@@ -314,7 +314,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
     </>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/source_selector.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiDescriptionList,
   EuiDescriptionListDescription,
@@ -227,7 +227,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
           >
             <EuiFlexGroup gutterSize="s">
               <EuiFlexItem>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder="Select a database"
                   singleSelection={{ asPlainText: true }}
                   options={databases}
@@ -276,7 +276,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
           >
             <EuiFlexGroup gutterSize="s">
               <EuiFlexItem>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   placeholder="Select a table"
                   singleSelection={{ asPlainText: true }}
                   options={tables}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/covering_index/covering_index_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/covering_index/covering_index_builder.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiExpression,
   EuiFlexGroup,
@@ -85,7 +85,7 @@ export const CoveringIndexBuilder = ({
           >
             <>
               <EuiPopoverTitle paddingSize="l">Columns</EuiPopoverTitle>
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Select one or more options"
                 options={accelerationFormData.dataTableFields.map((x) => ({ label: x.fieldName }))}
                 selectedOptions={selectedOptions}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
@@ -6,7 +6,7 @@
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
   EuiFlexGroup,
@@ -116,7 +116,7 @@ export const AddColumnPopOver = ({
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiCompressedFormRow label="Function">
-              <EuiComboBox
+              <EuiCompressedComboBox
                 singleSelection={{ asPlainText: true }}
                 options={ACCELERATION_AGGREGRATION_FUNCTIONS}
                 selectedOptions={selectedFunction}
@@ -128,7 +128,7 @@ export const AddColumnPopOver = ({
           {selectedFunction[0].label !== 'window.start' && (
             <EuiFlexItem>
               <EuiCompressedFormRow label="Aggregation field">
-                <EuiComboBox
+                <EuiCompressedComboBox
                   singleSelection={{ asPlainText: true }}
                   options={[
                     { label: '*', disabled: selectedFunction[0].label !== 'count' },

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
@@ -8,7 +8,7 @@ import {
   EuiButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -144,7 +144,7 @@ export const AddColumnPopOver = ({
         </EuiFlexGroup>
         <EuiSpacer size="m" />
         <EuiCompressedFormRow label="Column alias - optional">
-          <EuiFieldText name="aliasField" onChange={onChangeAlias} />
+          <EuiCompressedFieldText name="aliasField" onChange={onChangeAlias} />
         </EuiCompressedFormRow>
       </>
       <EuiPopoverFooter>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
@@ -11,7 +11,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPopover,
   EuiPopoverFooter,
   EuiPopoverTitle,
@@ -115,7 +115,7 @@ export const AddColumnPopOver = ({
       <>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiFormRow label="Function">
+            <EuiCompressedFormRow label="Function">
               <EuiComboBox
                 singleSelection={{ asPlainText: true }}
                 options={ACCELERATION_AGGREGRATION_FUNCTIONS}
@@ -123,11 +123,11 @@ export const AddColumnPopOver = ({
                 onChange={setSelectedFunction}
                 isClearable={false}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           {selectedFunction[0].label !== 'window.start' && (
             <EuiFlexItem>
-              <EuiFormRow label="Aggregation field">
+              <EuiCompressedFormRow label="Aggregation field">
                 <EuiComboBox
                   singleSelection={{ asPlainText: true }}
                   options={[
@@ -138,14 +138,14 @@ export const AddColumnPopOver = ({
                   onChange={setSelectedField}
                   isClearable={false}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>
         <EuiSpacer size="m" />
-        <EuiFormRow label="Column alias - optional">
+        <EuiCompressedFormRow label="Column alias - optional">
           <EuiFieldText name="aliasField" onChange={onChangeAlias} />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
       <EuiPopoverFooter>
         <EuiButton size="s" fill onClick={onAddExpression}>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/add_column_popover.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiSmallButton,
+  EuiButton,
   EuiButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
@@ -10,7 +10,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPopover,
 } from '@elastic/eui';
 import producer from 'immer';
@@ -93,7 +93,7 @@ export const ColumnExpression = ({
             <>
               <EuiFlexGroup>
                 <EuiFlexItem grow={false}>
-                  <EuiFormRow label="Aggregate function">
+                  <EuiCompressedFormRow label="Aggregate function">
                     <EuiComboBox
                       singleSelection={{ asPlainText: true }}
                       options={ACCELERATION_AGGREGRATION_FUNCTIONS}
@@ -113,11 +113,11 @@ export const ColumnExpression = ({
                       }
                       isClearable={false}
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </EuiFlexItem>
                 {currentColumnExpressionValue.functionName !== 'window.start' && (
                   <EuiFlexItem grow={false}>
-                    <EuiFormRow label="Aggregation field">
+                    <EuiCompressedFormRow label="Aggregation field">
                       <EuiComboBox
                         singleSelection={{ asPlainText: true }}
                         options={[
@@ -145,7 +145,7 @@ export const ColumnExpression = ({
                         }
                         isClearable={false}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                 )}
               </EuiFlexGroup>
@@ -173,7 +173,7 @@ export const ColumnExpression = ({
               panelPaddingSize="s"
               anchorPosition="downLeft"
             >
-              <EuiFormRow label="Column alias">
+              <EuiCompressedFormRow label="Column alias">
                 <EuiFieldText
                   name="aliasField"
                   value={currentColumnExpressionValue.fieldAlias}
@@ -184,7 +184,7 @@ export const ColumnExpression = ({
                     )
                   }
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiPopover>
           </EuiFlexItem>
         )}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
@@ -7,7 +7,7 @@ import {
   EuiSmallButtonIcon,
   EuiComboBox,
   EuiExpression,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -174,7 +174,7 @@ export const ColumnExpression = ({
               anchorPosition="downLeft"
             >
               <EuiCompressedFormRow label="Column alias">
-                <EuiFieldText
+                <EuiCompressedFieldText
                   name="aliasField"
                   value={currentColumnExpressionValue.fieldAlias}
                   onChange={(e) =>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButtonIcon,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiExpression,
   EuiCompressedFieldText,
   EuiFlexGroup,
@@ -94,7 +94,7 @@ export const ColumnExpression = ({
               <EuiFlexGroup>
                 <EuiFlexItem grow={false}>
                   <EuiCompressedFormRow label="Aggregate function">
-                    <EuiComboBox
+                    <EuiCompressedComboBox
                       singleSelection={{ asPlainText: true }}
                       options={ACCELERATION_AGGREGRATION_FUNCTIONS}
                       selectedOptions={[
@@ -118,7 +118,7 @@ export const ColumnExpression = ({
                 {currentColumnExpressionValue.functionName !== 'window.start' && (
                   <EuiFlexItem grow={false}>
                     <EuiCompressedFormRow label="Aggregation field">
-                      <EuiComboBox
+                      <EuiCompressedComboBox
                         singleSelection={{ asPlainText: true }}
                         options={[
                           {

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/column_expression.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiComboBox,
   EuiExpression,
   EuiFieldText,
@@ -189,7 +189,7 @@ export const ColumnExpression = ({
           </EuiFlexItem>
         )}
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             color="danger"
             onClick={onDeleteColumnExpression}
             iconType="trash"

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiExpression,
   EuiCompressedFieldNumber,
@@ -94,7 +94,7 @@ export const GroupByTumbleExpression = ({
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiCompressedFormRow label="Time Field">
-              <EuiComboBox
+              <EuiCompressedComboBox
                 style={{ minWidth: '200px' }}
                 placeholder="Select one or more options"
                 singleSelection={{ asPlainText: true }}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
@@ -10,7 +10,7 @@ import {
   EuiFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPopover,
   EuiSelect,
 } from '@elastic/eui';
@@ -93,7 +93,7 @@ export const GroupByTumbleExpression = ({
       >
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiFormRow label="Time Field">
+            <EuiCompressedFormRow label="Time Field">
               <EuiComboBox
                 style={{ minWidth: '200px' }}
                 placeholder="Select one or more options"
@@ -105,25 +105,25 @@ export const GroupByTumbleExpression = ({
                 onChange={onChangeTimeField}
                 isClearable={false}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow label="Tumble Window">
+            <EuiCompressedFormRow label="Tumble Window">
               <EuiFieldNumber
                 value={groupbyValues.tumbleWindow}
                 onChange={onChangeTumbleWindow}
                 min={1}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow label="Tumble Interval">
+            <EuiCompressedFormRow label="Tumble Interval">
               <EuiSelect
                 value={groupbyValues.tumbleInterval}
                 onChange={onChangeTumbleInterval}
                 options={ACCELERATION_TIME_INTERVAL}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPopover>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
@@ -7,7 +7,7 @@ import {
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiExpression,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -109,7 +109,7 @@ export const GroupByTumbleExpression = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiCompressedFormRow label="Tumble Window">
-              <EuiFieldNumber
+              <EuiCompressedFieldNumber
                 value={groupbyValues.tumbleWindow}
                 onChange={onChangeTumbleWindow}
                 min={1}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/group_by_tumble_expression.tsx
@@ -12,7 +12,7 @@ import {
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiPopover,
-  EuiSelect,
+  EuiCompressedSelect,
 } from '@elastic/eui';
 import producer from 'immer';
 import React, { useState } from 'react';
@@ -118,7 +118,7 @@ export const GroupByTumbleExpression = ({
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiCompressedFormRow label="Tumble Interval">
-              <EuiSelect
+              <EuiCompressedSelect
                 value={groupbyValues.tumbleInterval}
                 onChange={onChangeTumbleInterval}
                 options={ACCELERATION_TIME_INTERVAL}

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/add_fields_modal.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/add_fields_modal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiInMemoryTable,
   EuiModal,
   EuiModalBody,
@@ -84,8 +84,8 @@ export const AddFieldsModal = ({
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButton onClick={() => setIsAddModalVisible(false)}>Cancel</EuiButton>
-        <EuiButton
+        <EuiSmallButton onClick={() => setIsAddModalVisible(false)}>Cancel</EuiSmallButton>
+        <EuiSmallButton
           onClick={() => {
             setAccelerationFormData(
               producer((accData) => {
@@ -105,7 +105,7 @@ export const AddFieldsModal = ({
           fill
         >
           Add
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/delete_fields_modal.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/delete_fields_modal.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiInMemoryTable,
   EuiModal,
   EuiModalBody,
@@ -83,8 +83,8 @@ export const DeleteFieldsModal = ({
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButton onClick={() => setIsDeleteModalVisible(false)}>Cancel</EuiButton>
-        <EuiButton
+        <EuiSmallButton onClick={() => setIsDeleteModalVisible(false)}>Cancel</EuiSmallButton>
+        <EuiSmallButton
           onClick={() => {
             setAccelerationFormData({
               ...accelerationFormData,
@@ -100,7 +100,7 @@ export const DeleteFieldsModal = ({
           fill
         >
           Delete
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/generate_fields.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/generate_fields.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiConfirmModal } from '@elastic/eui';
+import { EuiSmallButton, EuiConfirmModal } from '@elastic/eui';
 import producer from 'immer';
 import React, { useEffect, useState } from 'react';
 import {
@@ -118,9 +118,9 @@ export const GenerateFields = ({
 
   return (
     <>
-      <EuiButton onClick={onClickGenerate} isDisabled={isSkippingtableLoading}>
+      <EuiSmallButton onClick={onClickGenerate} isDisabled={isSkippingtableLoading}>
         {isGenerateRun ? 'Regenerate' : 'Generate'}
-      </EuiButton>
+      </EuiSmallButton>
       {replaceDefinitionModal}
     </>
   );

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/skipping_index_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/skipping_index_builder.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -178,21 +178,21 @@ export const SkippingIndexBuilder = ({
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 onClick={() => setIsAddModalVisible(true)}
                 isDisabled={isSkippingtableLoading}
               >
                 Add fields
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 onClick={() => setIsDeleteModalVisible(true)}
                 isDisabled={isSkippingtableLoading}
                 color="danger"
               >
                 Bulk delete
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/skipping_index_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/skipping_index_builder.tsx
@@ -9,7 +9,7 @@ import {
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -103,7 +103,7 @@ export const SkippingIndexBuilder = ({
     {
       name: 'Acceleration method',
       render: (item: SkippingIndexRowType) => (
-        <EuiSelect
+        <EuiCompressedSelect
           id="selectDocExample"
           options={
             item.dataType === SPARK_STRING_DATATYPE

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/skipping_index_builder.tsx
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/skipping_index_builder.tsx
@@ -6,7 +6,7 @@
 import {
   EuiBasicTable,
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSelect,
@@ -122,7 +122,7 @@ export const SkippingIndexBuilder = ({
       readOnly: isSkippingtableLoading,
       render: (item: SkippingIndexRowType) => {
         return (
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             onClick={() => {
               setAccelerationFormData({
                 ...accelerationFormData,

--- a/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
+++ b/public/components/datasources/components/manage/accelerations/utils/acceleration_utils.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiHealth } from '@elastic/eui';
+import { EuiSmallButton, EuiHealth } from '@elastic/eui';
 import React from 'react';
 import { DATA_SOURCE_TYPES } from '../../../../../../../common/constants/data_sources';
 import {
@@ -107,7 +107,7 @@ export const CreateAccelerationFlyoutButton = ({
 }) => {
   return (
     <>
-      <EuiButton
+      <EuiSmallButton
         onClick={() =>
           renderCreateAccelerationFlyout({
             dataSource: dataSourceName,
@@ -118,7 +118,7 @@ export const CreateAccelerationFlyoutButton = ({
         fill
       >
         Create acceleration
-      </EuiButton>
+      </EuiSmallButton>
     </>
   );
 };

--- a/public/components/datasources/components/manage/access_control_tab.tsx
+++ b/public/components/datasources/components/manage/access_control_tab.tsx
@@ -9,7 +9,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiHorizontalRule,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { EuiPanel } from '@elastic/eui';
@@ -107,12 +107,12 @@ export const AccessControlTab = (props: AccessControlTabProps) => {
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="createButton"
             onClick={() => setMode(mode === 'view' ? 'edit' : 'view')}
           >
             {mode === 'view' ? 'Edit' : 'Cancel'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiDescriptionList,
   EuiDescriptionListDescription,
   EuiDescriptionListTitle,
@@ -214,7 +214,7 @@ export const AssociatedObjectsDetailsFlyout = ({
         </p>
       }
       actions={
-        <EuiButton
+        <EuiSmallButton
           color="primary"
           fill
           onClick={() =>
@@ -232,7 +232,7 @@ export const AssociatedObjectsDetailsFlyout = ({
           {i18n.translate('datasources.associatedObjectsFlyout.createAccelerationButton', {
             defaultMessage: CREATE_ACCELERATION_DESCRIPTION,
           })}
-        </EuiButton>
+        </EuiSmallButton>
       }
     />
   );
@@ -341,7 +341,7 @@ export const AssociatedObjectsDetailsFlyout = ({
           </EuiFlexItem>
           {dataSourceType === 'SECURITYLAKE' && (
             <EuiFlexItem grow={false}>
-              <EuiButton onClick={onCreateAcceleration}>Create acceleration</EuiButton>
+              <EuiSmallButton onClick={onCreateAcceleration}>Create acceleration</EuiSmallButton>
             </EuiFlexItem>
           )}
         </EuiFlexGroup>

--- a/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
+++ b/public/components/datasources/components/manage/associated_objects/associated_objects_details_flyout.tsx
@@ -312,7 +312,7 @@ export const AssociatedObjectsDetailsFlyout = ({
       <EuiFlyoutHeader hasBorder>
         <EuiFlexGroup direction="row" alignItems="center" gutterSize="m">
           <EuiFlexItem>
-            <EuiText size="m">
+            <EuiText size="s">
               <h2 className="accsDetailFlyoutTitle">{tableDetail.name}</h2>
             </EuiText>
           </EuiFlexItem>

--- a/public/components/datasources/components/manage/associated_objects/utils/associated_objects_refresh_button.tsx
+++ b/public/components/datasources/components/manage/associated_objects/utils/associated_objects_refresh_button.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton } from '@elastic/eui';
+import { EuiSmallButton } from '@elastic/eui';
 import React from 'react';
 import { ASSC_OBJ_REFRESH_BTN } from './associated_objects_tab_utils';
 
@@ -18,8 +18,8 @@ export const AssociatedObjectsRefreshButton: React.FC<AssociatedObjectsRefreshBu
   const { isLoading, onClick } = props;
 
   return (
-    <EuiButton iconType="refresh" onClick={onClick} isLoading={isLoading} isDisabled={isLoading}>
+    <EuiSmallButton iconType="refresh" onClick={onClick} isLoading={isLoading} isDisabled={isLoading}>
       {ASSC_OBJ_REFRESH_BTN}
-    </EuiButton>
+    </EuiSmallButton>
   );
 };

--- a/public/components/datasources/components/manage/associated_objects/utils/associated_objects_tab_empty.tsx
+++ b/public/components/datasources/components/manage/associated_objects/utils/associated_objects_tab_empty.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import React from 'react';
 import { LoadCacheType } from '../../../../../../../common/types/data_connections';
 import { coreRefs } from '../../../../../../framework/core_refs';
@@ -17,13 +17,13 @@ export const AssociatedObjectsTabEmpty: React.FC<AssociatedObjectsTabEmptyProps>
   const { application } = coreRefs;
 
   const QueryWorkbenchButton = (
-    <EuiButton
+    <EuiSmallButton
       iconSide="right"
       onClick={() => application!.navigateToApp('opensearch-query-workbench')}
       iconType="popout"
     >
       Query Workbench
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   let titleText;

--- a/public/components/datasources/components/manage/data_connection.tsx
+++ b/public/components/datasources/components/manage/data_connection.tsx
@@ -18,7 +18,7 @@ import {
   EuiTabbedContent,
   EuiText,
   EuiTitle,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import escapeRegExp from 'lodash/escapeRegExp';
 import React, { useEffect, useState } from 'react';
@@ -327,12 +327,12 @@ export const DataConnection = (props: { dataSource: string }) => {
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
+                <EuiSmallButtonEmpty
                   iconType={'pencil'}
                   onClick={() => setSelectedTabId(accessControlTabId)}
                 >
                   Edit
-                </EuiButtonEmpty>
+                </EuiSmallButtonEmpty>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/public/components/datasources/components/manage/inactive_data_connection.tsx
+++ b/public/components/datasources/components/manage/inactive_data_connection.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiCallOut } from '@elastic/eui';
+import { EuiSmallButton, EuiCallOut } from '@elastic/eui';
 import React from 'react';
 import {
   DATACONNECTIONS_BASE,
@@ -45,9 +45,9 @@ export const InactiveDataConnectionCallout = ({
       <p>
         Associated objects and accelerations are not available while this connection is inactive.
       </p>
-      <EuiButton onClick={enableDataSource} color="warning">
+      <EuiSmallButton onClick={enableDataSource} color="warning">
         Enable connection
-      </EuiButton>
+      </EuiSmallButton>
     </EuiCallOut>
   );
 };

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -4,9 +4,8 @@
  */
 
 import {
-  EuiButton,
   EuiSmallButton,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -235,7 +234,7 @@ export const InstalledIntegrationsTable = ({
       <EuiSpacer />
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiFieldSearch
+          <EuiCompressedFieldSearch
             fullWidth
             placeholder="Search..."
             onChange={(queryEvent) => {

--- a/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
+++ b/public/components/datasources/components/manage/integrations/installed_integrations_table.tsx
@@ -5,6 +5,7 @@
 
 import {
   EuiButton,
+  EuiSmallButton,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
@@ -99,9 +100,9 @@ const AddIntegrationButton = ({
   toggleFlyout: () => void;
 }) => {
   return (
-    <EuiButton fill={fill} onClick={toggleFlyout}>
+    <EuiSmallButton fill={fill} onClick={toggleFlyout}>
       Add Integrations
-    </EuiButton>
+    </EuiSmallButton>
   );
 };
 

--- a/public/components/datasources/components/manage/manage_data_connections_description.tsx
+++ b/public/components/datasources/components/manage/manage_data_connections_description.tsx
@@ -9,7 +9,7 @@ import {
   EuiTitle,
   EuiHorizontalRule,
   EuiLink,
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
@@ -38,9 +38,9 @@ export const DataConnectionsDescription = (props: DataConnectionsDescriptionProp
           </>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton onClick={refresh} iconType="refresh">
+          <EuiSmallButton onClick={refresh} iconType="refresh">
             Refresh
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/public/components/datasources/components/new/auth_details.tsx
+++ b/public/components/datasources/components/new/auth_details.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCompressedFormRow, EuiFieldText, EuiFieldPassword } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCompressedFieldText, EuiCompressedFieldPassword } from '@elastic/eui';
 import { useState } from 'react';
 import React from 'react';
 import { AuthMethod } from '../../../../../common/constants/data_connections';
@@ -46,7 +46,7 @@ export const AuthDetails = (props: AuthDetailProps) => {
       return (
         <>
           <EuiCompressedFormRow label="Username">
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder={'Username'}
               value={username}
               onChange={(e) => setUsername(e.target.value)}
@@ -54,7 +54,7 @@ export const AuthDetails = (props: AuthDetailProps) => {
             />
           </EuiCompressedFormRow>
           <EuiCompressedFormRow label="Password">
-            <EuiFieldPassword
+            <EuiCompressedFieldPassword
               type={'dual'}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -67,7 +67,7 @@ export const AuthDetails = (props: AuthDetailProps) => {
       return (
         <>
           <EuiCompressedFormRow label="Auth Region">
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder="us-west-2"
               value={region}
               onBlur={(e) => {
@@ -79,7 +79,7 @@ export const AuthDetails = (props: AuthDetailProps) => {
             />
           </EuiCompressedFormRow>
           <EuiCompressedFormRow label="Access Key">
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder={'Access key placeholder'}
               value={accessKey}
               onChange={(e) => setAccessKey(e.target.value)}
@@ -87,7 +87,7 @@ export const AuthDetails = (props: AuthDetailProps) => {
             />
           </EuiCompressedFormRow>
           <EuiCompressedFormRow label="Secret Key">
-            <EuiFieldPassword
+            <EuiCompressedFieldPassword
               type={'dual'}
               value={secretKey}
               onChange={(e) => setSecretKey(e.target.value)}

--- a/public/components/datasources/components/new/auth_details.tsx
+++ b/public/components/datasources/components/new/auth_details.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiFormRow, EuiFieldText, EuiFieldPassword } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiFieldText, EuiFieldPassword } from '@elastic/eui';
 import { useState } from 'react';
 import React from 'react';
 import { AuthMethod } from '../../../../../common/constants/data_connections';
@@ -45,28 +45,28 @@ export const AuthDetails = (props: AuthDetailProps) => {
     case 'basicauth':
       return (
         <>
-          <EuiFormRow label="Username">
+          <EuiCompressedFormRow label="Username">
             <EuiFieldText
               placeholder={'Username'}
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               onBlur={(e) => setUsernameForRequest(e.target.value)}
             />
-          </EuiFormRow>
-          <EuiFormRow label="Password">
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow label="Password">
             <EuiFieldPassword
               type={'dual'}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               onBlur={(e) => setPasswordForRequest(e.target.value)}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       );
     case 'awssigv4':
       return (
         <>
-          <EuiFormRow label="Auth Region">
+          <EuiCompressedFormRow label="Auth Region">
             <EuiFieldText
               placeholder="us-west-2"
               value={region}
@@ -77,23 +77,23 @@ export const AuthDetails = (props: AuthDetailProps) => {
                 setRegion(e.target.value);
               }}
             />
-          </EuiFormRow>
-          <EuiFormRow label="Access Key">
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow label="Access Key">
             <EuiFieldText
               placeholder={'Access key placeholder'}
               value={accessKey}
               onChange={(e) => setAccessKey(e.target.value)}
               onBlur={(e) => setAccessKeyForRequest(e.target.value)}
             />
-          </EuiFormRow>
-          <EuiFormRow label="Secret Key">
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow label="Secret Key">
             <EuiFieldPassword
               type={'dual'}
               value={secretKey}
               onChange={(e) => setSecretKey(e.target.value)}
               onBlur={(e) => setSecretKeyForRequest(e.target.value)}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       );
     default:

--- a/public/components/datasources/components/new/configure_datasource.tsx
+++ b/public/components/datasources/components/new/configure_datasource.tsx
@@ -9,11 +9,11 @@ import {
   EuiPage,
   EuiPageBody,
   EuiSpacer,
-  EuiSmallButton,
+  EuiButton,
   EuiSteps,
   EuiPageSideBar,
   EuiBottomBar,
-  EuiSmallButtonEmpty,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ConfigureS3Datasource } from './configure_s3_datasource';
@@ -194,7 +194,7 @@ export function Configure(props: ConfigureDatasourceProps) {
       <EuiBottomBar>
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiSmallButtonEmpty
+            <EuiButtonEmpty
               onClick={() => {
                 window.location.hash = '#/new';
               }}
@@ -203,20 +203,20 @@ export function Configure(props: ConfigureDatasourceProps) {
               iconType="cross"
             >
               Cancel
-            </EuiSmallButtonEmpty>
+            </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiSmallButton
+            <EuiButton
               onClick={() => (page === 'review' ? setPage('configure') : {})}
               color="ghost"
               size="s"
               iconType="arrowLeft"
             >
               Previous
-            </EuiSmallButton>
+            </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiSmallButton
+            <EuiButton
               onClick={() => (page === 'review' ? createDatasource() : setPage('review'))}
               size="s"
               iconType="arrowRight"
@@ -225,7 +225,7 @@ export function Configure(props: ConfigureDatasourceProps) {
               {page === 'configure'
                 ? `Review Configuration`
                 : `Connect to ${DatasourceTypeToDisplayName[type]}`}
-            </EuiSmallButton>
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiBottomBar>

--- a/public/components/datasources/components/new/configure_datasource.tsx
+++ b/public/components/datasources/components/new/configure_datasource.tsx
@@ -9,7 +9,7 @@ import {
   EuiPage,
   EuiPageBody,
   EuiSpacer,
-  EuiButton,
+  EuiSmallButton,
   EuiSteps,
   EuiPageSideBar,
   EuiBottomBar,
@@ -206,17 +206,17 @@ export function Configure(props: ConfigureDatasourceProps) {
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               onClick={() => (page === 'review' ? setPage('configure') : {})}
               color="ghost"
               size="s"
               iconType="arrowLeft"
             >
               Previous
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               onClick={() => (page === 'review' ? createDatasource() : setPage('review'))}
               size="s"
               iconType="arrowRight"
@@ -225,7 +225,7 @@ export function Configure(props: ConfigureDatasourceProps) {
               {page === 'configure'
                 ? `Review Configuration`
                 : `Connect to ${DatasourceTypeToDisplayName[type]}`}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiBottomBar>

--- a/public/components/datasources/components/new/configure_datasource.tsx
+++ b/public/components/datasources/components/new/configure_datasource.tsx
@@ -13,7 +13,7 @@ import {
   EuiSteps,
   EuiPageSideBar,
   EuiBottomBar,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ConfigureS3Datasource } from './configure_s3_datasource';
@@ -194,7 +194,7 @@ export function Configure(props: ConfigureDatasourceProps) {
       <EuiBottomBar>
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               onClick={() => {
                 window.location.hash = '#/new';
               }}
@@ -203,7 +203,7 @@ export function Configure(props: ConfigureDatasourceProps) {
               iconType="cross"
             >
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton

--- a/public/components/datasources/components/new/configure_prometheus_datasource.tsx
+++ b/public/components/datasources/components/new/configure_prometheus_datasource.tsx
@@ -11,7 +11,7 @@ import {
   EuiLink,
   EuiCompressedFormRow,
   EuiCompressedFieldText,
-  EuiTextArea,
+  EuiCompressedTextArea,
   EuiCompressedSelect,
   EuiForm,
 } from '@elastic/eui';
@@ -113,7 +113,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
             setErrorForForm={setError}
           />
           <EuiCompressedFormRow label="Description - Optional">
-            <EuiTextArea
+            <EuiCompressedTextArea
               data-test-subj="data-source-description"
               placeholder="Placeholder"
               value={details}

--- a/public/components/datasources/components/new/configure_prometheus_datasource.tsx
+++ b/public/components/datasources/components/new/configure_prometheus_datasource.tsx
@@ -9,7 +9,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiLink,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiTextArea,
   EuiSelect,
@@ -113,7 +113,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
             currentError={error}
             setErrorForForm={setError}
           />
-          <EuiFormRow label="Description - Optional">
+          <EuiCompressedFormRow label="Description - Optional">
             <EuiTextArea
               data-test-subj="data-source-description"
               placeholder="Placeholder"
@@ -125,7 +125,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
                 setDetails(e.target.value);
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
 
           <EuiText>
@@ -133,7 +133,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
           </EuiText>
           <EuiSpacer size="m" />
 
-          <EuiFormRow label="Prometheus URI">
+          <EuiCompressedFormRow label="Prometheus URI">
             <>
               <EuiText size="xs">
                 <p>Enter the Prometheus URI endpoint.</p>
@@ -150,7 +150,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
                 }}
               />
             </>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
 
           <EuiText>
@@ -158,7 +158,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
           </EuiText>
           <EuiSpacer size="m" />
 
-          <EuiFormRow label="Authentication method">
+          <EuiCompressedFormRow label="Authentication method">
             <EuiSelect
               id="selectAuthMethod"
               options={authOptions}
@@ -167,7 +167,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
                 setAuthMethodForRequest(e.target.value as AuthMethod);
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <AuthDetails
             currentUsername={currentUsername}

--- a/public/components/datasources/components/new/configure_prometheus_datasource.tsx
+++ b/public/components/datasources/components/new/configure_prometheus_datasource.tsx
@@ -10,10 +10,9 @@ import {
   EuiText,
   EuiLink,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiTextArea,
   EuiSelect,
-  EuiFieldPassword,
   EuiForm,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -138,7 +137,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
               <EuiText size="xs">
                 <p>Enter the Prometheus URI endpoint.</p>
               </EuiText>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="Prometheus-URI"
                 placeholder="Prometheus URI"
                 value={store}

--- a/public/components/datasources/components/new/configure_prometheus_datasource.tsx
+++ b/public/components/datasources/components/new/configure_prometheus_datasource.tsx
@@ -12,7 +12,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiTextArea,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiForm,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -158,7 +158,7 @@ export const ConfigurePrometheusDatasource = (props: ConfigurePrometheusDatasour
           <EuiSpacer size="m" />
 
           <EuiCompressedFormRow label="Authentication method">
-            <EuiSelect
+            <EuiCompressedSelect
               id="selectAuthMethod"
               options={authOptions}
               value={currentAuthMethod}

--- a/public/components/datasources/components/new/configure_s3_datasource.tsx
+++ b/public/components/datasources/components/new/configure_s3_datasource.tsx
@@ -12,7 +12,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiTextArea,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiCallOut,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -191,7 +191,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
             <EuiText size="xs">
               <p>Authentication settings to access the index store.</p>
             </EuiText>
-            <EuiSelect
+            <EuiCompressedSelect
               id="selectAuthMethod"
               options={authOptions}
               value={currentAuthMethod}

--- a/public/components/datasources/components/new/configure_s3_datasource.tsx
+++ b/public/components/datasources/components/new/configure_s3_datasource.tsx
@@ -9,7 +9,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiLink,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiTextArea,
   EuiSelect,
@@ -107,7 +107,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
           currentError={error}
           setErrorForForm={setError}
         />
-        <EuiFormRow label="Description - Optional">
+        <EuiCompressedFormRow label="Description - Optional">
           <EuiTextArea
             placeholder="Describe data source"
             value={details}
@@ -118,7 +118,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
               setDetails(e.target.value);
             }}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <EuiSpacer />
 
         <EuiText>
@@ -126,7 +126,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
         </EuiText>
         <EuiSpacer size="m" />
 
-        <EuiFormRow label="Authentication Method">
+        <EuiCompressedFormRow label="Authentication Method">
           <>
             <EuiText size="xs">
               <p>
@@ -136,9 +136,9 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
             </EuiText>
             <EuiFieldText data-test-subj="authentication-method" value="IAM role" disabled />
           </>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
-        <EuiFormRow label="AWS Glue Data Catalog authentication ARN">
+        <EuiCompressedFormRow label="AWS Glue Data Catalog authentication ARN">
           <>
             <EuiText size="xs">
               <p>This should be the IAM role ARN</p>
@@ -155,7 +155,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
               }}
             />
           </>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
         <EuiSpacer />
 
@@ -164,7 +164,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
         </EuiText>
         <EuiSpacer size="m" />
 
-        <EuiFormRow label="AWS Glue Data Catalog index store URI">
+        <EuiCompressedFormRow label="AWS Glue Data Catalog index store URI">
           <>
             <EuiText size="xs">
               <p>
@@ -184,9 +184,9 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
               }}
             />
           </>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
 
-        <EuiFormRow label="AWS Glue Data Catalog index store authentication">
+        <EuiCompressedFormRow label="AWS Glue Data Catalog index store authentication">
           <>
             <EuiText size="xs">
               <p>Authentication settings to access the index store.</p>
@@ -200,7 +200,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
               }}
             />
           </>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         <AuthDetails
           currentUsername={currentUsername}
           setUsernameForRequest={setUsernameForRequest}

--- a/public/components/datasources/components/new/configure_s3_datasource.tsx
+++ b/public/components/datasources/components/new/configure_s3_datasource.tsx
@@ -10,7 +10,7 @@ import {
   EuiText,
   EuiLink,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiTextArea,
   EuiSelect,
   EuiCallOut,
@@ -134,7 +134,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
                 engine to connect to AWS Glue Data Catalog.
               </p>
             </EuiText>
-            <EuiFieldText data-test-subj="authentication-method" value="IAM role" disabled />
+            <EuiCompressedFieldText data-test-subj="authentication-method" value="IAM role" disabled />
           </>
         </EuiCompressedFormRow>
 
@@ -143,7 +143,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
             <EuiText size="xs">
               <p>This should be the IAM role ARN</p>
             </EuiText>
-            <EuiFieldText
+            <EuiCompressedFieldText
               data-test-subj="role-ARN"
               placeholder="Role ARN"
               value={arn}
@@ -172,7 +172,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
                 Catalog. This OpenSearch instance is used for writing index data back.
               </p>
             </EuiText>
-            <EuiFieldText
+            <EuiCompressedFieldText
               data-test-subj="index-URI"
               placeholder="Index store URI"
               value={store}

--- a/public/components/datasources/components/new/configure_s3_datasource.tsx
+++ b/public/components/datasources/components/new/configure_s3_datasource.tsx
@@ -11,7 +11,7 @@ import {
   EuiLink,
   EuiCompressedFormRow,
   EuiCompressedFieldText,
-  EuiTextArea,
+  EuiCompressedTextArea,
   EuiCompressedSelect,
   EuiCallOut,
 } from '@elastic/eui';
@@ -108,7 +108,7 @@ export const ConfigureS3Datasource = (props: ConfigureS3DatasourceProps) => {
           setErrorForForm={setError}
         />
         <EuiCompressedFormRow label="Description - Optional">
-          <EuiTextArea
+          <EuiCompressedTextArea
             placeholder="Describe data source"
             value={details}
             onBlur={(e) => {

--- a/public/components/datasources/components/new/name_row.tsx
+++ b/public/components/datasources/components/new/name_row.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiText, EuiCompressedFormRow, EuiFieldText } from '@elastic/eui';
+import { EuiText, EuiCompressedFormRow, EuiCompressedFieldText } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../../public/framework/core_refs';
 
@@ -52,7 +52,7 @@ export const NameRow = (props: ConfigureNameProps) => {
             and concise.
           </p>
         </EuiText>
-        <EuiFieldText
+        <EuiCompressedFieldText
           data-test-subj="name"
           placeholder="Title"
           value={name}

--- a/public/components/datasources/components/new/name_row.tsx
+++ b/public/components/datasources/components/new/name_row.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiText, EuiFormRow, EuiFieldText } from '@elastic/eui';
+import { EuiText, EuiCompressedFormRow, EuiFieldText } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../../public/framework/core_refs';
 
@@ -44,7 +44,7 @@ export const NameRow = (props: ConfigureNameProps) => {
   };
 
   return (
-    <EuiFormRow label="Data source name" isInvalid={currentError.length !== 0} error={currentError}>
+    <EuiCompressedFormRow label="Data source name" isInvalid={currentError.length !== 0} error={currentError}>
       <>
         <EuiText size="xs">
           <p>
@@ -63,6 +63,6 @@ export const NameRow = (props: ConfigureNameProps) => {
           isInvalid={currentError.length !== 0}
         />
       </>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 };

--- a/public/components/datasources/components/new/query_permissions.tsx
+++ b/public/components/datasources/components/new/query_permissions.tsx
@@ -7,7 +7,7 @@ import {
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiRadioGroup,
   EuiSpacer,
   EuiText,
@@ -43,7 +43,7 @@ export const QueryPermissionsConfiguration = (props: PermissionsConfigurationPro
         <EuiText size="xs">
           Select one or more OpenSearch roles that can query this data connection.
         </EuiText>
-        <EuiFormRow
+        <EuiCompressedFormRow
           isInvalid={selectedRoles.length === 0}
           error={
             selectedRoles.length === 0
@@ -60,7 +60,7 @@ export const QueryPermissionsConfiguration = (props: PermissionsConfigurationPro
             data-test-subj="query-permissions-combo-box"
             isInvalid={selectedRoles.length === 0}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </div>
     );
   };

--- a/public/components/datasources/components/new/query_permissions.tsx
+++ b/public/components/datasources/components/new/query_permissions.tsx
@@ -8,7 +8,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -80,7 +80,7 @@ export const QueryPermissionsConfiguration = (props: PermissionsConfigurationPro
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiRadioGroup
+          <EuiCompressedRadioGroup
             options={accessLevelOptions}
             idSelected={selectedAccessLevel}
             onChange={(id) => {

--- a/public/components/datasources/components/new/query_permissions.tsx
+++ b/public/components/datasources/components/new/query_permissions.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -51,7 +51,7 @@ export const QueryPermissionsConfiguration = (props: PermissionsConfigurationPro
               : undefined
           }
         >
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Select one or more options"
             options={roles}
             selectedOptions={selectedRoles}

--- a/public/components/datasources/components/new/review_prometheus_datasource_configuration.tsx
+++ b/public/components/datasources/components/new/review_prometheus_datasource_configuration.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiHorizontalRule,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import React from 'react';
 import { AuthMethod } from '../../../../../common/constants/data_connections';
@@ -53,7 +53,7 @@ export const ReviewPrometheusDatasource = (props: ConfigurePrometheusDatasourceP
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={goBack}>Edit</EuiButton>
+            <EuiSmallButton onClick={goBack}>Edit</EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiHorizontalRule />

--- a/public/components/datasources/components/new/review_s3_datasource_configuration.tsx
+++ b/public/components/datasources/components/new/review_s3_datasource_configuration.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiHorizontalRule,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import React from 'react';
 import { AuthMethod } from '../../../../../common/constants/data_connections';
@@ -53,7 +53,7 @@ export const ReviewS3Datasource = (props: ConfigureS3DatasourceProps) => {
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={goBack}>Edit</EuiButton>
+            <EuiSmallButton onClick={goBack}>Edit</EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiHorizontalRule />

--- a/public/components/datasources/components/no_access.tsx
+++ b/public/components/datasources/components/no_access.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiEmptyPrompt, EuiPage, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt, EuiPage, EuiText } from '@elastic/eui';
 import React from 'react';
 
 export const NoAccess = () => {
@@ -20,9 +20,9 @@ export const NoAccess = () => {
           </EuiText>
         }
         actions={
-          <EuiButton color="primary" fill onClick={() => (window.location.hash = '')}>
+          <EuiSmallButton color="primary" fill onClick={() => (window.location.hash = '')}>
             Return to data connections
-          </EuiButton>
+          </EuiSmallButton>
         }
       />
     </EuiPage>

--- a/public/components/event_analytics/explorer/accelerate_callout.tsx
+++ b/public/components/event_analytics/explorer/accelerate_callout.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiCallOut, EuiButtonEmpty, EuiLink, EuiSpacer } from '@elastic/eui';
+import { EuiCallOut, EuiSmallButtonEmpty, EuiLink, EuiSpacer } from '@elastic/eui';
 
 interface AccelerateCalloutProps {
   onCreateAcceleration: () => void;
@@ -22,7 +22,7 @@ export const AccelerateCallout = ({ onCreateAcceleration }: AccelerateCalloutPro
             Security Lake tables include acceleration with skipping index, but the query performance
             can be further improved with other types of accelerations.
           </span>
-          <EuiButtonEmpty onClick={onCreateAcceleration}>Create acceleration</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={onCreateAcceleration}>Create acceleration</EuiSmallButtonEmpty>
           <span>&nbsp;or&nbsp;</span>
           <EuiLink
             href="https://opensearch.org/docs/latest/dashboards/management/accelerate-external-data/"

--- a/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
+++ b/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiBasicTableColumn,
   EuiInMemoryTable,
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCopy,
@@ -328,9 +328,9 @@ export const TablesFlyout = ({
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButton color="primary" fill onClick={resetFlyout}>
+            <EuiSmallButton color="primary" fill onClick={resetFlyout}>
               Close
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>

--- a/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
+++ b/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
@@ -20,6 +20,7 @@ import {
   EuiFlexItem,
   EuiCopy,
   EuiSmallButtonIcon,
+  EuiText,
 } from '@elastic/eui';
 import {
   useLoadDatabasesToCache,
@@ -237,7 +238,11 @@ export const TablesFlyout = ({
             return (
               <EuiCopy textToCopy={`${dataSourceName}.${selectedDatabase}.${name}`}>
                 {(copy) => (
-                  <EuiSmallButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                  <EuiSmallButtonIcon
+                    aria-label="copy-button"
+                    onClick={copy}
+                    iconType="copyClipboard"
+                  />
                 )}
               </EuiCopy>
             );
@@ -260,9 +265,9 @@ export const TablesFlyout = ({
   return (
     <EuiFlyout onClose={resetFlyout}>
       <EuiFlyoutHeader hasBorder={true}>
-        <EuiTitle>
-          <h1>{dataSourceName}</h1>
-        </EuiTitle>
+        <EuiText size="s">
+          <h2>{dataSourceName}</h2>
+        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <EuiTitle size="m">

--- a/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
+++ b/public/components/event_analytics/explorer/datasources/tables_flyout.tsx
@@ -19,7 +19,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCopy,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
 } from '@elastic/eui';
 import {
   useLoadDatabasesToCache,
@@ -237,7 +237,7 @@ export const TablesFlyout = ({
             return (
               <EuiCopy textToCopy={`${dataSourceName}.${selectedDatabase}.${name}`}>
                 {(copy) => (
-                  <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                  <EuiSmallButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
                 )}
               </EuiCopy>
             );

--- a/public/components/event_analytics/explorer/direct_query_running.tsx
+++ b/public/components/event_analytics/explorer/direct_query_running.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiProgress,
   EuiSpacer,
@@ -71,15 +71,15 @@ export const DirectQueryRunning = ({
             <EuiSpacer size="s" />
             <EuiFlexGroup>
               <EuiFlexItem>
-                <EuiButton color="success" onClick={cancelQuery}>
+                <EuiSmallButton color="success" onClick={cancelQuery}>
                   Cancel
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
               {isS3Connection && (
                 <EuiFlexItem>
-                  <EuiButton fill onClick={onCreateAcceleration}>
+                  <EuiSmallButton fill onClick={onCreateAcceleration}>
                     Create acceleration
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
               )}
             </EuiFlexGroup>

--- a/public/components/event_analytics/explorer/events_views/detail_table/table_row_btn_collapse.tsx
+++ b/public/components/event_analytics/explorer/events_views/detail_table/table_row_btn_collapse.tsx
@@ -2,10 +2,10 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
- 
+
 import React from 'react';
 import { i18n } from '@osd/i18n';
-import { EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+import { EuiToolTip, EuiSmallButtonIcon } from '@elastic/eui';
 
 export interface Props {
   onClick: () => void;
@@ -18,7 +18,7 @@ export function DocViewTableRowBtnCollapse({ onClick, isCollapsed }: Props) {
   });
   return (
     <EuiToolTip content={label}>
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         aria-expanded={!isCollapsed}
         aria-label={label}
         data-test-subj="collapseBtn"

--- a/public/components/event_analytics/explorer/events_views/docViewRow.tsx
+++ b/public/components/event_analytics/explorer/events_views/docViewRow.tsx
@@ -10,7 +10,7 @@ import uniqueId from 'lodash/uniqueId';
 import has from 'lodash/has';
 import forEach from 'lodash/forEach';
 import isEqual from 'lodash/isEqual';
-import { EuiButtonIcon, EuiLink } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiLink } from '@elastic/eui';
 import { useEffect } from 'react';
 import { IExplorerFields, IField } from '../../../../../common/types/explorer';
 import { DocFlyout } from './doc_flyout';
@@ -142,7 +142,7 @@ export const FlyoutButton = forwardRef((props: FlyoutButtonProps, ref) => {
   const getExpColapTd = () => {
     return (
       <td className="osdDocTableCell__toggleDetails" key={uniqueId('grid-td-')}>
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           className="euiButtonIcon euiButtonIcon--text"
           data-test-subj="eventExplorer__flyoutArrow"
           onClick={() => {
@@ -292,7 +292,7 @@ export const FlyoutButton = forwardRef((props: FlyoutButtonProps, ref) => {
 
   return (
     <>
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         onClick={() => toggleDetailOpen()}
         iconType={detailsOpen || surroundingEventsOpen ? 'minimize' : 'inspect'}
         aria-label="inspect document details"

--- a/public/components/event_analytics/explorer/events_views/doc_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/doc_flyout.tsx
@@ -6,7 +6,7 @@
 import './docView.scss';
 import React from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -108,13 +108,13 @@ export const DocFlyout = ({
               )
             }
           >
-            <EuiButton
+            <EuiSmallButton
               onClick={openSurroundingFlyout}
               className="header-button"
               isDisabled={rawQuery.match(PPL_STATS_REGEX) || !doc.hasOwnProperty(timeStampField)}
             >
               View surrounding events
-            </EuiButton>
+            </EuiSmallButton>
           </EuiToolTip>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/components/event_analytics/explorer/events_views/doc_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/doc_flyout.tsx
@@ -12,8 +12,8 @@ import {
   EuiFlexItem,
   EuiFlyoutBody,
   EuiFlyoutHeader,
-  EuiTitle,
   EuiToolTip,
+  EuiText,
 } from '@elastic/eui';
 import moment from 'moment';
 import { FlyoutContainers } from '../../../common/flyout_containers';
@@ -71,7 +71,7 @@ export const DocFlyout = ({
     <EuiFlyoutHeader hasBorder>
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiTitle size="s">
+          <EuiText size="s">
             <h2 id="eventsDocFyout" className="vertical-center">
               {doc.hasOwnProperty(timeStampField)
                 ? `Event: ${moment(doc[timeStampField]).format(
@@ -79,7 +79,7 @@ export const DocFlyout = ({
                   )}`
                 : `Event Details`}
             </h2>
-          </EuiTitle>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonIcon

--- a/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
@@ -6,7 +6,7 @@
 import './docView.scss';
 import React, { useEffect, useState, Fragment } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiButtonIcon,
   EuiCallOut,
@@ -215,14 +215,14 @@ export const SurroundingFlyout = ({
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             onClick={openDetailsFlyout}
             className="header-button"
             iconType="sortRight"
             iconSide="right"
           >
             View event details
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiFlyoutHeader>

--- a/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
@@ -19,7 +19,6 @@ import {
   EuiFormRow,
   EuiSpacer,
   EuiText,
-  EuiTitle,
   EuiDataGrid,
   EuiDescriptionList,
   EuiDescriptionListTitle,
@@ -195,11 +194,11 @@ export const SurroundingFlyout = ({
     <EuiFlyoutHeader hasBorder>
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiTitle size="s">
+          <EuiText size="s">
             <h2 id="surroundingFyout" className="vertical-center">
               View surrounding events
             </h2>
-          </EuiTitle>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButtonIcon

--- a/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
@@ -7,7 +7,7 @@ import './docView.scss';
 import React, { useEffect, useState, Fragment } from 'react';
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiButtonIcon,
   EuiCallOut,
   EuiFieldNumber,
@@ -238,14 +238,14 @@ export const SurroundingFlyout = ({
       <EuiFlexGroup>
         <EuiFlexItem grow={false}>
           <EuiFormRow>
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               isLoading={typeOfDocs === 'new' ? loadingNewEvents : loadingOldEvents}
               iconSide="left"
               onClick={() => loadButton(typeOfDocs)}
               iconType={iconType}
             >
               Load
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false} className="cnt-picker">

--- a/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
@@ -10,7 +10,7 @@ import {
   EuiSmallButtonEmpty,
   EuiButtonIcon,
   EuiCallOut,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyoutBody,
@@ -251,7 +251,7 @@ export const SurroundingFlyout = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false} className="cnt-picker">
           <EuiCompressedFormRow>
-            <EuiFieldNumber
+            <EuiCompressedFieldNumber
               value={value}
               onChange={(e) => onChange(e)}
               aria-label={typeOfDocs === 'new' ? 'fetch newer events' : 'fetch older events'}

--- a/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
+++ b/public/components/event_analytics/explorer/events_views/surrounding_flyout.tsx
@@ -15,6 +15,7 @@ import {
   EuiFlexItem,
   EuiFlyoutBody,
   EuiFlyoutHeader,
+  EuiCompressedFormRow,
   EuiFormRow,
   EuiSpacer,
   EuiText,
@@ -237,7 +238,7 @@ export const SurroundingFlyout = ({
     return (
       <EuiFlexGroup>
         <EuiFlexItem grow={false}>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiSmallButtonEmpty
               isLoading={typeOfDocs === 'new' ? loadingNewEvents : loadingOldEvents}
               iconSide="left"
@@ -246,10 +247,10 @@ export const SurroundingFlyout = ({
             >
               Load
             </EuiSmallButtonEmpty>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false} className="cnt-picker">
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiFieldNumber
               value={value}
               onChange={(e) => onChange(e)}
@@ -258,10 +259,10 @@ export const SurroundingFlyout = ({
               max={10000}
               onKeyDown={(e) => handleKeyDown(e, typeOfDocs)}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFormRow display="center">
+          <EuiFormRow display="centerCompressed">
             <EuiText>{typeOfDocs === 'new' ? 'newer' : 'older'} events</EuiText>
           </EuiFormRow>
         </EuiFlexItem>

--- a/public/components/event_analytics/explorer/log_patterns/patterns_header.tsx
+++ b/public/components/event_analytics/explorer/log_patterns/patterns_header.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -54,7 +54,7 @@ export const PatternsHeader = ({
       <EuiFlexItem grow={false}>
         <EuiPopover
           button={
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               iconType="gear"
               onClick={() => setIsPatternConfigPopoverOpen(!isPatternConfigPopoverOpen)}
             />

--- a/public/components/event_analytics/explorer/log_patterns/patterns_header.tsx
+++ b/public/components/event_analytics/explorer/log_patterns/patterns_header.tsx
@@ -11,7 +11,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiLink,
   EuiPopover,
   EuiPopoverFooter,
@@ -69,7 +69,7 @@ export const PatternsHeader = ({
           <EuiText size="s">Log patterns allow you to cluster your logs, to help</EuiText>
           <EuiText size="s">summarize large volume of logs.</EuiText>
           <EuiSpacer size="s" />
-          <EuiFormRow
+          <EuiCompressedFormRow
             helpText={
               <EuiText size="s">
                 Pattern regex is used to reduce logs into log groups.{' '}
@@ -83,7 +83,7 @@ export const PatternsHeader = ({
               value={patternRegexInput}
               onChange={(e) => setPatternRegexInput(e.target.value)}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiPopoverFooter>
             <EuiFlexGroup justifyContent="flexEnd">
               <EuiFlexItem grow={false}>

--- a/public/components/event_analytics/explorer/log_patterns/patterns_header.tsx
+++ b/public/components/event_analytics/explorer/log_patterns/patterns_header.tsx
@@ -8,7 +8,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiSmallButtonIcon,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -79,7 +79,7 @@ export const PatternsHeader = ({
               </EuiText>
             }
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               value={patternRegexInput}
               onChange={(e) => setPatternRegexInput(e.target.value)}
             />

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiComboBoxOptionOption,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -337,7 +337,7 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
         <EuiFlexItem>
           <EuiInputPopover
             input={
-              <EuiFieldText
+              <EuiCompressedFieldText
                 inputRef={inputRef}
                 placeholder="Ask me a question"
                 disabled={loading}

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBoxOptionOption,
   EuiFieldText,
   EuiFlexGroup,
@@ -386,7 +386,7 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
       {props.children}
       <EuiSpacer size="m" />
       {props.lastFocusedInput === 'query_area' ? (
-        <EuiButton
+        <EuiSmallButton
           fill
           isLoading={loading}
           onClick={props.runChanges}
@@ -394,7 +394,7 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
           style={{ height: 44 }}
         >
           Run
-        </EuiButton>
+        </EuiSmallButton>
       ) : (
         <EuiSplitButton
           disabled={loading}

--- a/public/components/event_analytics/explorer/save_panel/save_panel.tsx
+++ b/public/components/event_analytics/explorer/save_panel/save_panel.tsx
@@ -7,6 +7,7 @@ import React, { useState } from 'react';
 import {
   EuiTitle,
   EuiComboBox,
+  EuiCompressedFormRow,
   EuiFormRow,
   EuiFieldText,
   EuiSwitch,
@@ -78,7 +79,7 @@ export const SavePanel = ({
           <EuiTitle size="xxs">
             <h3>{'Custom operational dashboards/application'}</h3>
           </EuiTitle>
-          <EuiFormRow helpText="Search existing dashboards or applications by name">
+          <EuiCompressedFormRow helpText="Search existing dashboards or applications by name">
             <EuiComboBox
               placeholder="Select dashboards/applications"
               onChange={(daOptions) => {
@@ -95,13 +96,13 @@ export const SavePanel = ({
               singleSelection={{ asPlainText: true }}
               data-test-subj="eventExplorer__querySaveComboBox"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
       <EuiTitle size="xxs">
         <h3>Name</h3>
       </EuiTitle>
-      <EuiFormRow helpText="Name for your savings">
+      <EuiCompressedFormRow helpText="Name for your savings">
         <EuiFieldText
           key={'save-panel-id'}
           value={savePanelName}
@@ -111,7 +112,7 @@ export const SavePanel = ({
           }}
           data-test-subj="eventExplorer__querySaveName"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
       {showOptionList && (
         <>
           <EuiFormRow display="columnCompressedSwitch">

--- a/public/components/event_analytics/explorer/save_panel/save_panel.tsx
+++ b/public/components/event_analytics/explorer/save_panel/save_panel.tsx
@@ -6,7 +6,7 @@
 import React, { useState } from 'react';
 import {
   EuiTitle,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFormRow,
   EuiFormRow,
   EuiCompressedFieldText,
@@ -80,7 +80,7 @@ export const SavePanel = ({
             <h3>{'Custom operational dashboards/application'}</h3>
           </EuiTitle>
           <EuiCompressedFormRow helpText="Search existing dashboards or applications by name">
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select dashboards/applications"
               onChange={(daOptions) => {
                 handleOptionChange(daOptions);

--- a/public/components/event_analytics/explorer/save_panel/save_panel.tsx
+++ b/public/components/event_analytics/explorer/save_panel/save_panel.tsx
@@ -9,7 +9,7 @@ import {
   EuiComboBox,
   EuiCompressedFormRow,
   EuiFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSwitch,
   EuiToolTip,
 } from '@elastic/eui';
@@ -103,7 +103,7 @@ export const SavePanel = ({
         <h3>Name</h3>
       </EuiTitle>
       <EuiCompressedFormRow helpText="Name for your savings">
-        <EuiFieldText
+        <EuiCompressedFieldText
           key={'save-panel-id'}
           value={savePanelName}
           isInvalid={isEmpty(savePanelName)}

--- a/public/components/event_analytics/explorer/sidebar/field.tsx
+++ b/public/components/event_analytics/explorer/sidebar/field.tsx
@@ -5,6 +5,7 @@
 
 import {
   EuiBadge,
+  EuiSmallButtonIcon,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -222,7 +223,7 @@ export const Field = (props: IFieldProps) => {
         >
           <>
             {isFieldToggleButtonDisabled ? (
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 color={selected ? 'danger' : 'primary'}
                 iconType={selected ? 'cross' : 'plusInCircleFilled'}
                 isDisabled
@@ -231,7 +232,7 @@ export const Field = (props: IFieldProps) => {
                 className="dscSidebarField__actionButton"
               />
             ) : (
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 color={selected ? 'danger' : 'primary'}
                 iconType={selected ? 'cross' : 'plusInCircleFilled'}
                 onClick={(e: React.MouseEvent<HTMLButtonElement>) => {

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiIcon,
   EuiTabbedContent,
@@ -188,7 +188,7 @@ export const ConfigPanel = ({ visualizations, setCurVisId, callback }: any) => {
   return (
     <div className="cp__rightContainer">
       <div className="cp__rightHeader">
-        <EuiComboBox
+        <EuiCompressedComboBox
           aria-label="config chart selector"
           placeholder="Select a chart"
           options={memorizedVisualizationTypes}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useState } from 'react';
 import {
   EuiButton,
   EuiAccordion,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldNumber,
   EuiColorPicker,
   EuiSpacer,
@@ -133,28 +133,28 @@ export const ConfigAvailability = ({ visualizations, onConfigChange, vizState = 
           vizState.level.map((thr: AvailabilityUnitType) => {
             return (
               <>
-                <EuiFormRow fullWidth label="">
+                <EuiCompressedFormRow fullWidth label="">
                   <EuiFlexGroup alignItems="center" gutterSize="xs">
                     <EuiFlexItem grow={3}>
-                      <EuiFormRow helpText="color">
+                      <EuiCompressedFormRow helpText="color">
                         <EuiColorPicker
                           fullWidth
                           onChange={handleAvailabilityChange(thr.thid, 'color')}
                           color={thr.color}
                         />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </EuiFlexItem>
                     <EuiFlexItem grow={5}>
-                      <EuiFormRow helpText="name">
+                      <EuiCompressedFormRow helpText="name">
                         <EuiFieldText
                           onChange={handleAvailabilityChange(thr.thid, 'name')}
                           value={thr.name || ''}
                           arial-label="Input availability name"
                           data-test-subj="nameFieldText"
                         />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </EuiFlexItem>
-                    <EuiFormRow helpText="expression">
+                    <EuiCompressedFormRow helpText="expression">
                       <EuiFlexItem grow={4}>
                         <EuiSelect
                           options={expressionOptions}
@@ -164,9 +164,9 @@ export const ConfigAvailability = ({ visualizations, onConfigChange, vizState = 
                           data-test-subj="expressionSelect"
                         />
                       </EuiFlexItem>
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                     <EuiFlexItem grow={5}>
-                      <EuiFormRow helpText="value">
+                      <EuiCompressedFormRow helpText="value">
                         <EuiFieldNumber
                           fullWidth
                           placeholder="availability value"
@@ -175,15 +175,15 @@ export const ConfigAvailability = ({ visualizations, onConfigChange, vizState = 
                           aria-label="Input availability value"
                           data-test-subj="valueFieldNumber"
                         />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </EuiFlexItem>
                     <EuiFlexItem grow={1}>
-                      <EuiFormRow>
+                      <EuiCompressedFormRow>
                         <EuiIcon type="trash" onClick={handleAvailabilityDelete(thr.thid)} />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </EuiFlexItem>
                   </EuiFlexGroup>
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </>
             );
           })}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
@@ -8,13 +8,13 @@ import {
   EuiButton,
   EuiAccordion,
   EuiCompressedFormRow,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiColorPicker,
   EuiSpacer,
   EuiIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSelect,
   htmlIdGenerator,
   EuiText,
@@ -146,7 +146,7 @@ export const ConfigAvailability = ({ visualizations, onConfigChange, vizState = 
                     </EuiFlexItem>
                     <EuiFlexItem grow={5}>
                       <EuiCompressedFormRow helpText="name">
-                        <EuiFieldText
+                        <EuiCompressedFieldText
                           onChange={handleAvailabilityChange(thr.thid, 'name')}
                           value={thr.name || ''}
                           arial-label="Input availability name"
@@ -167,7 +167,7 @@ export const ConfigAvailability = ({ visualizations, onConfigChange, vizState = 
                     </EuiCompressedFormRow>
                     <EuiFlexItem grow={5}>
                       <EuiCompressedFormRow helpText="value">
-                        <EuiFieldNumber
+                        <EuiCompressedFieldNumber
                           fullWidth
                           placeholder="availability value"
                           value={thr.value || 0}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFieldText,
-  EuiSelect,
+  EuiCompressedSelect,
   htmlIdGenerator,
   EuiText,
 } from '@elastic/eui';
@@ -156,7 +156,7 @@ export const ConfigAvailability = ({ visualizations, onConfigChange, vizState = 
                     </EuiFlexItem>
                     <EuiCompressedFormRow helpText="expression">
                       <EuiFlexItem grow={4}>
-                        <EuiSelect
+                        <EuiCompressedSelect
                           options={expressionOptions}
                           value={thr.expression || ''}
                           onChange={handleAvailabilityChange(thr.thid, 'expression')}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_palette_picker.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_palette_picker.tsx
@@ -11,7 +11,7 @@ import {
   EuiFlexGroup,
   EuiColorPalettePicker,
   EuiColorPicker,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import {
   DEFAULT_PALETTE,
@@ -80,9 +80,9 @@ export const ColorPalettePicker = ({
       <EuiFlexGroup gutterSize={'xs'}>
         {[SINGLE_COLOR_PALETTE, MULTI_COLOR_PALETTE].includes(selectedColor.name) && (
           <EuiFlexItem grow={1}>
-            <EuiFormRow helpText={selectedColor.name === MULTI_COLOR_PALETTE && 'Child field'}>
+            <EuiCompressedFormRow helpText={selectedColor.name === MULTI_COLOR_PALETTE && 'Child field'}>
               <EuiColorPicker onChange={onChildColorChange} color={childColor} />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         )}
         {selectedColor.name === MULTI_COLOR_PALETTE &&
@@ -91,12 +91,12 @@ export const ColorPalettePicker = ({
             .fill(0)
             .map((_, i) => (
               <EuiFlexItem grow={1} key={i}>
-                <EuiFormRow helpText={`Parent ${i + 1} field`}>
+                <EuiCompressedFormRow helpText={`Parent ${i + 1} field`}>
                   <EuiColorPicker
                     onChange={onParentColorChange(i)}
                     color={parentColors[i] ?? '#000000'}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
             ))}
         <EuiFlexItem grow={3}>

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_theme.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_theme.tsx
@@ -7,7 +7,7 @@ import React, { Fragment, useCallback } from 'react';
 import {
   EuiButton,
   EuiAccordion,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiColorPicker,
   EuiSpacer,
   EuiIcon,
@@ -92,19 +92,19 @@ export const ConfigColorTheme = ({
         vizState.map((ct) => {
           return (
             <Fragment key={ct.ctid}>
-              <EuiFormRow fullWidth label="">
+              <EuiCompressedFormRow fullWidth label="">
                 <EuiFlexGroup alignItems="center" gutterSize="xs">
                   <EuiFlexItem grow={3}>
-                    <EuiFormRow helpText="Color">
+                    <EuiCompressedFormRow helpText="Color">
                       <EuiColorPicker
                         fullWidth
                         onChange={handleColorThemeChange(ct.ctid, 'color')}
                         color={ct.color}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={4}>
-                    <EuiFormRow helpText="Field">
+                    <EuiCompressedFormRow helpText="Field">
                       <EuiComboBox
                         id={ct.ctid}
                         placeholder="Select a field"
@@ -114,15 +114,15 @@ export const ConfigColorTheme = ({
                         onChange={handleColorThemeChange(ct.ctid, 'name')}
                         aria-label="Use aria labels when no actual label is in use"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={1}>
-                    <EuiFormRow>
+                    <EuiCompressedFormRow>
                       <EuiIcon type="trash" onClick={handleColorThemeDelete(ct.ctid)} />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                 </EuiFlexGroup>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </Fragment>
           );
         })}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_theme.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_color_theme.tsx
@@ -14,7 +14,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   htmlIdGenerator,
-  EuiComboBox,
+  EuiCompressedComboBox,
 } from '@elastic/eui';
 import isEmpty from 'lodash/isEmpty';
 import { ADD_BUTTON_TEXT, AGGREGATIONS } from '../../../../../../../../common/constants/explorer';
@@ -105,7 +105,7 @@ export const ConfigColorTheme = ({
                   </EuiFlexItem>
                   <EuiFlexItem grow={4}>
                     <EuiCompressedFormRow helpText="Field">
-                      <EuiComboBox
+                      <EuiCompressedComboBox
                         id={ct.ctid}
                         placeholder="Select a field"
                         options={getUpdatedOptions()}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_number_input.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_number_input.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiFieldNumber, EuiTitle, EuiSpacer, htmlIdGenerator } from '@elastic/eui';
+import { EuiCompressedFieldNumber, EuiTitle, EuiSpacer, htmlIdGenerator } from '@elastic/eui';
 
 interface InputFieldProps {
   title: string;
@@ -33,7 +33,7 @@ export const InputFieldItem: React.FC<InputFieldProps> = ({
         <h3>{title}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiFieldNumber
+      <EuiCompressedFieldNumber
         id={htmlIdGenerator('input-number')()}
         fullWidth
         placeholder="auto"

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_item.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import uniqueId from 'lodash/uniqueId';
 import isEmpty from 'lodash/isEmpty';
-import { EuiTitle, EuiComboBox, EuiSpacer } from '@elastic/eui';
+import { EuiTitle, EuiCompressedComboBox, EuiSpacer } from '@elastic/eui';
 
 export const PanelItem = ({
   paddingTitle,
@@ -30,7 +30,7 @@ export const PanelItem = ({
         <h3>{paddingTitle}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiComboBox
+      <EuiCompressedComboBox
         id={uniqueId('axis-select-')}
         placeholder="Select a field"
         options={options}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_option_gauge.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_option_gauge.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiCompressedFormRow, EuiFieldNumber } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCompressedFieldNumber } from '@elastic/eui';
 import find from 'lodash/find';
 import {
   DEFAULT_GAUGE_CHART_PARAMETERS,
@@ -44,7 +44,7 @@ export const ConfigPanelOptionGauge = ({
 
   return (
     <EuiCompressedFormRow fullWidth label="Number of gauges" helpText={helpText}>
-      <EuiFieldNumber
+      <EuiCompressedFieldNumber
         name="numberOfGauges"
         onChange={(e) => {
           setNumberOfGauges(Number(e.target.value));

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_option_gauge.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_option_gauge.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiFormRow, EuiFieldNumber } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiFieldNumber } from '@elastic/eui';
 import find from 'lodash/find';
 import {
   DEFAULT_GAUGE_CHART_PARAMETERS,
@@ -43,7 +43,7 @@ export const ConfigPanelOptionGauge = ({
   }, [vizState?.numberOfGauges]);
 
   return (
-    <EuiFormRow fullWidth label="Number of gauges" helpText={helpText}>
+    <EuiCompressedFormRow fullWidth label="Number of gauges" helpText={helpText}>
       <EuiFieldNumber
         name="numberOfGauges"
         onChange={(e) => {
@@ -61,6 +61,6 @@ export const ConfigPanelOptionGauge = ({
         placeholder={'Number of gauges'}
         readOnly={dimensions.length === 0}
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 };

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_options.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_options.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiFieldText, EuiForm, EuiCompressedFormRow, EuiTextArea, EuiAccordion } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiForm, EuiCompressedFormRow, EuiTextArea, EuiAccordion } from '@elastic/eui';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import { DEFAULT_GAUGE_CHART_PARAMETERS } from '../../../../../../../../common/constants/explorer';
 import { ConfigPanelOptionGauge } from './config_panel_option_gauge';
@@ -44,7 +44,7 @@ export const ConfigPanelOptions = ({ visualizations, handleConfigChange, vizStat
     >
       <EuiForm component="form">
         <EuiCompressedFormRow fullWidth label="Title" helpText={`${helpText}`}>
-          <EuiFieldText
+          <EuiCompressedFieldText
             name="title"
             onChange={handleTextChange}
             onBlur={() => handleConfigChange(panelOptionsValues)}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_options.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_options.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiFieldText, EuiForm, EuiFormRow, EuiTextArea, EuiAccordion } from '@elastic/eui';
+import { EuiFieldText, EuiForm, EuiCompressedFormRow, EuiTextArea, EuiAccordion } from '@elastic/eui';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import { DEFAULT_GAUGE_CHART_PARAMETERS } from '../../../../../../../../common/constants/explorer';
 import { ConfigPanelOptionGauge } from './config_panel_option_gauge';
@@ -43,7 +43,7 @@ export const ConfigPanelOptions = ({ visualizations, handleConfigChange, vizStat
       paddingSize="s"
     >
       <EuiForm component="form">
-        <EuiFormRow fullWidth label="Title" helpText={`${helpText}`}>
+        <EuiCompressedFormRow fullWidth label="Title" helpText={`${helpText}`}>
           <EuiFieldText
             name="title"
             onChange={handleTextChange}
@@ -51,8 +51,8 @@ export const ConfigPanelOptions = ({ visualizations, handleConfigChange, vizStat
             value={panelOptionsValues.title}
             placeholder={'Title'}
           />
-        </EuiFormRow>
-        <EuiFormRow label="Description">
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow label="Description">
           <EuiTextArea
             name="description"
             aria-label="Use aria labels when no actual label is in use"
@@ -61,7 +61,7 @@ export const ConfigPanelOptions = ({ visualizations, handleConfigChange, vizStat
             onChange={handleTextChange}
             onBlur={() => handleConfigChange(panelOptionsValues)}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         {visualizations?.vis?.name?.toLowerCase() === VIS_CHART_TYPES.Gauge && (
           <ConfigPanelOptionGauge
             onChange={handleTextChange}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_options.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_panel_options.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiCompressedFieldText, EuiForm, EuiCompressedFormRow, EuiTextArea, EuiAccordion } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiForm, EuiCompressedFormRow, EuiCompressedTextArea, EuiAccordion } from '@elastic/eui';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import { DEFAULT_GAUGE_CHART_PARAMETERS } from '../../../../../../../../common/constants/explorer';
 import { ConfigPanelOptionGauge } from './config_panel_option_gauge';
@@ -53,7 +53,7 @@ export const ConfigPanelOptions = ({ visualizations, handleConfigChange, vizStat
           />
         </EuiCompressedFormRow>
         <EuiCompressedFormRow label="Description">
-          <EuiTextArea
+          <EuiCompressedTextArea
             name="description"
             aria-label="Use aria labels when no actual label is in use"
             placeholder={'Description'}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_single_color_picker.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_single_color_picker.tsx
@@ -10,7 +10,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiColorPicker,
-  EuiFormRow,
+  EuiCompressedFormRow,
   colorPalette,
 } from '@elastic/eui';
 import { lightenColor } from '../../../../../../event_analytics/utils/utils';
@@ -29,9 +29,9 @@ export const SingleColorPicker = ({ title, selectedColor, onSelectChange }: any)
       <EuiSpacer size="s" />
       <EuiFlexGroup gutterSize={'xs'}>
         <EuiFlexItem grow={3}>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiColorPicker onChange={onColorChange} color={selectedColor.color} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="m" />

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_switch.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_switch.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { Fragment } from 'react';
-import { EuiSpacer, EuiFormRow, EuiSwitch, htmlIdGenerator } from '@elastic/eui';
+import { EuiSpacer, EuiCompressedFormRow, EuiSwitch, htmlIdGenerator } from '@elastic/eui';
 
 interface EUISwitch {
   label: string;
@@ -14,7 +14,7 @@ interface EUISwitch {
 }
 export const ConfigSwitch: React.FC<EUISwitch> = ({ label, disabled, checked, handleChange }) => (
   <Fragment key={`config-switch-${label}`}>
-    <EuiFormRow label={label}>
+    <EuiCompressedFormRow label={label}>
       <EuiSwitch
         id={htmlIdGenerator('switch-button')()}
         showLabel={false}
@@ -24,7 +24,7 @@ export const ConfigSwitch: React.FC<EUISwitch> = ({ label, disabled, checked, ha
         onChange={(e) => handleChange(e.target.checked)}
         compressed
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
     <EuiSpacer size="s" />
   </Fragment>
 );

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_switch_button.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_switch_button.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiSwitch, EuiSpacer } from '@elastic/eui';
+import { EuiCompressedSwitch, EuiSpacer } from '@elastic/eui';
 
 interface SwitchButtonProps {
   currentValue: boolean;
@@ -15,7 +15,7 @@ export const SwitchButton = ({ currentValue, onToggle, title }: SwitchButtonProp
   return (
     <>
       <EuiSpacer />
-      <EuiSwitch
+      <EuiCompressedSwitch
         label={title}
         checked={currentValue}
         onChange={(e) => onToggle(e.target.checked)}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_text_input.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_text_input.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiFieldText, EuiTitle, EuiSpacer, htmlIdGenerator } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiTitle, EuiSpacer, htmlIdGenerator } from '@elastic/eui';
 
 interface InputFieldProps {
   name: string;
@@ -33,7 +33,7 @@ export const TextInputFieldItem: React.FC<InputFieldProps> = ({
         <h3>{title}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiFieldText
+      <EuiCompressedFieldText
         id={htmlIdGenerator('input-text')()}
         name={name}
         fullWidth

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds.tsx
@@ -7,7 +7,7 @@ import React, { Fragment, useCallback } from 'react';
 import {
   EuiButton,
   EuiAccordion,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldNumber,
   EuiColorPicker,
   EuiSpacer,
@@ -111,19 +111,19 @@ export const ConfigThresholds = ({
         vizState.map((thr: ThresholdUnitType) => {
           return (
             <Fragment key={thr.thid}>
-              <EuiFormRow fullWidth label="">
+              <EuiCompressedFormRow fullWidth label="">
                 <EuiFlexGroup alignItems="center" gutterSize="xs">
                   <EuiFlexItem grow={3}>
-                    <EuiFormRow helpText="color">
+                    <EuiCompressedFormRow helpText="color">
                       <EuiColorPicker
                         fullWidth
                         onChange={handleThresholdChange(thr.thid, 'color')}
                         color={thr.color}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={5}>
-                    <EuiFormRow helpText="name">
+                    <EuiCompressedFormRow helpText="name">
                       <EuiFieldText
                         onChange={handleThresholdChange(thr.thid, 'name')}
                         value={thr.name || ''}
@@ -131,10 +131,10 @@ export const ConfigThresholds = ({
                         data-test-subj="nameFieldText"
                         readOnly={thr.isReadOnly}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={5}>
-                    <EuiFormRow helpText="value">
+                    <EuiCompressedFormRow helpText="value">
                       <EuiFieldNumber
                         fullWidth
                         placeholder="threshold value"
@@ -144,17 +144,17 @@ export const ConfigThresholds = ({
                         data-test-subj="valueFieldNumber"
                         readOnly={thr.isReadOnly}
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   {!thr.isReadOnly && (
                     <EuiFlexItem grow={1}>
-                      <EuiFormRow>
+                      <EuiCompressedFormRow>
                         <EuiIcon type="trash" onClick={handleThresholdDelete(thr.thid)} />
-                      </EuiFormRow>
+                      </EuiCompressedFormRow>
                     </EuiFlexItem>
                   )}
                 </EuiFlexGroup>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </Fragment>
           );
         })}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds.tsx
@@ -8,13 +8,13 @@ import {
   EuiButton,
   EuiAccordion,
   EuiCompressedFormRow,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiColorPicker,
   EuiSpacer,
   EuiIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFieldText,
+  EuiCompressedFieldText,
   htmlIdGenerator,
   EuiToolTip,
 } from '@elastic/eui';
@@ -124,7 +124,7 @@ export const ConfigThresholds = ({
                   </EuiFlexItem>
                   <EuiFlexItem grow={5}>
                     <EuiCompressedFormRow helpText="name">
-                      <EuiFieldText
+                      <EuiCompressedFieldText
                         onChange={handleThresholdChange(thr.thid, 'name')}
                         value={thr.name || ''}
                         arial-label="Input threshold name"
@@ -135,7 +135,7 @@ export const ConfigThresholds = ({
                   </EuiFlexItem>
                   <EuiFlexItem grow={5}>
                     <EuiCompressedFormRow helpText="value">
-                      <EuiFieldNumber
+                      <EuiCompressedFieldNumber
                         fullWidth
                         placeholder="threshold value"
                         value={thr.value || 0}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonIcon, EuiLink, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiLink, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import isEmpty from 'lodash/isEmpty';
 import React, { Fragment } from 'react';
 import { ParentUnitType, TreemapParentsProps } from '../../../../../../../../common/types/explorer';
@@ -50,7 +50,7 @@ export const ConfigTreemapParentFields = ({
                     {obj.label !== '' ? obj.label : `Parent ${index + 1}`}
                   </EuiLink>
                 </EuiText>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   color="subdued"
                   iconType="cross"
                   aria-label="clear-field"
@@ -64,7 +64,7 @@ export const ConfigTreemapParentFields = ({
       <EuiSpacer size="s" />
       <EuiPanel className="panelItem_button" grow>
         <EuiText size="s">{addButtonText}</EuiText>
-        <EuiButtonIcon
+        <EuiSmallButtonIcon
           iconType="plusInCircle"
           aria-label="clear-field"
           iconSize="s"

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_yaxis_side.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_yaxis_side.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   htmlIdGenerator,
-  EuiComboBox,
+  EuiCompressedComboBox,
 } from '@elastic/eui';
 import isEmpty from 'lodash/isEmpty';
 import {
@@ -98,7 +98,7 @@ export const ConfigYAxisSide = ({
                 <EuiFlexGroup alignItems="center" gutterSize="xs">
                   <EuiFlexItem grow={4}>
                     <EuiCompressedFormRow helpText="Field">
-                      <EuiComboBox
+                      <EuiCompressedComboBox
                         id={ct.ctid}
                         placeholder="Select a field"
                         options={getUpdatedOptions()}
@@ -111,7 +111,7 @@ export const ConfigYAxisSide = ({
                   </EuiFlexItem>
                   <EuiFlexItem grow={3}>
                     <EuiCompressedFormRow helpText="Position">
-                      <EuiComboBox
+                      <EuiCompressedComboBox
                         id={ct.ctid}
                         placeholder="Select position"
                         options={SERIES_POSITION_OPTIONS}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_yaxis_side.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_yaxis_side.tsx
@@ -7,7 +7,7 @@ import React, { Fragment, useCallback } from 'react';
 import {
   EuiButton,
   EuiAccordion,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiIcon,
   EuiFlexGroup,
@@ -94,10 +94,10 @@ export const ConfigYAxisSide = ({
         vizState.map((ct) => {
           return (
             <Fragment key={ct.ctid}>
-              <EuiFormRow fullWidth label="">
+              <EuiCompressedFormRow fullWidth label="">
                 <EuiFlexGroup alignItems="center" gutterSize="xs">
                   <EuiFlexItem grow={4}>
-                    <EuiFormRow helpText="Field">
+                    <EuiCompressedFormRow helpText="Field">
                       <EuiComboBox
                         id={ct.ctid}
                         placeholder="Select a field"
@@ -107,10 +107,10 @@ export const ConfigYAxisSide = ({
                         onChange={handleColorThemeChange(ct.ctid, 'label')}
                         aria-label="series-dropdown"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={3}>
-                    <EuiFormRow helpText="Position">
+                    <EuiCompressedFormRow helpText="Position">
                       <EuiComboBox
                         id={ct.ctid}
                         placeholder="Select position"
@@ -126,15 +126,15 @@ export const ConfigYAxisSide = ({
                         onChange={handleColorThemeChange(ct.ctid, 'side')}
                         aria-label="series-position-dropdown"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem grow={1}>
-                    <EuiFormRow>
+                    <EuiCompressedFormRow>
                       <EuiIcon type="trash" onClick={handleDeletePosition(ct.ctid)} />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                 </EuiFlexGroup>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </Fragment>
           );
         })}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -12,7 +12,7 @@ import {
   EuiText,
   EuiTitle,
   EuiToolTip,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFormLabel,
 } from '@elastic/eui';
 import isArray from 'lodash/isArray';
@@ -88,7 +88,7 @@ export const DataConfigPanelFields = ({
   );
 
   return (
-    <EuiFormRow>
+    <EuiCompressedFormRow>
       <>
         <div style={{ display: 'flex' }}>
           <EuiFormLabel className="panel_title">{sectionName}</EuiFormLabel>
@@ -162,6 +162,6 @@ export const DataConfigPanelFields = ({
           )}
         </div>
       </>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 };

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -4,7 +4,7 @@
  */
 import React, { Fragment } from 'react';
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiIcon,
   EuiLink,
   EuiPanel,
@@ -66,7 +66,7 @@ export const DataConfigPanelFields = ({
 
   const tooltipIcon = <EuiIcon type="iInCircle" color="text" size="m" />;
   const crossIcon = (index: number, configName: string) => (
-    <EuiButtonIcon
+    <EuiSmallButtonIcon
       color="subdued"
       iconType="cross"
       aria-label="clear-field"
@@ -150,7 +150,7 @@ export const DataConfigPanelFields = ({
           {!hideClickToAddButton(sectionName) && (
             <EuiPanel className="panelItem_button" data-test-subj="viz-config-section" grow>
               <EuiText size="s">{addButtonText}</EuiText>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 iconType="plusInCircle"
                 aria-label="add-field"
                 iconSize="s"

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFieldNumber,
@@ -581,7 +581,7 @@ export const DataConfigPanelItem = ({
         )}
         <div className="logExplorerVisConfig__content">
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="visualizeEditorRenderButton"
               iconType="play"
               onClick={() => updateChart()}
@@ -589,7 +589,7 @@ export const DataConfigPanelItem = ({
               isDisabled={isEmpty(configList[AGGREGATIONS])}
             >
               Update chart
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </div>
       </div>

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -8,8 +8,8 @@ import {
   EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiFlexItem,
   EuiCompressedFormRow,
   EuiPanel,
@@ -380,7 +380,7 @@ export const DataConfigPanelItem = ({
                 <>
                   {getCommonDimensionsField(selectedObj, name)}
                   <EuiCompressedFormRow label="Custom label">
-                    <EuiFieldText
+                    <EuiCompressedFieldText
                       placeholder="Custom label"
                       value={selectedObj[CUSTOM_LABEL]}
                       onChange={(e) => updateList(e.target.value, CUSTOM_LABEL)}
@@ -458,7 +458,7 @@ export const DataConfigPanelItem = ({
 
   const getNumberField = (type: string) => (
     <>
-      <EuiFieldNumber
+      <EuiCompressedFieldNumber
         id={htmlIdGenerator('input-number')()}
         fullWidth
         placeholder="auto"
@@ -482,7 +482,7 @@ export const DataConfigPanelItem = ({
             <EuiPanel color="subdued" style={{ padding: '0px' }}>
               <EuiSpacer size="s" />
               <EuiCompressedFormRow label="Interval">
-                <EuiFieldNumber
+                <EuiCompressedFieldNumber
                   placeholder="Placeholder text"
                   value={configList.span?.interval ?? 1}
                   min={1}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -11,7 +11,7 @@ import {
   EuiFieldNumber,
   EuiFieldText,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPanel,
   EuiSpacer,
   EuiTitle,
@@ -356,7 +356,7 @@ export const DataConfigPanelItem = ({
             <EuiPanel color="subdued" style={{ padding: '0px' }}>
               {/* Aggregation input for Series */}
               {isAggregations && (
-                <EuiFormRow label="Aggregation">
+                <EuiCompressedFormRow label="Aggregation">
                   <EuiComboBox
                     aria-label="aggregation input"
                     placeholder="Select a aggregation"
@@ -373,20 +373,20 @@ export const DataConfigPanelItem = ({
                     }
                     onChange={(e) => updateList(e.length > 0 ? e[0].label : '', 'aggregation')}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               )}
               {/* Show input fields for Series when aggregation is not empty  */}
               {isAggregations && selectedObj.aggregation !== '' && (
                 <>
                   {getCommonDimensionsField(selectedObj, name)}
-                  <EuiFormRow label="Custom label">
+                  <EuiCompressedFormRow label="Custom label">
                     <EuiFieldText
                       placeholder="Custom label"
                       value={selectedObj[CUSTOM_LABEL]}
                       onChange={(e) => updateList(e.target.value, CUSTOM_LABEL)}
                       aria-label="input label"
                     />
-                  </EuiFormRow>
+                  </EuiCompressedFormRow>
                 </>
               )}
               {/* Show input fields for dimensions */}
@@ -427,7 +427,7 @@ export const DataConfigPanelItem = ({
   const getCommonDimensionsField = (selectedObj: ConfigListEntry, name: string) => {
     return (
       <>
-        <EuiFormRow label="Field">
+        <EuiCompressedFormRow label="Field">
           <EuiComboBox
             aria-label="input field"
             placeholder="Select a field"
@@ -450,7 +450,7 @@ export const DataConfigPanelItem = ({
                 : updateList(e.length > 0 ? e[0].label : '', 'label')
             }
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         {isTimeStampSelected && DateHistogram}
       </>
     );
@@ -481,7 +481,7 @@ export const DataConfigPanelItem = ({
           <div className="first-division">
             <EuiPanel color="subdued" style={{ padding: '0px' }}>
               <EuiSpacer size="s" />
-              <EuiFormRow label="Interval">
+              <EuiCompressedFormRow label="Interval">
                 <EuiFieldNumber
                   placeholder="Placeholder text"
                   value={configList.span?.interval ?? 1}
@@ -501,8 +501,8 @@ export const DataConfigPanelItem = ({
                   aria-label="interval field"
                   data-test-subj="valueFieldNumber"
                 />
-              </EuiFormRow>
-              <EuiFormRow label="Unit">
+              </EuiCompressedFormRow>
+              <EuiCompressedFormRow label="Unit">
                 <EuiComboBox
                   aria-label="date unit"
                   placeholder="Select fields"
@@ -516,7 +516,7 @@ export const DataConfigPanelItem = ({
                   selectedOptions={configList.span?.unit ? [...configList.span?.unit] : []}
                   onChange={(e) => handleTimeStampFieldsChange(e, 'unit')}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiPanel>
           </div>
         </div>

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -6,7 +6,7 @@
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import {
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldNumber,
   EuiCompressedFieldText,
@@ -357,7 +357,7 @@ export const DataConfigPanelItem = ({
               {/* Aggregation input for Series */}
               {isAggregations && (
                 <EuiCompressedFormRow label="Aggregation">
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     aria-label="aggregation input"
                     placeholder="Select a aggregation"
                     singleSelection={{ asPlainText: true }}
@@ -428,7 +428,7 @@ export const DataConfigPanelItem = ({
     return (
       <>
         <EuiCompressedFormRow label="Field">
-          <EuiComboBox
+          <EuiCompressedComboBox
             aria-label="input field"
             placeholder="Select a field"
             singleSelection={{ asPlainText: true }}
@@ -503,7 +503,7 @@ export const DataConfigPanelItem = ({
                 />
               </EuiCompressedFormRow>
               <EuiCompressedFormRow label="Unit">
-                <EuiComboBox
+                <EuiCompressedComboBox
                   aria-label="date unit"
                   placeholder="Select fields"
                   singleSelection

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import {
-  EuiSmallButton,
+  EuiButton,
   EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiCompressedFieldNumber,
@@ -581,7 +581,7 @@ export const DataConfigPanelItem = ({
         )}
         <div className="logExplorerVisConfig__content">
           <EuiFlexItem grow={false}>
-            <EuiSmallButton
+            <EuiButton
               data-test-subj="visualizeEditorRenderButton"
               iconType="play"
               onClick={() => updateChart()}
@@ -589,7 +589,7 @@ export const DataConfigPanelItem = ({
               isDisabled={isEmpty(configList[AGGREGATIONS])}
             >
               Update chart
-            </EuiSmallButton>
+            </EuiButton>
           </EuiFlexItem>
         </div>
       </div>

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
@@ -8,6 +8,7 @@ import {
   EuiTitle,
   EuiComboBox,
   EuiSpacer,
+  EuiSmallButton,
   EuiButton,
   EuiFlexItem,
   EuiFormRow,
@@ -203,7 +204,7 @@ export const LogsViewConfigPanelItem = ({
         <EuiSpacer size="s" />
         {
           <EuiFlexItem grow>
-            <EuiButton
+            <EuiSmallButton
               fullWidth
               iconType="plusInCircleFilled"
               color="primary"
@@ -211,7 +212,7 @@ export const LogsViewConfigPanelItem = ({
               disabled={queriedFields.length !== 0}
             >
               Add
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         }
       </Fragment>

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
@@ -11,7 +11,7 @@ import {
   EuiSmallButton,
   EuiButton,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiIcon,
   EuiText,
 } from '@elastic/eui';
@@ -173,7 +173,7 @@ export const LogsViewConfigPanelItem = ({
   const getLogsViewUI = () => {
     const list = configList[GROUPBY] ? configList[GROUPBY] : [];
     const listUI = list.map((field, index) => (
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Field"
         labelAppend={
           <EuiText size="xs">
@@ -196,7 +196,7 @@ export const LogsViewConfigPanelItem = ({
             updateLogsViewConfig(e.length > 0 ? e[0].label : '', field as ConfigListEntry)
           }
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     ));
     return (
       <Fragment key="logsViewUI">

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState, useContext, Fragment } from 'react';
 import {
   EuiTitle,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiSpacer,
   EuiSmallButton,
   EuiButton,
@@ -185,7 +185,7 @@ export const LogsViewConfigPanelItem = ({
           </EuiText>
         }
       >
-        <EuiComboBox
+        <EuiCompressedComboBox
           aria-label="logsViewField"
           placeholder="Select a field"
           singleSelection={{ asPlainText: true }}

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiSmallButton,
+  EuiButton,
   EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexItem,
@@ -262,14 +262,14 @@ export const TreemapConfigPanelItem = ({
       <EuiSpacer size="s" />
       <EuiSpacer size="s" />
       <EuiFlexItem grow={false}>
-        <EuiSmallButton
+        <EuiButton
           data-test-subj="visualizeEditorRenderButton"
           iconType="play"
           onClick={() => updateChart()}
           size="s"
         >
           Update chart
-        </EuiSmallButton>
+        </EuiButton>
       </EuiFlexItem>
     </div>
   );

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -8,7 +8,7 @@ import {
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiPanel,
   EuiSpacer,
   EuiTitle,
@@ -208,7 +208,7 @@ export const TreemapConfigPanelItem = ({
       </EuiTitle>
       <div className="first-division">
         <EuiPanel color="subdued">
-          <EuiFormRow label="Child Field">
+          <EuiCompressedFormRow label="Child Field">
             <EuiComboBox
               placeholder="Select a field"
               options={getOptionsAvailable(GROUPBY)}
@@ -222,7 +222,7 @@ export const TreemapConfigPanelItem = ({
                 updateList(GROUPBY, CHILDFIELD, val.length > 0 ? val[0].label : '')
               }
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
 
           <EuiSpacer size="s" />
           <EuiTitle size="xxxs">
@@ -242,7 +242,7 @@ export const TreemapConfigPanelItem = ({
       </EuiTitle>
       <div className="first-division">
         <EuiPanel color="subdued">
-          <EuiFormRow label="Value Field">
+          <EuiCompressedFormRow label="Value Field">
             <EuiComboBox
               placeholder="Select a field"
               options={getOptionsAvailable(AGGREGATIONS)}
@@ -256,7 +256,7 @@ export const TreemapConfigPanelItem = ({
                 updateList(AGGREGATIONS, VALUEFIELD, val.length > 0 ? val[0].label : '')
               }
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiPanel>
       </div>
       <EuiSpacer size="s" />

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexItem,
@@ -262,14 +262,14 @@ export const TreemapConfigPanelItem = ({
       <EuiSpacer size="s" />
       <EuiSpacer size="s" />
       <EuiFlexItem grow={false}>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="visualizeEditorRenderButton"
           iconType="play"
           onClick={() => updateChart()}
           size="s"
         >
           Update chart
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
     </div>
   );

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -143,7 +143,7 @@ export const TreemapConfigPanelItem = ({
           title={`Parent ${index + 1}`}
           closeMenu={() => isHandlePanelClickBack(selectedAxis)}
         />
-        <EuiComboBox
+        <EuiCompressedComboBox
           id={htmlIdGenerator('axis-select-')}
           placeholder="Select a field"
           options={options}
@@ -209,7 +209,7 @@ export const TreemapConfigPanelItem = ({
       <div className="first-division">
         <EuiPanel color="subdued">
           <EuiCompressedFormRow label="Child Field">
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select a field"
               options={getOptionsAvailable(GROUPBY)}
               selectedOptions={
@@ -243,7 +243,7 @@ export const TreemapConfigPanelItem = ({
       <div className="first-division">
         <EuiPanel color="subdued">
           <EuiCompressedFormRow label="Value Field">
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select a field"
               options={getOptionsAvailable(AGGREGATIONS)}
               selectedOptions={

--- a/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/default_vis_editor.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/default_vis_editor.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiForm, EuiFormRow } from '@elastic/eui';
+import { EuiForm, EuiCompressedFormRow } from '@elastic/eui';
 import { ConfigPanelOptions } from './config_controls';
 
 export const VizDataPanel = ({ visualizations, onConfigChange, vizState = {}, tabProps }: any) => {
@@ -20,7 +20,7 @@ export const VizDataPanel = ({ visualizations, onConfigChange, vizState = {}, ta
   const dynamicContent = tabProps.sections.map((section) => {
     const Editor = section.editor;
     return (
-      <EuiFormRow key={section.id} fullWidth>
+      <EuiCompressedFormRow key={section.id} fullWidth>
         <Editor
           visualizations={visualizations}
           schemas={section.schemas}
@@ -30,20 +30,20 @@ export const VizDataPanel = ({ visualizations, onConfigChange, vizState = {}, ta
           sectionId={section.id}
           props={section.props || {}}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   });
 
   return (
     <div className="visEditorSidebar__config">
       <EuiForm className="visEditorSidebar__form">
-        <EuiFormRow>
+        <EuiCompressedFormRow>
           <ConfigPanelOptions
             vizState={vizState?.panelOptions}
             visualizations={visualizations}
             handleConfigChange={handleConfigEditing('panelOptions')}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
         {dynamicContent}
       </EuiForm>
     </div>

--- a/public/components/event_analytics/explorer/visualizations/direct_query_vis.tsx
+++ b/public/components/event_analytics/explorer/visualizations/direct_query_vis.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiCallOut, EuiPage, EuiButton } from '@elastic/eui';
+import { EuiCallOut, EuiPage, EuiSmallButton } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage, I18nProvider } from '@osd/i18n/react';
 
@@ -26,12 +26,12 @@ export const DirectQueryVisualization = ({
               index."
             />
           </p>
-          <EuiButton iconType={'bolt'} onClick={onCreateAcceleration} color="warning">
+          <EuiSmallButton iconType={'bolt'} onClick={onCreateAcceleration} color="warning">
             <FormattedMessage
               id="observability.directQueryVisualization.CreateAcceleration"
               defaultMessage="Create acceleration"
             />
-          </EuiButton>
+          </EuiSmallButton>
         </EuiCallOut>
       </EuiPage>
     </I18nProvider>

--- a/public/components/event_analytics/explorer/visualizations/shared_components/plotly_viz_editor/plotly_actions.tsx
+++ b/public/components/event_analytics/explorer/visualizations/shared_components/plotly_viz_editor/plotly_actions.tsx
@@ -31,7 +31,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { EuiButtonIcon, EuiContextMenuPanel, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiContextMenuPanel, EuiContextMenuItem, EuiPopover } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 
 interface PlotlyEditorActionsMenuProps {
@@ -49,7 +49,7 @@ function PlotlyEditorActionsMenu({ formatHJson }: PlotlyEditorActionsMenuProps) 
 
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
-  const button = <EuiButtonIcon iconType="wrench" onClick={onButtonClick} />;
+  const button = <EuiSmallButtonIcon iconType="wrench" onClick={onButtonClick} />;
 
   const items = [
     <EuiContextMenuItem key="hjson" onClick={onHJsonCLick}>

--- a/public/components/event_analytics/home/home.tsx
+++ b/public/components/event_analytics/home/home.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFlexGroup,
@@ -191,14 +191,14 @@ const EventAnalyticsHome = (props: IHomeProps) => {
   };
 
   const popoverButton = (
-    <EuiButton
+    <EuiSmallButton
       iconType="arrowDown"
       iconSide="right"
       onClick={() => setIsActionsPopoverOpen(!isActionsPopoverOpen)}
       data-test-subj="eventHomeAction"
     >
       Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const deleteHistory = () => {
@@ -282,7 +282,7 @@ const EventAnalyticsHome = (props: IHomeProps) => {
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton
+                    <EuiSmallButton
                       key="redirect"
                       onClick={() => {
                         setIsActionsPopoverOpen(false);
@@ -292,7 +292,7 @@ const EventAnalyticsHome = (props: IHomeProps) => {
                       fill
                     >
                       Event Explorer
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>
@@ -322,22 +322,22 @@ const EventAnalyticsHome = (props: IHomeProps) => {
                     <EuiSpacer size="m" />
                     <EuiFlexGroup justifyContent="center">
                       <EuiFlexItem grow={false}>
-                        <EuiButton
+                        <EuiSmallButton
                           fullWidth={false}
                           onClick={() => history.push(`/explorer`)}
                           data-test-subj="actionEventExplorer"
                         >
                           Event Explorer
-                        </EuiButton>
+                        </EuiSmallButton>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiButton
+                        <EuiSmallButton
                           fullWidth={false}
                           onClick={() => addSampledata()}
                           data-test-subj="actionAddSamples"
                         >
                           Add samples
-                        </EuiButton>
+                        </EuiSmallButton>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiSpacer size="xxl" />

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -16,7 +16,6 @@ import {
   EuiText,
   EuiLink,
   EuiCompressedFormRow,
-  EuiTitle,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { HttpStart } from '../../../../../../src/core/public';
@@ -99,7 +98,10 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
             }
           />
         </EuiCompressedFormRow>
-        <EuiCompressedFormRow label="Name" helpText="This will be used to label the newly added integration.">
+        <EuiCompressedFormRow
+          label="Name"
+          helpText="This will be used to label the newly added integration."
+        >
           <EuiCompressedFieldText
             data-test-subj="new-instance-name"
             name="first"
@@ -122,9 +124,9 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
   return (
     <EuiFlyout data-test-subj="addIntegrationFlyout" onClose={onClose} size="s">
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle data-test-subj="addIntegrationFlyoutTitle">
+        <EuiText data-test-subj="addIntegrationFlyoutTitle" size="s">
           <h2>Add Integration</h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>{renderContent()}</EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -78,7 +78,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
             value={dataSource}
             isInvalid={isDataSourceValid === false}
             append={
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj="validateIndex"
                 onClick={async () => {
                   const validationResult = await doExistingDataSourceValidation(
@@ -95,7 +95,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
                 disabled={dataSource.length === 0}
               >
                 Validate
-              </EuiButton>
+              </EuiSmallButton>
             }
           />
         </EuiFormRow>
@@ -130,12 +130,12 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
       <EuiFlyoutFooter>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiButton onClick={() => onClose()} color="danger">
+            <EuiSmallButton onClick={() => onClose()} color="danger">
               Cancel
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButton
+            <EuiSmallButton
               onClick={() => {
                 onCreate(name, dataSource);
                 onClose();
@@ -152,7 +152,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
               data-click-metric-element="integrations.create_from_setup"
             >
               Add Integration
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -15,7 +15,7 @@ import {
   EuiForm,
   EuiText,
   EuiLink,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiTitle,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -54,7 +54,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
   const formContent = () => {
     return (
       <div>
-        <EuiFormRow
+        <EuiCompressedFormRow
           label="Index name or wildcard pattern"
           helpText="Input an index name or wildcard pattern that your integration will query."
           isInvalid={isDataSourceValid === false}
@@ -98,15 +98,15 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
               </EuiSmallButton>
             }
           />
-        </EuiFormRow>
-        <EuiFormRow label="Name" helpText="This will be used to label the newly added integration.">
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow label="Name" helpText="This will be used to label the newly added integration.">
           <EuiFieldText
             data-test-subj="new-instance-name"
             name="first"
             onChange={(e) => onNameChange(e)}
             value={name}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </div>
     );
   };

--- a/public/components/integrations/components/add_integration_flyout.tsx
+++ b/public/components/integrations/components/add_integration_flyout.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -71,7 +71,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
             </EuiText>
           }
         >
-          <EuiFieldText
+          <EuiCompressedFieldText
             data-test-subj="data-source-name"
             name="first"
             onChange={(e) => onDatasourceChange(e)}
@@ -100,7 +100,7 @@ export function AddIntegrationFlyout(props: IntegrationFlyoutProps) {
           />
         </EuiCompressedFormRow>
         <EuiCompressedFormRow label="Name" helpText="This will be used to label the newly added integration.">
-          <EuiFieldText
+          <EuiCompressedFieldText
             data-test-subj="new-instance-name"
             name="first"
             onChange={(e) => onNameChange(e)}

--- a/public/components/integrations/components/added_integration.tsx
+++ b/public/components/integrations/components/added_integration.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHealth,
@@ -135,7 +135,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
               </EuiFlexGroup>
 
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   iconType="trash"
                   aria-label="Delete"
                   color="danger"

--- a/public/components/integrations/components/added_integration.tsx
+++ b/public/components/integrations/components/added_integration.tsx
@@ -21,7 +21,6 @@ import {
   EuiSpacer,
   EuiTableFieldDataColumnType,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import truncate from 'lodash/truncate';
@@ -125,9 +124,9 @@ export function AddedIntegration(props: AddedIntegrationProps) {
             <EuiFlexGroup gutterSize="xs">
               <EuiFlexGroup>
                 <EuiFlexItem grow={false}>
-                  <EuiTitle data-test-subj="eventHomePageTitle" size="l">
+                  <EuiText data-test-subj="eventHomePageTitle" size="s">
                     <h1>{data?.name}</h1>
-                  </EuiTitle>
+                  </EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem style={{ justifyContent: 'center' }}>
                   <IntegrationHealthBadge status={data?.status} />

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiButtonGroup,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -90,7 +90,7 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
     <EuiPanel>
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>
-          <EuiFieldSearch
+          <EuiCompressedFieldSearch
             fullWidth
             isClearable={false}
             placeholder="Search..."

--- a/public/components/integrations/components/available_integration_overview_page.tsx
+++ b/public/components/integrations/components/available_integration_overview_page.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiFieldSearch,
-  EuiFilterButton,
+  EuiSmallFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
   EuiPage,
@@ -71,7 +71,7 @@ export const CategoryFilters = ({ items, setItems }: CategoryFiltersProps) => {
   };
 
   const button = (
-    <EuiFilterButton
+    <EuiSmallFilterButton
       iconType="arrowDown"
       onClick={onButtonClick}
       isSelected={isPopoverOpen}
@@ -80,7 +80,7 @@ export const CategoryFilters = ({ items, setItems }: CategoryFiltersProps) => {
       numActiveFilters={items.filter((item) => item.checked).length}
     >
       Categories
-    </EuiFilterButton>
+    </EuiSmallFilterButton>
   );
 
   return (

--- a/public/components/integrations/components/available_integration_table.tsx
+++ b/public/components/integrations/components/available_integration_table.tsx
@@ -146,7 +146,7 @@ export function AvailableIntegrationsTable(props: AvailableIntegrationsTableProp
       ) : (
         <>
           <EuiSpacer size="xxl" />
-          <EuiText textAlign="center">
+          <EuiText textAlign="center" size="s">
             <h2>No Integrations Available</h2>
           </EuiText>
           <EuiSpacer size="m" />

--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -125,6 +125,7 @@ export function Integration(props: AvailableIntegrationProps) {
         disabled={tab.disabled}
         key={index}
         data-test-subj={tab.id}
+        s
       >
         {tab.name}
       </EuiTab>
@@ -164,7 +165,9 @@ export function Integration(props: AvailableIntegrationProps) {
         <EuiSpacer />
         {IntegrationScreenshots({ integration, http })}
         <EuiSpacer />
-        <EuiTabs display="condensed">{renderTabs()}</EuiTabs>
+        <EuiTabs display="condensed" size="s">
+          {renderTabs()}
+        </EuiTabs>
         <EuiSpacer size="s" />
         {selectedTabId === 'assets'
           ? IntegrationAssets({ integration, integrationAssets })

--- a/public/components/integrations/components/integration_details_panel.tsx
+++ b/public/components/integrations/components/integration_details_panel.tsx
@@ -71,22 +71,24 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
           <EuiText>
             <h4>Contributer</h4>
           </EuiText>
-          <EuiLink href={config.sourceUrl} external={true} target="blank">
-            {config.author}
-          </EuiLink>
+          <EuiText size="s">
+            <EuiLink href={config.sourceUrl} external={true} target="blank">
+              {config.author}
+            </EuiLink>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText>
             <h4>License</h4>
           </EuiText>
-          <EuiText size="m">{config.license}</EuiText>
+          <EuiText size="s">{config.license}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexItem>
         <EuiText>
           <h4>Description</h4>
         </EuiText>
-        <EuiText size="m">{config.description}</EuiText>
+        <EuiText size="s">{config.description}</EuiText>
       </EuiFlexItem>
     </EuiPanel>
   );

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiLink,
@@ -47,9 +47,9 @@ export const IntegrationHeaderActions = ({ onShowUpload }: { onShowUpload: () =>
     <EuiContextMenuItem href={OPENSEARCH_CATALOG_URL}>View Catalog</EuiContextMenuItem>,
   ];
   const button = (
-    <EuiButton iconType="arrowDown" fill={true} onClick={onButtonClick}>
+    <EuiSmallButton iconType="arrowDown" fill={true} onClick={onButtonClick}>
       Catalog
-    </EuiButton>
+    </EuiSmallButton>
   );
   return (
     <EuiPopover

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -15,7 +15,6 @@ import {
   EuiTab,
   EuiTabs,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import {
@@ -106,9 +105,9 @@ export const IntegrationHeader = () => {
     <div>
       <EuiPageHeader>
         <EuiPageHeaderSection>
-          <EuiTitle size="l" data-test-subj="integrations-header">
+          <EuiText size="s" data-test-subj="integrations-header">
             <h1>Integrations</h1>
-          </EuiTitle>
+          </EuiText>
         </EuiPageHeaderSection>
         <EuiPageHeaderSection>
           <IntegrationHeaderActions onShowUpload={() => setShowUploadFlyout(true)} />

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -59,7 +59,7 @@ export const IntegrationHeaderActions = ({ onShowUpload }: { onShowUpload: () =>
       panelPaddingSize="none"
       anchorPosition="downLeft"
     >
-      <EuiContextMenuPanel items={items} />
+      <EuiContextMenuPanel items={items} size="s" />
     </EuiPopover>
   );
 };
@@ -121,7 +121,9 @@ export const IntegrationHeader = () => {
         </EuiLink>
       </EuiText>
       <EuiSpacer size="l" />
-      <EuiTabs display="condensed">{renderTabs()}</EuiTabs>
+      <EuiTabs display="condensed" size="s">
+        {renderTabs()}
+      </EuiTabs>
       <EuiSpacer size="s" />
       {showUploadFlyout ? (
         <IntegrationUploadFlyout onClose={() => setShowUploadFlyout(false)} />

--- a/public/components/integrations/components/integration_overview_panel.tsx
+++ b/public/components/integrations/components/integration_overview_panel.tsx
@@ -9,9 +9,9 @@ import {
   EuiPageHeader,
   EuiPageHeaderSection,
   EuiSpacer,
-  EuiTitle,
   EuiFlexItem,
   EuiPageContentHeaderSection,
+  EuiText,
 } from '@elastic/eui';
 import React from 'react';
 
@@ -32,9 +32,9 @@ export function IntegrationOverview(props: any) {
         <EuiPageContentHeaderSection>
           <EuiFlexGroup gutterSize="xs" justifyContent="spaceBetween">
             <EuiFlexItem>
-              <EuiTitle data-test-subj="eventHomePageTitle" size="l">
+              <EuiText data-test-subj="eventHomePageTitle" size="s">
                 <h1>{config.displayName || config.name}</h1>
-              </EuiTitle>
+              </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton

--- a/public/components/integrations/components/integration_overview_panel.tsx
+++ b/public/components/integrations/components/integration_overview_panel.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiSmallButton,
+  EuiButton,
   EuiFlexGroup,
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -37,7 +37,7 @@ export function IntegrationOverview(props: any) {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiSmallButton
+              <EuiButton
                 size="m"
                 onClick={() => {
                   props.setUpSample();
@@ -47,10 +47,10 @@ export function IntegrationOverview(props: any) {
                 data-click-metric-element="integrations.create_from_try_it"
               >
                 Try It
-              </EuiSmallButton>
+              </EuiButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiSmallButton
+              <EuiButton
                 size="m"
                 onClick={() => {
                   props.showFlyout(config.name);
@@ -61,7 +61,7 @@ export function IntegrationOverview(props: any) {
                 data-click-metric-element="integrations.set_up"
               >
                 Set Up
-              </EuiSmallButton>
+              </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPageContentHeaderSection>

--- a/public/components/integrations/components/integration_overview_panel.tsx
+++ b/public/components/integrations/components/integration_overview_panel.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiPageHeader,
   EuiPageHeaderSection,
@@ -37,7 +37,7 @@ export function IntegrationOverview(props: any) {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 size="m"
                 onClick={() => {
                   props.setUpSample();
@@ -47,10 +47,10 @@ export function IntegrationOverview(props: any) {
                 data-click-metric-element="integrations.create_from_try_it"
               >
                 Try It
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 size="m"
                 onClick={() => {
                   props.showFlyout(config.name);
@@ -61,7 +61,7 @@ export function IntegrationOverview(props: any) {
                 data-click-metric-element="integrations.set_up"
               >
                 Set Up
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPageContentHeaderSection>

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -6,7 +6,7 @@
 import {
   EuiBottomBar,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -268,7 +268,7 @@ export function SetupBottomBar({
   return (
     <EuiFlexGroup justifyContent="flexEnd">
       <EuiFlexItem grow={false}>
-        <EuiButtonEmpty
+        <EuiSmallButtonEmpty
           color="text"
           iconType="cross"
           onClick={() => {
@@ -286,7 +286,7 @@ export function SetupBottomBar({
           disabled={loading}
         >
           Discard
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiSmallButton

--- a/public/components/integrations/components/setup_integration.tsx
+++ b/public/components/integrations/components/setup_integration.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiBottomBar,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -289,7 +289,7 @@ export function SetupBottomBar({
         </EuiButtonEmpty>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton
+        <EuiSmallButton
           fill
           iconType="arrowRight"
           iconSide="right"
@@ -321,7 +321,7 @@ export function SetupBottomBar({
           data-test-subj="create-instance-button"
         >
           Add Integration
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -248,7 +248,7 @@ export function IntegrationConnectionInputs({
           <EuiSpacer />
         </>
       )}
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Connection Type"
         helpText="Select the type of connection to use for queries."
       >

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -7,7 +7,7 @@ import {
   EuiCallOut,
   EuiCheckableCard,
   EuiComboBox,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
   EuiSelect,
@@ -177,7 +177,7 @@ export function IntegrationDetailsInputs({
       error={['Must be at least 1 character.']}
       isInvalid={config.displayName.length === 0}
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         value={config.displayName}
         onChange={(event) => updateConfig({ displayName: event.target.value })}
         placeholder={`${integration.name} Integration`}
@@ -330,7 +330,7 @@ export function IntegrationQueryInputs({
             error={['Must be at least 1 character.']}
             isInvalid={config.connectionTableName.length === 0}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               placeholder={integration.name}
               value={config.connectionTableName}
               onChange={(evt) => {
@@ -344,7 +344,7 @@ export function IntegrationQueryInputs({
             isInvalid={isBucketBlurred && !config.connectionLocation.startsWith('s3://')}
             error={["Must be a URL starting with 's3://'."]}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               value={config.connectionLocation}
               onChange={(event) => updateConfig({ connectionLocation: event.target.value })}
               placeholder="s3://"
@@ -367,7 +367,7 @@ export function IntegrationQueryInputs({
         isInvalid={isCheckpointBlurred && !config.checkpointLocation.startsWith('s3://')}
         error={["Must be a URL starting with 's3://'."]}
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           value={config.checkpointLocation}
           onChange={(event) => updateConfig({ checkpointLocation: event.target.value })}
           placeholder="s3://"

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -10,7 +10,7 @@ import {
   EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -252,7 +252,7 @@ export function IntegrationConnectionInputs({
         label="Connection Type"
         helpText="Select the type of connection to use for queries."
       >
-        <EuiSelect
+        <EuiCompressedSelect
           options={integrationConnectionSelectorItems.filter((item) => {
             if (item.value === 'securityLake') {
               return (

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -9,7 +9,7 @@ import {
   EuiComboBox,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiSpacer,
   EuiText,
@@ -172,7 +172,7 @@ export function IntegrationDetailsInputs({
   integration: IntegrationConfig;
 }) {
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       label={'Integration display Name'}
       error={['Must be at least 1 character.']}
       isInvalid={config.displayName.length === 0}
@@ -184,7 +184,7 @@ export function IntegrationDetailsInputs({
         isInvalid={config.displayName.length === 0}
         data-test-subj="new-instance-name"
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }
 
@@ -233,7 +233,7 @@ export function IntegrationConnectionInputs({
     <>
       {dataSourceEnabled && (
         <>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Data Source"
             helpText="Select the type of remote data source to query from."
           >
@@ -244,7 +244,7 @@ export function IntegrationConnectionInputs({
               fullWidth={false}
               removePrepend={true}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
         </>
       )}
@@ -276,8 +276,8 @@ export function IntegrationConnectionInputs({
           }
           disabled={lockConnectionType}
         />
-      </EuiFormRow>
-      <EuiFormRow label={connectionType.title} helpText={connectionType.help}>
+      </EuiCompressedFormRow>
+      <EuiCompressedFormRow label={connectionType.title} helpText={connectionType.help}>
         <EuiComboBox
           options={dataSourceSuggestions}
           isLoading={isSuggestionsLoading}
@@ -303,7 +303,7 @@ export function IntegrationConnectionInputs({
           data-test-subj="data-source-name"
           isDisabled={lockConnectionType}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 }
@@ -324,7 +324,7 @@ export function IntegrationQueryInputs({
     <>
       {config.connectionType !== 'securityLake' && (
         <>
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Spark Table Name"
             helpText="Select a table name to associate with your data."
             error={['Must be at least 1 character.']}
@@ -338,8 +338,8 @@ export function IntegrationQueryInputs({
               }}
               isInvalid={config.connectionTableName.length === 0}
             />
-          </EuiFormRow>
-          <EuiFormRow
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow
             label="S3 Data Location"
             isInvalid={isBucketBlurred && !config.connectionLocation.startsWith('s3://')}
             error={["Must be a URL starting with 's3://'."]}
@@ -353,10 +353,10 @@ export function IntegrationQueryInputs({
                 setIsBucketBlurred(true);
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </>
       )}
-      <EuiFormRow
+      <EuiCompressedFormRow
         label={`S3 Checkpoint Location`}
         helpText={
           config.connectionType === 'securityLake'
@@ -376,7 +376,7 @@ export function IntegrationQueryInputs({
             setIsCheckpointBlurred(true);
           }}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 }
@@ -414,7 +414,7 @@ export function IntegrationWorkflowsInputs({
   }, [useWorkflows]);
 
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       isInvalid={![...useWorkflows.values()].includes(true)}
       error={['Must select at least one workflow.']}
     >
@@ -424,7 +424,7 @@ export function IntegrationWorkflowsInputs({
         useWorkflows={useWorkflows}
         toggleWorkflow={toggleWorkflow}
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }
 
@@ -483,14 +483,14 @@ export function SetupIntegrationFormInputs(props: IntegrationConfigProps) {
           <EuiText>
             <h3>Query Fields</h3>
           </EuiText>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiText grow={false} size="xs">
               <p>
                 To set up the integration, we need to know some information about how to process
                 your data.
               </p>
             </EuiText>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
           <IntegrationQueryInputs
             config={config}
@@ -503,7 +503,7 @@ export function SetupIntegrationFormInputs(props: IntegrationConfigProps) {
               <EuiText>
                 <h3>Integration Resources</h3>
               </EuiText>
-              <EuiFormRow>
+              <EuiCompressedFormRow>
                 <EuiText grow={false} size="xs">
                   <p>
                     This integration offers different kinds of resources compatible with your data
@@ -511,7 +511,7 @@ export function SetupIntegrationFormInputs(props: IntegrationConfigProps) {
                     Select at least one of the following options.
                   </p>
                 </EuiText>
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               <EuiSpacer />
               <IntegrationWorkflowsInputs
                 config={config}

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -13,7 +13,6 @@ import {
   EuiCompressedSelect,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { NotificationsStart, SavedObjectsStart } from '../../../../../../src/core/public';
@@ -443,9 +442,9 @@ export function SetupIntegrationFormInputs(props: IntegrationConfigProps) {
 
   return (
     <EuiForm>
-      <EuiTitle>
+      <EuiText size="s">
         <h1>Set Up Integration</h1>
-      </EuiTitle>
+      </EuiText>
       <EuiSpacer />
       {setupCallout.show ? (
         <EuiCallOut title={setupCallout.title} color="danger">

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -6,7 +6,7 @@
 import {
   EuiCallOut,
   EuiCheckableCard,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
@@ -278,7 +278,7 @@ export function IntegrationConnectionInputs({
         />
       </EuiCompressedFormRow>
       <EuiCompressedFormRow label={connectionType.title} helpText={connectionType.help}>
-        <EuiComboBox
+        <EuiCompressedComboBox
           options={dataSourceSuggestions}
           isLoading={isSuggestionsLoading}
           onChange={(selected) => {

--- a/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
+++ b/public/components/integrations/components/setup_integration_inputs_security_lake.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   EuiCallOut,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -130,7 +130,7 @@ export const SetupIntegrationInputsForSecurityLake = ({
           <EuiText>
             <h3>Included resources</h3>
           </EuiText>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiText grow={false} size="xs">
               <p>
                 This integration offers resources compatible with your data source. These can
@@ -138,7 +138,7 @@ export const SetupIntegrationInputsForSecurityLake = ({
                 following options.
               </p>
             </EuiText>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
           <EuiSpacer />
           <IntegrationWorkflowsInputs
             updateConfig={updateConfig}

--- a/public/components/integrations/components/upload_flyout.tsx
+++ b/public/components/integrations/components/upload_flyout.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
@@ -147,10 +147,10 @@ export const IntegrationUploadFlyout = ({ onClose }: { onClose: () => void }) =>
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="spaceBetween">
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={onClose}>Cancel</EuiButton>
+            <EuiSmallButton onClick={onClose}>Cancel</EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               disabled={isInvalid}
               onClick={async () => {
@@ -164,7 +164,7 @@ export const IntegrationUploadFlyout = ({ onClose }: { onClose: () => void }) =>
               }}
             >
               Upload
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlyoutFooter>

--- a/public/components/integrations/components/upload_flyout.tsx
+++ b/public/components/integrations/components/upload_flyout.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiFilePicker,
+  EuiCompressedFilePicker,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -117,7 +117,7 @@ export const IntegrationUploadPicker = ({
         isInvalid={checkCompleted && isInvalid}
         error={['Must be an ndjson bundle of integration templates']}
       >
-        <EuiFilePicker
+        <EuiCompressedFilePicker
           id="integrationBundlePicker"
           initialPromptText="Select or drag and drop integration bundles"
           onChange={handleFileChange}

--- a/public/components/integrations/components/upload_flyout.tsx
+++ b/public/components/integrations/components/upload_flyout.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlyoutHeader,
   EuiForm,
   EuiCompressedFormRow,
+  EuiText,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { useToast } from '../../../../public/components/common/toast';
@@ -136,7 +137,11 @@ export const IntegrationUploadFlyout = ({ onClose }: { onClose: () => void }) =>
 
   return (
     <EuiFlyout onClose={onClose} size="s">
-      <EuiFlyoutHeader>Upload Integrations</EuiFlyoutHeader>
+      <EuiFlyoutHeader>
+        <EuiText size="s">
+          <h2>Upload Integrations</h2>
+        </EuiText>
+      </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <IntegrationUploadPicker
           onFileSelected={setBundle}

--- a/public/components/integrations/components/upload_flyout.tsx
+++ b/public/components/integrations/components/upload_flyout.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { useToast } from '../../../../public/components/common/toast';
@@ -112,7 +112,7 @@ export const IntegrationUploadPicker = ({
 
   return (
     <EuiForm>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Select file"
         isInvalid={checkCompleted && isInvalid}
         error={['Must be an ndjson bundle of integration templates']}
@@ -124,7 +124,7 @@ export const IntegrationUploadPicker = ({
           isInvalid={checkCompleted && isInvalid}
           onBlur={() => setBlurred(true)}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiForm>
   );
 };

--- a/public/components/metrics/sidebar/data_source_picker.tsx
+++ b/public/components/metrics/sidebar/data_source_picker.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiComboBox, EuiTitle } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiTitle } from '@elastic/eui';
 import React from 'react';
 import { DATASOURCE_OPTIONS } from '../../../../common/constants/metrics';
 import { OptionType } from '../../../../common/types/metrics';
@@ -26,7 +26,7 @@ export const DataSourcePicker = ({
       <EuiTitle size="xxxs">
         <h5>Metrics source</h5>
       </EuiTitle>
-      <EuiComboBox
+      <EuiCompressedComboBox
         placeholder="Select a metric source"
         singleSelection={{ asPlainText: true }}
         options={DATASOURCE_OPTIONS}

--- a/public/components/metrics/sidebar/index_picker.tsx
+++ b/public/components/metrics/sidebar/index_picker.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiComboBox, EuiTitle } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiTitle } from '@elastic/eui';
 import React, { useState } from 'react';
 
 export const IndexPicker = (props: { otelIndices: unknown; setSelectedOTIndex: unknown }) => {
@@ -23,7 +23,7 @@ export const IndexPicker = (props: { otelIndices: unknown; setSelectedOTIndex: u
       <EuiTitle size="xxxs">
         <h5>Otel Index</h5>
       </EuiTitle>
-      <EuiComboBox
+      <EuiCompressedComboBox
         placeholder="Select an index"
         singleSelection={{ asPlainText: true }}
         options={otelIndex}

--- a/public/components/metrics/top_menu/metrics_export.tsx
+++ b/public/components/metrics/top_menu/metrics_export.tsx
@@ -373,6 +373,7 @@ const MetricsExportPopOver = () => {
       button={<Savebutton setIsPanelOpen={setIsPanelOpen} />}
       isOpen={isPanelOpen}
       closePopover={() => setIsPanelOpen(false)}
+      panelPaddingSize="s"
     >
       <MetricsExportPanel
         availableDashboards={availableDashboards ?? []}

--- a/public/components/metrics/top_menu/metrics_export.tsx
+++ b/public/components/metrics/top_menu/metrics_export.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -49,7 +49,7 @@ const Savebutton = ({
   setIsPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   return (
-    <EuiButton
+    <EuiSmallButton
       iconSide="right"
       onClick={() => {
         setIsPanelOpen((staleState) => !staleState);
@@ -58,7 +58,7 @@ const Savebutton = ({
       iconType="arrowDown"
     >
       Save
-    </EuiButton>
+    </EuiSmallButton>
   );
 };
 
@@ -392,7 +392,7 @@ const MetricsExportPopOver = () => {
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               size="s"
               fill
               onClick={() => {
@@ -401,7 +401,7 @@ const MetricsExportPopOver = () => {
               data-test-subj="metrics__SaveConfirm"
             >
               Save
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPopoverFooter>

--- a/public/components/metrics/top_menu/metrics_export.tsx
+++ b/public/components/metrics/top_menu/metrics_export.tsx
@@ -5,6 +5,7 @@
 
 import {
   EuiSmallButton,
+  EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -392,7 +393,7 @@ const MetricsExportPopOver = () => {
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiSmallButton
+            <EuiButton
               size="s"
               fill
               onClick={() => {
@@ -401,7 +402,7 @@ const MetricsExportPopOver = () => {
               data-test-subj="metrics__SaveConfirm"
             >
               Save
-            </EuiSmallButton>
+            </EuiButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPopoverFooter>

--- a/public/components/metrics/top_menu/metrics_export_panel.tsx
+++ b/public/components/metrics/top_menu/metrics_export_panel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useEffect } from 'react';
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFieldText,
   EuiFlexGroup,
   EuiCompressedFormRow,
@@ -57,7 +57,7 @@ export const MetricsExportPanel = ({
         label="Custom operational dashboards/application"
         helpText="Search existing dashboards or applications by name"
       >
-        <EuiComboBox
+        <EuiCompressedComboBox
           placeholder="Select dashboards/applications"
           onChange={(newOptions) => {
             setSelectedPanelOptions(newOptions);

--- a/public/components/metrics/top_menu/metrics_export_panel.tsx
+++ b/public/components/metrics/top_menu/metrics_export_panel.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect } from 'react';
 import {
   EuiComboBox,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiCompressedFormRow,
   EuiFlexItem,
@@ -84,7 +84,7 @@ export const MetricsExportPanel = ({
                 <EuiFlexGroup>
                   <EuiFlexItem>
                     <EuiCompressedFormRow label={'Metric Name #' + (index + 1)}>
-                      <EuiFieldText
+                      <EuiCompressedFieldText
                         key={`metric-name-input-id-${index}`}
                         value={metaData.name}
                         onChange={(e) => onNameChange(index, e.target.value)}

--- a/public/components/metrics/top_menu/metrics_export_panel.tsx
+++ b/public/components/metrics/top_menu/metrics_export_panel.tsx
@@ -8,7 +8,7 @@ import {
   EuiComboBox,
   EuiFieldText,
   EuiFlexGroup,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFlexItem,
   EuiForm,
 } from '@elastic/eui';
@@ -53,7 +53,7 @@ export const MetricsExportPanel = ({
 
   return (
     <div style={{ minWidth: '15vw' }}>
-      <EuiFormRow
+      <EuiCompressedFormRow
         label="Custom operational dashboards/application"
         helpText="Search existing dashboards or applications by name"
       >
@@ -74,7 +74,7 @@ export const MetricsExportPanel = ({
           isClearable={true}
           data-test-subj="eventExplorer__querySaveComboBox"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
 
       {metricsToExport.length > 0 && (
         <div style={{ maxHeight: '30vh', overflowY: 'scroll', width: 'auto', overflowX: 'hidden' }}>
@@ -83,14 +83,14 @@ export const MetricsExportPanel = ({
               <EuiForm component="form" key={`save-panel-id-${index}`}>
                 <EuiFlexGroup>
                   <EuiFlexItem>
-                    <EuiFormRow label={'Metric Name #' + (index + 1)}>
+                    <EuiCompressedFormRow label={'Metric Name #' + (index + 1)}>
                       <EuiFieldText
                         key={`metric-name-input-id-${index}`}
                         value={metaData.name}
                         onChange={(e) => onNameChange(index, e.target.value)}
                         data-test-subj="metrics__querySaveName"
                       />
-                    </EuiFormRow>
+                    </EuiCompressedFormRow>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiForm>

--- a/public/components/metrics/top_menu/top_menu.tsx
+++ b/public/components/metrics/top_menu/top_menu.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSelect,
@@ -29,7 +29,7 @@ export const TopMenu = () => {
         <EuiFlexGroup gutterSize="s" justifyContent={'flexEnd'}>
           <EuiFlexItem grow={false}>
             <div className="resolutionSelect">
-              <EuiFieldText
+              <EuiCompressedFieldText
                 className="resolutionSelectText"
                 prepend="Span Interval"
                 value={dateSpanFilter.span}

--- a/public/components/metrics/top_menu/top_menu.tsx
+++ b/public/components/metrics/top_menu/top_menu.tsx
@@ -7,7 +7,7 @@ import {
   EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiSuperDatePicker,
 } from '@elastic/eui';
 import React from 'react';
@@ -37,7 +37,7 @@ export const TopMenu = () => {
                 onChange={(e) => dispatch(setDateSpan({ span: e.target.value }))}
                 data-test-subj="metrics__spanValue"
                 append={
-                  <EuiSelect
+                  <EuiCompressedSelect
                     className="resolutionSelectOption"
                     options={resolutionOptions}
                     value={dateSpanFilter.resolution}

--- a/public/components/metrics/top_menu/top_menu.tsx
+++ b/public/components/metrics/top_menu/top_menu.tsx
@@ -8,7 +8,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedSelect,
-  EuiSuperDatePicker,
+  EuiCompressedSuperDatePicker,
 } from '@elastic/eui';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -51,7 +51,7 @@ export const TopMenu = () => {
             </div>
           </EuiFlexItem>
           <EuiFlexItem className="metrics-search-bar-datepicker">
-            <EuiSuperDatePicker
+            <EuiCompressedSuperDatePicker
               dateFormat={uiSettingsService.get('dateFormat')}
               start={dateSpanFilter.start}
               end={dateSpanFilter.end}

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -16,6 +16,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiSmallButton,
+  EuiText,
 } from '@elastic/eui';
 
 /*
@@ -30,7 +31,7 @@ import {
  * btn2txt - string as content to fill "confirm button"
  * openNoteName - Default input value for the field
  */
-type CustomInputModalProps = {
+interface CustomInputModalProps {
   runModal: (value: string) => void;
   closeModal: (
     event?: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -41,10 +42,19 @@ type CustomInputModalProps = {
   btn2txt: string;
   openNoteName: string;
   helpText: string;
-};
+}
 
 export const CustomInputModal = (props: CustomInputModalProps) => {
-  const { runModal, closeModal, labelTxt, titletxt, btn1txt, btn2txt, openNoteName, helpText } = props;
+  const {
+    runModal,
+    closeModal,
+    labelTxt,
+    titletxt,
+    btn1txt,
+    btn2txt,
+    openNoteName,
+    helpText,
+  } = props;
   const [value, setValue] = useState(openNoteName || ''); // sets input value
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,7 +65,11 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={closeModal} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{titletxt}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{titletxt}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
@@ -73,7 +87,10 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
 
         <EuiModalFooter>
           <EuiSmallButtonEmpty onClick={closeModal}>{btn1txt}</EuiSmallButtonEmpty>
-          <EuiSmallButton data-test-subj="custom-input-modal-confirm-button" onClick={() => runModal(value)} fill>
+          <EuiSmallButton
+            data-test-subj="custom-input-modal-confirm-button"
+            onClick={() => runModal(value)}
+          >
             {btn2txt}
           </EuiSmallButton>
         </EuiModalFooter>

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -15,7 +15,7 @@ import {
   EuiOverlayMask,
   EuiFormRow,
   EuiFieldText,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 
 /*
@@ -73,9 +73,9 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
 
         <EuiModalFooter>
           <EuiButtonEmpty onClick={closeModal}>{btn1txt}</EuiButtonEmpty>
-          <EuiButton data-test-subj="custom-input-modal-confirm-button" onClick={() => runModal(value)} fill>
+          <EuiSmallButton data-test-subj="custom-input-modal-confirm-button" onClick={() => runModal(value)} fill>
             {btn2txt}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -14,7 +14,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSmallButton,
 } from '@elastic/eui';
 
@@ -61,7 +61,7 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
         <EuiModalBody>
           <EuiForm>
             <EuiCompressedFormRow label={labelTxt} helpText={helpText}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="custom-input-modal-input"
                 name="input"
                 value={value}

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import {
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiForm,
   EuiModal,
   EuiModalBody,
@@ -72,7 +72,7 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={closeModal}>{btn1txt}</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={closeModal}>{btn1txt}</EuiSmallButtonEmpty>
           <EuiSmallButton data-test-subj="custom-input-modal-confirm-button" onClick={() => runModal(value)} fill>
             {btn2txt}
           </EuiSmallButton>

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -13,7 +13,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiOverlayMask,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiSmallButton,
 } from '@elastic/eui';
@@ -60,14 +60,14 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
 
         <EuiModalBody>
           <EuiForm>
-            <EuiFormRow label={labelTxt} helpText={helpText}>
+            <EuiCompressedFormRow label={labelTxt} helpText={helpText}>
               <EuiFieldText
                 data-test-subj="custom-input-modal-input"
                 name="input"
                 value={value}
                 onChange={(e) => onChange(e)}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiModalBody>
 

--- a/public/components/notebooks/components/helpers/custom_modals/reporting_loading_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/reporting_loading_modal.tsx
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { 
-  EuiOverlayMask, 
-  EuiModal, 
-  EuiModalHeader, 
-  EuiTitle, 
-  EuiText, 
-  EuiModalBody, 
-  EuiSpacer, 
-  EuiFlexGroup, 
-  EuiFlexItem, 
-  EuiLoadingSpinner, 
-  EuiButton 
+import {
+  EuiOverlayMask,
+  EuiModal,
+  EuiModalHeader,
+  EuiTitle,
+  EuiText,
+  EuiModalBody,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLoadingSpinner,
+  EuiSmallButton
 } from "@elastic/eui";
 import React from "react";
 
@@ -22,7 +22,7 @@ export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
   const {
     setShowLoading
   } = props;
-  
+
   const closeModal = () => {
     setShowLoading(false);
   };
@@ -54,12 +54,12 @@ export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
             <EuiSpacer size="l" />
             <EuiFlexGroup alignItems="flexEnd" justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="reporting-loading-modal-close-button"
                   onClick={closeModal}
                 >
                   Close
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiModalBody>

--- a/public/components/notebooks/components/helpers/custom_modals/reporting_loading_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/reporting_loading_modal.tsx
@@ -7,21 +7,18 @@ import {
   EuiOverlayMask,
   EuiModal,
   EuiModalHeader,
-  EuiTitle,
   EuiText,
   EuiModalBody,
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
-  EuiSmallButton
-} from "@elastic/eui";
-import React from "react";
+  EuiSmallButton,
+} from '@elastic/eui';
+import React from 'react';
 
-export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
-  const {
-    setShowLoading
-  } = props;
+export function GenerateReportLoadingModal(props: { setShowLoading: any }) {
+  const { setShowLoading } = props;
 
   const closeModal = () => {
     setShowLoading(false);
@@ -36,15 +33,15 @@ export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
           id="downloadInProgressLoadingModal"
         >
           <EuiModalHeader>
-            <EuiTitle>
-              <EuiText textAlign="right">
-                <h2>Generating report</h2>
-              </EuiText>
-            </EuiTitle>
+            <EuiText size="s" textAlign="right">
+              <h2>Generating report</h2>
+            </EuiText>
           </EuiModalHeader>
           <EuiModalBody>
-            <EuiText>Preparing your file for download.</EuiText>
-            <EuiText>You can close this dialog while we continue in the background.</EuiText>
+            <EuiText size="s">Preparing your file for download.</EuiText>
+            <EuiText size="s">
+              You can close this dialog while we continue in the background.
+            </EuiText>
             <EuiSpacer />
             <EuiFlexGroup justifyContent="center" alignItems="center">
               <EuiFlexItem grow={false}>
@@ -67,4 +64,4 @@ export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
       </EuiOverlayMask>
     </div>
   );
-};
+}

--- a/public/components/notebooks/components/helpers/modal_containers.tsx
+++ b/public/components/notebooks/components/helpers/modal_containers.tsx
@@ -18,7 +18,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiText,
-  EuiSpacer
+  EuiSpacer,
 } from '@elastic/eui';
 import { CustomInputModal } from './custom_modals/custom_input_modal';
 
@@ -38,7 +38,7 @@ export const getCustomModal = (
   btn1txt: string,
   btn2txt: string,
   openNoteName?: string,
-  helpText?: string,
+  helpText?: string
 ) => {
   return (
     <CustomInputModal
@@ -92,7 +92,12 @@ export const getSampleNotebooksModal = (
         confirmButtonText="Yes"
         defaultFocusedButton="confirm"
       >
-        <p>Do you want to add sample notebooks? This will also add Dashboards sample flights and logs data if they have not been added.</p>
+        <EuiText size="s">
+          <p>
+            Do you want to add sample notebooks? This will also add Dashboards sample flights and
+            logs data if they have not been added.
+          </p>
+        </EuiText>
       </EuiConfirmModal>
     </EuiOverlayMask>
   );
@@ -105,7 +110,7 @@ export const getDeleteModal = (
   onConfirm: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void,
   title: string,
   message: string,
-  confirmMessage?: string,
+  confirmMessage?: string
 ) => {
   return (
     <EuiOverlayMask>
@@ -114,11 +119,11 @@ export const getDeleteModal = (
         onCancel={onCancel}
         onConfirm={onConfirm}
         cancelButtonText="Cancel"
-        confirmButtonText={confirmMessage || "Delete"}
+        confirmButtonText={confirmMessage || 'Delete'}
         buttonColor="danger"
         defaultFocusedButton="confirm"
       >
-        {message}
+        <EuiText size="s">{message}</EuiText>
       </EuiConfirmModal>
     </EuiOverlayMask>
   );
@@ -145,12 +150,16 @@ export const DeleteNotebookModal = ({
     <EuiOverlayMask>
       <EuiModal onClose={onCancel} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{title}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiText>{message}</EuiText>
-          <EuiText>The action cannot be undone.</EuiText>
+          <EuiText size="s">{message}</EuiText>
+          <EuiText size="s">The action cannot be undone.</EuiText>
           <EuiSpacer />
           <EuiForm>
             <EuiCompressedFormRow label={'To confirm deletion, enter "delete" in the text field'}>

--- a/public/components/notebooks/components/helpers/modal_containers.tsx
+++ b/public/components/notebooks/components/helpers/modal_containers.tsx
@@ -11,7 +11,7 @@ import {
   EuiSmallButtonEmpty,
   EuiFieldText,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -153,7 +153,7 @@ export const DeleteNotebookModal = ({
           <EuiText>The action cannot be undone.</EuiText>
           <EuiSpacer />
           <EuiForm>
-            <EuiFormRow label={'To confirm deletion, enter "delete" in the text field'}>
+            <EuiCompressedFormRow label={'To confirm deletion, enter "delete" in the text field'}>
               <EuiFieldText
                 data-test-subj="delete-notebook-modal-input"
                 name="input"
@@ -161,7 +161,7 @@ export const DeleteNotebookModal = ({
                 value={value}
                 onChange={(e) => onChange(e)}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiForm>
         </EuiModalBody>
 

--- a/public/components/notebooks/components/helpers/modal_containers.tsx
+++ b/public/components/notebooks/components/helpers/modal_containers.tsx
@@ -9,7 +9,7 @@ import {
   EuiConfirmModal,
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiForm,
   EuiCompressedFormRow,
   EuiModal,
@@ -154,7 +154,7 @@ export const DeleteNotebookModal = ({
           <EuiSpacer />
           <EuiForm>
             <EuiCompressedFormRow label={'To confirm deletion, enter "delete" in the text field'}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="delete-notebook-modal-input"
                 name="input"
                 placeholder="delete"

--- a/public/components/notebooks/components/helpers/modal_containers.tsx
+++ b/public/components/notebooks/components/helpers/modal_containers.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import {
   EuiOverlayMask,
   EuiConfirmModal,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFieldText,
   EuiForm,
@@ -167,7 +167,7 @@ export const DeleteNotebookModal = ({
 
         <EuiModalFooter>
           <EuiButtonEmpty onClick={onCancel}>Cancel</EuiButtonEmpty>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="delete-notebook-modal-delete-button"
             onClick={() => onConfirm()}
             color="danger"
@@ -175,7 +175,7 @@ export const DeleteNotebookModal = ({
             disabled={value !== 'delete'}
           >
             Delete
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/components/notebooks/components/helpers/modal_containers.tsx
+++ b/public/components/notebooks/components/helpers/modal_containers.tsx
@@ -8,7 +8,7 @@ import {
   EuiOverlayMask,
   EuiConfirmModal,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFieldText,
   EuiForm,
   EuiFormRow,
@@ -166,7 +166,7 @@ export const DeleteNotebookModal = ({
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={onCancel}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={onCancel}>Cancel</EuiSmallButtonEmpty>
           <EuiSmallButton
             data-test-subj="delete-notebook-modal-delete-button"
             onClick={() => onConfirm()}

--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -234,9 +234,9 @@ export function NoteTable({
         <EuiPageBody component="div">
           <EuiPageHeader>
             <EuiPageHeaderSection>
-              <EuiTitle size="l">
+              <EuiText size="s">
                 <h1>Notebooks</h1>
-              </EuiTitle>
+              </EuiText>
             </EuiPageHeaderSection>
           </EuiPageHeader>
           <EuiPageContent id="notebookArea">
@@ -266,7 +266,7 @@ export function NoteTable({
                       isOpen={isActionsPopoverOpen}
                       closePopover={() => setIsActionsPopoverOpen(false)}
                     >
-                      <EuiContextMenuPanel items={popoverItems} />
+                      <EuiContextMenuPanel items={popoverItems} size="s" />
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
@@ -322,7 +322,7 @@ export function NoteTable({
                 <EuiText textAlign="center" data-test-subj="notebookEmptyTableText">
                   <h2>No notebooks</h2>
                   <EuiSpacer size="m" />
-                  <EuiText color="subdued">
+                  <EuiText color="subdued" size="s">
                     Use notebooks to create post-mortem reports, build live infrastructure
                     <br />
                     reports, or foster explorative collaborations with data.

--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -7,7 +7,7 @@ import {
   EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -280,7 +280,7 @@ export function NoteTable({
             <EuiHorizontalRule margin="m" />
             {notebooks.length > 0 ? (
               <>
-                <EuiFieldSearch
+                <EuiCompressedFieldSearch
                   fullWidth
                   placeholder="Search notebook name"
                   value={searchQuery}

--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFieldSearch,
@@ -163,14 +163,14 @@ export function NoteTable({
   };
 
   const popoverButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="notebookTableActionBtn"
       iconType="arrowDown"
       iconSide="right"
       onClick={() => setIsActionsPopoverOpen(!isActionsPopoverOpen)}
     >
       Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const popoverItems: ReactElement[] = [
@@ -270,9 +270,9 @@ export function NoteTable({
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton fill href="#/create" data-test-subj="createNotebookPrimaryBtn">
+                    <EuiSmallButton fill href="#/create" data-test-subj="createNotebookPrimaryBtn">
                       Create notebook
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>
@@ -331,22 +331,22 @@ export function NoteTable({
                 <EuiSpacer size="m" />
                 <EuiFlexGroup justifyContent="center">
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       href="#/create"
                       data-test-subj="notebookEmptyTableCreateBtn"
                       fullWidth={false}
                     >
                       Create notebook
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="notebookEmptyTableAddSamplesBtn"
                       fullWidth={false}
                       onClick={() => addSampleNotebooksModal()}
                     >
                       Add samples
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer size="xxl" />

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -21,7 +21,6 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import CSS from 'csstype';
 import moment from 'moment';
@@ -1007,7 +1006,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
           isOpen={this.state.isReportingActionsPopoverOpen}
           closePopover={() => this.setState({ isReportingActionsPopoverOpen: false })}
         >
-          <EuiContextMenu initialPanelId={0} panels={reportingActionPanels} />
+          <EuiContextMenu initialPanelId={0} panels={reportingActionPanels} size="s" />
         </EuiPopover>
       </div>
     ) : null;
@@ -1059,7 +1058,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                     isOpen={this.state.isParaActionsPopoverOpen}
                     closePopover={() => this.setState({ isParaActionsPopoverOpen: false })}
                   >
-                    <EuiContextMenu initialPanelId={0} panels={paraActionsPanels} />
+                    <EuiContextMenu initialPanelId={0} panels={paraActionsPanels} size="s" />
                   </EuiPopover>
                 </EuiFlexItem>
               )}
@@ -1084,7 +1083,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                     isOpen={this.state.isNoteActionsPopoverOpen}
                     closePopover={() => this.setState({ isNoteActionsPopoverOpen: false })}
                   >
-                    <EuiContextMenu initialPanelId={0} panels={noteActionsPanels} />
+                    <EuiContextMenu initialPanelId={0} panels={noteActionsPanels} size="s" />
                   </EuiPopover>
                 </EuiFlexItem>
               ) : (
@@ -1098,20 +1097,20 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                     </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="delete-notebook"
                       onClick={() => this.showDeleteNotebookModal()}
                     >
                       Delete this notebook
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </>
               )}
             </EuiFlexGroup>
             <EuiSpacer size="s" />
-            <EuiTitle size="l" data-test-subj="notebookTitle">
+            <EuiText size="s" data-test-subj="notebookTitle">
               <h1>{this.state.path}</h1>
-            </EuiTitle>
+            </EuiText>
             <EuiSpacer />
             {!this.state.savedObjectNotebook && (
               <EuiFlexGroup>
@@ -1133,7 +1132,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             <EuiSpacer size="m" />
             <EuiFlexGroup alignItems={'flexStart'} gutterSize={'l'}>
               <EuiFlexItem grow={false}>
-                <EuiText>{createdText}</EuiText>
+                <EuiText size="s">{createdText}</EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
             {this.state.parsedPara.length > 0 ? (
@@ -1198,7 +1197,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                       isOpen={this.state.isAddParaPopoverOpen}
                       closePopover={() => this.setState({ isAddParaPopoverOpen: false })}
                     >
-                      <EuiContextMenu initialPanelId={0} panels={addParaPanels} />
+                      <EuiContextMenu initialPanelId={0} panels={addParaPanels} size="s" />
                     </EuiPopover>
                   </>
                 )}
@@ -1210,7 +1209,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                   <EuiSpacer size="xxl" />
                   <EuiText textAlign="center">
                     <h2>No paragraphs</h2>
-                    <EuiText>
+                    <EuiText size="s">
                       Add a paragraph to compose your document or story. Notebooks now support two
                       types of input:
                     </EuiText>

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonGroup,
   EuiButtonGroupOptionProps,
   EuiCallOut,
@@ -991,7 +991,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         <EuiPopover
           panelPaddingSize="none"
           button={
-            <EuiButton
+            <EuiSmallButton
               id="reportingActionsButton"
               iconType="arrowDown"
               iconSide="right"
@@ -1002,7 +1002,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
               }
             >
               Reporting actions
-            </EuiButton>
+            </EuiSmallButton>
           }
           isOpen={this.state.isReportingActionsPopoverOpen}
           closePopover={() => this.setState({ isReportingActionsPopoverOpen: false })}
@@ -1043,7 +1043,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                   <EuiPopover
                     panelPaddingSize="none"
                     button={
-                      <EuiButton
+                      <EuiSmallButton
                         data-test-subj="notebook-paragraph-actions-button"
                         iconType="arrowDown"
                         iconSide="right"
@@ -1054,7 +1054,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                         }
                       >
                         Paragraph actions
-                      </EuiButton>
+                      </EuiSmallButton>
                     }
                     isOpen={this.state.isParaActionsPopoverOpen}
                     closePopover={() => this.setState({ isParaActionsPopoverOpen: false })}
@@ -1068,7 +1068,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                   <EuiPopover
                     panelPaddingSize="none"
                     button={
-                      <EuiButton
+                      <EuiSmallButton
                         data-test-subj="notebook-notebook-actions-button"
                         iconType="arrowDown"
                         iconSide="right"
@@ -1079,7 +1079,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                         }
                       >
                         Notebook actions
-                      </EuiButton>
+                      </EuiSmallButton>
                     }
                     isOpen={this.state.isNoteActionsPopoverOpen}
                     closePopover={() => this.setState({ isNoteActionsPopoverOpen: false })}
@@ -1090,12 +1090,12 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
               ) : (
                 <>
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="upgrade-notebook-callout"
                       onClick={() => this.showUpgradeModal()}
                     >
                       Upgrade Notebook
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiButton
@@ -1119,12 +1119,12 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                   <EuiCallOut color="primary" iconType='iInCircle"'>
                     Upgrade this notebook to take full advantage of the latest features
                     <EuiSpacer size="s" />
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="upgrade-notebook"
                       onClick={() => this.showUpgradeModal()}
                     >
                       Upgrade Notebook
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiCallOut>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false} />
@@ -1186,14 +1186,14 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                     <EuiPopover
                       panelPaddingSize="none"
                       button={
-                        <EuiButton
+                        <EuiSmallButton
                           data-test-subj="AddParagraphButton"
                           iconType="arrowDown"
                           iconSide="right"
                           onClick={() => this.setState({ isAddParaPopoverOpen: true })}
                         >
                           Add paragraph
-                        </EuiButton>
+                        </EuiSmallButton>
                       }
                       isOpen={this.state.isAddParaPopoverOpen}
                       closePopover={() => this.setState({ isAddParaPopoverOpen: false })}
@@ -1225,13 +1225,13 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                           title="Code block"
                           description="Write contents directly using markdown, SQL or PPL."
                           footer={
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="emptyNotebookAddCodeBlockBtn"
                               onClick={() => this.addPara(0, '', 'CODE')}
                               style={{ marginBottom: 17 }}
                             >
                               Add code block
-                            </EuiButton>
+                            </EuiSmallButton>
                           }
                         />
                       </EuiFlexItem>
@@ -1241,12 +1241,12 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                           title="Visualization"
                           description="Import OpenSearch Dashboards or Observability visualizations to the notes."
                           footer={
-                            <EuiButton
+                            <EuiSmallButton
                               onClick={() => this.addPara(0, '', 'VISUALIZATION')}
                               style={{ marginBottom: 17 }}
                             >
                               Add visualization
-                            </EuiButton>
+                            </EuiSmallButton>
                           }
                         />
                       </EuiFlexItem>

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -25,7 +25,7 @@ import {
   EuiSpacer,
   EuiSuperDatePicker,
   EuiText,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import { Input, Prompt } from '@nteract/presentational-components';
 import React, { useState } from 'react';
@@ -72,7 +72,7 @@ export const ParaInput = (props: {
       <div style={{ width: '100%' }}>
         {/* If the para is selected show the editor else display the code in the paragraph */}
         {para.isSelected ? (
-          <EuiTextArea
+          <EuiCompressedTextArea
             data-test-subj={`editorArea-${index}`}
             placeholder={inputPlaceholderString}
             id="editorArea"

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCodeBlock,
   EuiComboBox,
@@ -149,7 +149,7 @@ export const ParaInput = (props: {
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="para-input-visualization-browse-button"
               onClick={() => {
                 setSelectableOptions([
@@ -161,7 +161,7 @@ export const ParaInput = (props: {
               }}
             >
               Browse
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={2} />
           <EuiFlexItem grow={9}>
@@ -220,13 +220,13 @@ export const ParaInput = (props: {
 
               <EuiModalFooter>
                 <EuiButtonEmpty onClick={() => setIsModalOpen(false)}>Cancel</EuiButtonEmpty>
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="para-input-select-button"
                   onClick={() => onSelect()}
                   fill
                 >
                   Select
-                </EuiButton>
+                </EuiSmallButton>
               </EuiModalFooter>
             </EuiModal>
           </EuiOverlayMask>

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -7,7 +7,7 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiCodeBlock,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -135,7 +135,7 @@ export const ParaInput = (props: {
         <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
           <EuiFlexItem grow={6}>
             <EuiCompressedFormRow label="Title" fullWidth>
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Find visualization"
                 singleSelection={{ asPlainText: true }}
                 options={props.visOptions}

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -11,7 +11,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiHighlight,
   EuiLink,
   EuiModal,
@@ -134,7 +134,7 @@ export const ParaInput = (props: {
       <>
         <EuiFlexGroup alignItems="flexEnd" gutterSize="s">
           <EuiFlexItem grow={6}>
-            <EuiFormRow label="Title" fullWidth>
+            <EuiCompressedFormRow label="Title" fullWidth>
               <EuiComboBox
                 placeholder="Find visualization"
                 singleSelection={{ asPlainText: true }}
@@ -146,7 +146,7 @@ export const ParaInput = (props: {
                   props.setIsOutputStale(true);
                 }}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiSmallButton
@@ -165,7 +165,7 @@ export const ParaInput = (props: {
           </EuiFlexItem>
           <EuiFlexItem grow={2} />
           <EuiFlexItem grow={9}>
-            <EuiFormRow label="Date range" fullWidth>
+            <EuiCompressedFormRow label="Date range" fullWidth>
               <EuiSuperDatePicker
                 start={props.startTime}
                 end={props.endTime}
@@ -177,7 +177,7 @@ export const ParaInput = (props: {
                   props.setIsOutputStale(true);
                 }}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem />
         </EuiFlexGroup>

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -186,7 +186,11 @@ export const ParaInput = (props: {
           <EuiOverlayMask>
             <EuiModal onClose={() => setIsModalOpen(false)} style={{ width: 500 }}>
               <EuiModalHeader>
-                <EuiModalHeaderTitle>Browse visualizations</EuiModalHeaderTitle>
+                <EuiModalHeaderTitle>
+                  <EuiText size="s">
+                    <h2>Browse visualizations</h2>
+                  </EuiText>
+                </EuiModalHeaderTitle>
               </EuiModalHeader>
 
               <EuiModalBody>
@@ -219,7 +223,9 @@ export const ParaInput = (props: {
               </EuiModalBody>
 
               <EuiModalFooter>
-                <EuiSmallButtonEmpty onClick={() => setIsModalOpen(false)}>Cancel</EuiSmallButtonEmpty>
+                <EuiSmallButtonEmpty onClick={() => setIsModalOpen(false)}>
+                  Cancel
+                </EuiSmallButtonEmpty>
                 <EuiSmallButton
                   data-test-subj="para-input-select-button"
                   onClick={() => onSelect()}

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCodeBlock,
   EuiComboBox,
   EuiComboBoxOptionOption,
@@ -219,7 +219,7 @@ export const ParaInput = (props: {
               </EuiModalBody>
 
               <EuiModalFooter>
-                <EuiButtonEmpty onClick={() => setIsModalOpen(false)}>Cancel</EuiButtonEmpty>
+                <EuiSmallButtonEmpty onClick={() => setIsModalOpen(false)}>Cancel</EuiSmallButtonEmpty>
                 <EuiSmallButton
                   data-test-subj="para-input-select-button"
                   onClick={() => onSelect()}

--- a/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -108,6 +108,7 @@ const OutputBody = ({
             key={key}
             className="wrapAll markdown-output-text"
             data-test-subj="markdownOutputText"
+            size="s"
           >
             <MarkdownRender source={val} />
           </EuiText>

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -447,7 +447,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
               isOpen={isPopoverOpen}
               closePopover={() => setIsPopoverOpen(false)}
             >
-              <EuiContextMenu initialPanelId={0} panels={panels} />
+              <EuiContextMenu initialPanelId={0} panels={panels} size="s" />
             </EuiPopover>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -469,7 +469,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
             )}
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText color="subdued" data-test-subj="lastRunText">
+            <EuiText color="subdued" data-test-subj="lastRunText" size="s">
               {`Last successful run ${moment(props.dateModified).format(UI_DATE_FORMAT)}.`}
             </EuiText>
           </EuiFlexItem>
@@ -484,12 +484,12 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
             <EuiIcon type="questionInCircle" color="primary" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText color="subdued">
+            <EuiText color="subdued" size="s">
               {`Output available from ${moment(props.dateModified).format(UI_DATE_FORMAT)}`}
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText>
+            <EuiText size="s">
               <EuiLink
                 data-test-subj="viewBothLink"
                 onClick={() => props.setSelectedViewId('view_both', index)}
@@ -618,7 +618,6 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
                   <EuiSmallButton
                     data-test-subj={`runRefreshBtn-${index}`}
                     onClick={() => onRunPara()}
-                    fill
                   >
                     {isOutputAvailable ? 'Refresh' : 'Run'}
                   </EuiSmallButton>

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiComboBoxOptionOption,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
@@ -422,7 +422,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           <EuiFlexItem>
             <EuiText style={{ fontSize: 17 }}>
               {`[${idx + 1}] ${type} `}
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 data-test-subj="paragraphToggleInputBtn"
                 aria-label="Toggle show input"
                 iconType={para.isInputExpanded ? 'arrowUp' : 'arrowDown'}
@@ -438,7 +438,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
             <EuiPopover
               panelPaddingSize="none"
               button={
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label="Open paragraph menu"
                   iconType="boxesHorizontal"
                   onClick={() => setIsPopoverOpen(true)}

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -11,7 +11,7 @@ import {
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiHorizontalRule,
   EuiIcon,
   EuiLink,
@@ -580,7 +580,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           {para.isInputExpanded && (
             <>
               <EuiSpacer size="s" />
-              <EuiFormRow
+              <EuiCompressedFormRow
                 fullWidth={true}
                 helpText={paragraphLabel}
                 isInvalid={showQueryParagraphError}
@@ -606,7 +606,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
                   dataSourceEnabled={dataSourceEnabled}
                   savedObjectsMDSClient={savedObjectsMDSClient}
                 />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
               {runParaError && (
                 <EuiText color="danger" size="s" data-test-subj="paragraphInputErrorText">{`${
                   para.isVizualisation ? 'Visualization' : 'Input'

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiComboBoxOptionOption,
   EuiContextMenu,
@@ -615,13 +615,13 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
               <EuiSpacer size="m" />
               <EuiFlexGroup alignItems="center" gutterSize="s">
                 <EuiFlexItem grow={false}>
-                  <EuiButton
+                  <EuiSmallButton
                     data-test-subj={`runRefreshBtn-${index}`}
                     onClick={() => onRunPara()}
                     fill
                   >
                     {isOutputAvailable ? 'Refresh' : 'Run'}
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
                 {isOutputAvailable && renderOutputTimestampMessage()}
               </EuiFlexGroup>

--- a/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,
@@ -96,7 +96,7 @@ export function FilterEditPopover(props: {
           </EuiButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             disabled={
               selectedFieldOptions.length === 0 ||
@@ -120,7 +120,7 @@ export function FilterEditPopover(props: {
             }}
           >
             Save
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </div>

--- a/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
@@ -6,7 +6,7 @@
 import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
@@ -43,7 +43,7 @@ export function FilterEditPopover(props: {
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem grow={6}>
           <EuiCompressedFormRow label={'Field'}>
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Select a field first"
               isClearable={false}
               options={props.filterFieldOptions}
@@ -59,7 +59,7 @@ export function FilterEditPopover(props: {
         </EuiFlexItem>
         <EuiFlexItem grow={5}>
           <EuiCompressedFormRow label={'Operator'}>
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder={selectedFieldOptions.length === 0 ? 'Waiting' : 'Select'}
               isClearable={false}
               isDisabled={selectedFieldOptions.length === 0}

--- a/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
@@ -10,7 +10,7 @@ import {
   EuiComboBoxOptionOption,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -42,7 +42,7 @@ export function FilterEditPopover(props: {
       <button style={{ width: 0, height: 0, position: 'fixed', marginLeft: -1000, bottom: 0 }} />
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem grow={6}>
-          <EuiFormRow label={'Field'}>
+          <EuiCompressedFormRow label={'Field'}>
             <EuiComboBox
               placeholder="Select a field first"
               isClearable={false}
@@ -55,10 +55,10 @@ export function FilterEditPopover(props: {
               }}
               singleSelection={{ asPlainText: true }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={5}>
-          <EuiFormRow label={'Operator'}>
+          <EuiCompressedFormRow label={'Operator'}>
             <EuiComboBox
               placeholder={selectedFieldOptions.length === 0 ? 'Waiting' : 'Select'}
               isClearable={false}
@@ -75,7 +75,7 @@ export function FilterEditPopover(props: {
               }}
               singleSelection={{ asPlainText: true }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
       {selectedOperatorOptions.length > 0 &&

--- a/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiComboBox,
   EuiComboBoxOptionOption,
   EuiFlexGroup,
@@ -88,12 +88,12 @@ export function FilterEditPopover(props: {
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
+          <EuiSmallButtonEmpty
             data-test-subj="filter-popover-cancel-button"
             onClick={props.closePopover}
           >
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
@@ -7,7 +7,7 @@ import {
   EuiComboBox,
   EuiFieldText,
   EuiFormControlLayoutDelimited,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
 } from '@elastic/eui';
 import get from 'lodash/get';
@@ -157,13 +157,13 @@ export const getValueComponent = (
   const textField = (
     <>
       <EuiSpacer size="s" />
-      <EuiFormRow label={'Value'}>
+      <EuiCompressedFormRow label={'Value'}>
         <EuiFieldText
           placeholder="Enter a value"
           value={value}
           onChange={(e) => setValue(e.target.value)}
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </>
   );
 
@@ -189,7 +189,7 @@ export const getValueComponent = (
     return (
       <>
         <EuiSpacer size="s" />
-        <EuiFormRow label={'Value'}>
+        <EuiCompressedFormRow label={'Value'}>
           <EuiFormControlLayoutDelimited
             startControl={
               <input
@@ -210,7 +210,7 @@ export const getValueComponent = (
               />
             }
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };
@@ -219,7 +219,7 @@ export const getValueComponent = (
     return (
       <>
         <EuiSpacer size="s" />
-        <EuiFormRow label={'Value'}>
+        <EuiCompressedFormRow label={'Value'}>
           <EuiComboBox
             placeholder="Select a value"
             options={[
@@ -234,7 +234,7 @@ export const getValueComponent = (
             selectedOptions={value || []}
             singleSelection={true}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </>
     );
   };

--- a/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiComboBox,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFormControlLayoutDelimited,
   EuiCompressedFormRow,
   EuiSpacer,
@@ -158,7 +158,7 @@ export const getValueComponent = (
     <>
       <EuiSpacer size="s" />
       <EuiCompressedFormRow label={'Value'}>
-        <EuiFieldText
+        <EuiCompressedFieldText
           placeholder="Enter a value"
           value={value}
           onChange={(e) => setValue(e.target.value)}

--- a/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedFieldText,
   EuiFormControlLayoutDelimited,
   EuiCompressedFormRow,
@@ -220,7 +220,7 @@ export const getValueComponent = (
       <>
         <EuiSpacer size="s" />
         <EuiCompressedFormRow label={'Value'}>
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Select a value"
             options={[
               {

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -6,7 +6,7 @@
 import {
   EuiBadge,
   EuiButtonEmpty,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
@@ -198,7 +198,7 @@ export function Filters(props: FiltersOwnProps) {
         isOpen={isPopoverOpen}
         closePopover={() => setIsPopoverOpen(false)}
         button={
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             onClick={() => setIsPopoverOpen(true)}
             iconType="filter"
             title="Change all filters"

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -210,7 +210,7 @@ export function Filters(props: FiltersOwnProps) {
         withTitle
         data-test-subj="global-filter-button"
       >
-        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} />
+        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} size="s" />
       </EuiPopover>
     );
   };

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable radix */
 
 import dateMath from '@elastic/datemath';
-import { EuiButton, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
 import { SpacerSize } from '@elastic/eui/src/components/spacer/spacer';
 import { isEmpty, round } from 'lodash';
 import React from 'react';
@@ -67,14 +67,14 @@ export function MissingConfigurationMessage(props: { mode: TraceAnalyticsMode })
         title={<h2>Trace Analytics not set up</h2>}
         body={<EuiText>{missingConfigurationBody}</EuiText>}
         actions={
-          <EuiButton
+          <EuiSmallButton
             color="primary"
             iconSide="right"
             iconType="popout"
             onClick={() => window.open(TRACE_ANALYTICS_DOCUMENTATION_LINK, '_blank')}
           >
             Learn more
-          </EuiButton>
+          </EuiSmallButton>
         }
       />
     </>

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -65,7 +65,7 @@ export function MissingConfigurationMessage(props: { mode: TraceAnalyticsMode })
     <>
       <EuiEmptyPrompt
         title={<h2>Trace Analytics not set up</h2>}
-        body={<EuiText>{missingConfigurationBody}</EuiText>}
+        body={<EuiText size="s">{missingConfigurationBody}</EuiText>}
         actions={
           <EuiSmallButton
             color="primary"

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable radix */
 
 import dateMath from '@elastic/datemath';
-import { EuiSmallButton, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButtonEmpty, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
 import { SpacerSize } from '@elastic/eui/src/components/spacer/spacer';
 import { isEmpty, round } from 'lodash';
 import React from 'react';
@@ -45,7 +45,7 @@ export function NoMatchMessage(props: { size: SpacerSize }) {
       <EuiEmptyPrompt
         title={<h2>No matches</h2>}
         body={
-          <EuiText>
+          <EuiText size="s">
             No data matches the selected filter. Clear the filter and/or increase the time range to
             see more results.
           </EuiText>
@@ -67,14 +67,14 @@ export function MissingConfigurationMessage(props: { mode: TraceAnalyticsMode })
         title={<h2>Trace Analytics not set up</h2>}
         body={<EuiText size="s">{missingConfigurationBody}</EuiText>}
         actions={
-          <EuiSmallButton
+          <EuiSmallButtonEmpty
             color="primary"
             iconSide="right"
             iconType="popout"
             onClick={() => window.open(TRACE_ANALYTICS_DOCUMENTATION_LINK, '_blank')}
           >
             Learn more
-          </EuiSmallButton>
+          </EuiSmallButtonEmpty>
         }
       />
     </>

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiButtonGroup,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -222,7 +222,7 @@ export function ServiceMap({
             <EuiText>Focus on</EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFieldSearch
+            <EuiCompressedFieldSearch
               placeholder="Service name"
               value={query}
               onChange={(e) => setQuery(e.target.value)}

--- a/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
@@ -37,7 +37,7 @@ export const ServiceMapNodeDetails = ({
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButtonIcon
+          <EuiSmallButtonIcon
             aria-label="Close node details"
             iconType="cross"
             color="text"

--- a/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
@@ -46,9 +46,9 @@ export const ServiceMapNodeDetails = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="l" />
-      <EuiText>{selectedNodeDetails?.average_latency}</EuiText>
-      <EuiText>{selectedNodeDetails?.error_rate}</EuiText>
-      <EuiText>{selectedNodeDetails?.throughput}</EuiText>
+      <EuiText size="s">{selectedNodeDetails?.average_latency}</EuiText>
+      <EuiText size="s">{selectedNodeDetails?.error_rate}</EuiText>
+      <EuiText size="s">{selectedNodeDetails?.throughput}</EuiText>
       <EuiSpacer size="l" />
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem>

--- a/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
@@ -52,7 +52,7 @@ export const ServiceMapNodeDetails = ({
       <EuiSpacer size="l" />
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem>
-          <EuiButton
+          <EuiSmallButton
             fill
             onClick={() =>
               setCurrentSelectedService &&
@@ -61,14 +61,14 @@ export const ServiceMapNodeDetails = ({
             }
           >
             View service details
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => selectedNodeDetails && addServiceFilter(selectedNodeDetails?.label)}
           >
             Filter map
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPanel>

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
@@ -90,14 +90,14 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
           {renderDatePicker(props.startTime, props.setStartTime, props.endTime, props.setEndTime)}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="superDatePickerApplyTimeButton"
             data-click-metric-element="trace_analytics.refresh_button"
             iconType="refresh"
             onClick={() => props.refresh()}
           >
             Refresh
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -72,7 +72,7 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
       <EuiFlexGroup gutterSize="s">
         {!props.datepickerOnly && (
           <EuiFlexItem>
-            <EuiFieldSearch
+            <EuiCompressedFieldSearch
               fullWidth
               isClearable={false}
               placeholder="Trace ID, trace group name, service name"

--- a/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
+++ b/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiText } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiText } from '@elastic/eui';
 import React, { useState } from 'react';
 import { LatencyPlt, LinePlt } from '../common/plots/latency_trend_plt';
 
@@ -29,7 +29,7 @@ export function LatencyTrendCell({
           ownFocus
           anchorPosition="downCenter"
           button={
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               aria-label="Open popover"
               onClick={() => setIsPopoverOpen(true)}
               iconType="magnifyWithPlus"
@@ -45,7 +45,7 @@ export function LatencyTrendCell({
               <EuiText size="s">{traceGroupName}</EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label="Close popover"
                 iconType="cross"
                 color="text"

--- a/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
+++ b/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSmallButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiText } from '@elastic/eui';
+import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiText } from '@elastic/eui';
 import React, { useState } from 'react';
 import { LatencyPlt, LinePlt } from '../common/plots/latency_trend_plt';
 
@@ -29,7 +29,7 @@ export function LatencyTrendCell({
           ownFocus
           anchorPosition="downCenter"
           button={
-            <EuiSmallButtonIcon
+            <EuiButtonIcon
               aria-label="Open popover"
               onClick={() => setIsPopoverOpen(true)}
               iconType="magnifyWithPlus"

--- a/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
+++ b/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiPopover, EuiText } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiSmallButtonIcon,
+  EuiText,
+} from '@elastic/eui';
 import React, { useState } from 'react';
 import { LatencyPlt, LinePlt } from '../common/plots/latency_trend_plt';
 

--- a/public/components/trace_analytics/components/dashboard/mode_picker.tsx
+++ b/public/components/trace_analytics/components/dashboard/mode_picker.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonEmpty, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
+import { EuiSmallButtonEmpty, EuiPopover, EuiPopoverTitle, EuiSelectable } from '@elastic/eui';
 import React, { useState } from 'react';
 import { TraceAnalyticsMode } from '../../home';
 
@@ -33,7 +33,7 @@ export function DataSourcePicker(props: {
   const createTrigger = () => {
     const { label, title, ...rest } = trigger;
     return (
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         flush="left"
         color="text"
         iconSide="right"
@@ -43,7 +43,7 @@ export function DataSourcePicker(props: {
         {...rest}
       >
         {label}
-      </EuiButtonEmpty>
+      </EuiSmallButtonEmpty>
     );
   };
 

--- a/public/components/trace_analytics/components/services/service_trends_plots.tsx
+++ b/public/components/trace_analytics/components/services/service_trends_plots.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiI18nNumber,
@@ -68,7 +68,7 @@ export const ServiceTrendsPlots = ({
                 </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiButtonIcon
+                <EuiSmallButtonIcon
                   aria-label="Close popover"
                   iconType="cross"
                   color="text"

--- a/public/components/trace_analytics/components/services/service_trends_plots.tsx
+++ b/public/components/trace_analytics/components/services/service_trends_plots.tsx
@@ -58,6 +58,7 @@ export const ServiceTrendsPlots = ({
             anchorPosition="downCenter"
             isOpen={isPopoverOpen}
             closePopover={() => setIsPopoverOpen(false)}
+            panelPaddingSize="s"
           >
             <EuiFlexGroup justifyContent="spaceBetween">
               <EuiFlexItem grow={false}>

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -6,7 +6,7 @@
 
 import {
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
@@ -154,14 +154,14 @@ export function ServiceView(props: ServiceViewProps) {
   }, [props.startTime, props.endTime, props.serviceName, props.mode]);
 
   const actionsButton = (
-    <EuiButton
+    <EuiSmallButton
       data-test-subj="ActionContextMenu"
       iconType="arrowDown"
       iconSide="right"
       onClick={() => setActionsMenuPopover(true)}
     >
       Actions
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const actionsMenu: EuiContextMenuPanelDescriptor[] = [

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -23,7 +23,6 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -240,9 +239,9 @@ export function ServiceView(props: ServiceViewProps) {
         ) : (
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem>
-              <EuiTitle size="l">
-                <h2 className="overview-content">{serviceName}</h2>
-              </EuiTitle>
+              <EuiText size="s">
+                <h1 className="overview-content">{serviceName}</h1>
+              </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               {renderDatePicker(startTime, setStartTime, endTime, setEndTime)}

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -220,9 +220,9 @@ export function ServiceView(props: ServiceViewProps) {
           <EuiFlyoutHeader hasBorder>
             <EuiFlexGroup justifyContent="spaceBetween">
               <EuiFlexItem>
-                <EuiTitle size="l">
+                <EuiText size="s">
                   <h2 className="overview-content">{serviceName}</h2>
-                </EuiTitle>
+                </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
@@ -231,7 +231,7 @@ export function ServiceView(props: ServiceViewProps) {
                   isOpen={actionsMenuPopover}
                   closePopover={() => setActionsMenuPopover(false)}
                 >
-                  <EuiContextMenu initialPanelId={0} panels={actionsMenu} />
+                  <EuiContextMenu initialPanelId={0} panels={actionsMenu} size="s" />
                 </EuiPopover>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/components/trace_analytics/components/traces/flyout_list_item.tsx
+++ b/public/components/trace_analytics/components/traces/flyout_list_item.tsx
@@ -4,7 +4,7 @@
  */
 
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiDescriptionList,
   EuiFlexGroup,
   EuiFlexItem,
@@ -37,7 +37,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
         <EuiFlexItem grow={false}>
           {hover && props.addSpanFilter && (
             <EuiToolTip position="top" content="Filter spans on this value">
-              <EuiButtonIcon
+              <EuiSmallButtonIcon
                 aria-label="span-flyout-filter-icon"
                 iconType="filter"
                 onClick={props.addSpanFilter}

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -5,7 +5,7 @@
 
 import {
   EuiButtonEmpty,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCodeBlock,
   EuiCopy,
   EuiFlexGroup,
@@ -125,7 +125,7 @@ export function SpanDetailFlyout(props: {
             <EuiFlexItem grow={false}>
               <EuiCopy textToCopy={getSpanValue(span, mode, 'SPAN_ID')}>
                 {(copy) => (
-                  <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                  <EuiSmallButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
                 )}
               </EuiCopy>
             </EuiFlexItem>
@@ -145,7 +145,7 @@ export function SpanDetailFlyout(props: {
                 textToCopy={mode === 'data_prepper' ? span.parentSpanId : span.references[0].spanID}
               >
                 {(copy) => (
-                  <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                  <EuiSmallButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
                 )}
               </EuiCopy>
             </EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -16,7 +16,6 @@ import {
   EuiHorizontalRule,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
@@ -125,7 +124,11 @@ export function SpanDetailFlyout(props: {
             <EuiFlexItem grow={false}>
               <EuiCopy textToCopy={getSpanValue(span, mode, 'SPAN_ID')}>
                 {(copy) => (
-                  <EuiSmallButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                  <EuiSmallButtonIcon
+                    aria-label="copy-button"
+                    onClick={copy}
+                    iconType="copyClipboard"
+                  />
                 )}
               </EuiCopy>
             </EuiFlexItem>
@@ -145,7 +148,11 @@ export function SpanDetailFlyout(props: {
                 textToCopy={mode === 'data_prepper' ? span.parentSpanId : span.references[0].spanID}
               >
                 {(copy) => (
-                  <EuiSmallButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                  <EuiSmallButtonIcon
+                    aria-label="copy-button"
+                    onClick={copy}
+                    iconType="copyClipboard"
+                  />
                 )}
               </EuiCopy>
             </EuiFlexItem>
@@ -306,9 +313,9 @@ export function SpanDetailFlyout(props: {
           <EuiSpacer size="s" />
           <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem>
-              <EuiTitle>
+              <EuiText size="s">
                 <h2>Span detail</h2>
-              </EuiTitle>
+              </EuiText>
             </EuiFlexItem>
             {mode === 'data_prepper' && (
               <EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCodeBlock,
   EuiCopy,
   EuiFlexGroup,
@@ -84,13 +84,13 @@ export function TraceView(props: TraceViewProps) {
                     <EuiFlexItem grow={false}>
                       <EuiCopy textToCopy={fields.trace_id}>
                         {(copy) => (
-                          <EuiButtonIcon
+                          <EuiSmallButtonIcon
                             aria-label="Copy trace id"
                             iconType="copyClipboard"
                             onClick={copy}
                           >
                             Click to copy
-                          </EuiButtonIcon>
+                          </EuiSmallButtonIcon>
                         )}
                       </EuiCopy>
                     </EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -16,7 +16,6 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import React, { useEffect, useState } from 'react';
@@ -55,9 +54,9 @@ export function TraceView(props: TraceViewProps) {
     return (
       <>
         <EuiFlexItem>
-          <EuiTitle size="l">
-            <h2 className="overview-content">{traceId}</h2>
-          </EuiTitle>
+          <EuiText size="s">
+            <h1 className="overview-content">{traceId}</h1>
+          </EuiText>
         </EuiFlexItem>
       </>
     );

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiCopy,
   EuiFlexGroup,
   EuiFlexItem,
@@ -76,13 +76,13 @@ export function TracesTable(props: TracesTableProps) {
               <EuiFlexItem grow={false}>
                 <EuiCopy textToCopy={item}>
                   {(copy) => (
-                    <EuiButtonIcon
+                    <EuiSmallButtonIcon
                       aria-label="Copy trace id"
                       iconType="copyClipboard"
                       onClick={copy}
                     >
                       Click to copy
-                    </EuiButtonIcon>
+                    </EuiSmallButtonIcon>
                   )}
                 </EuiCopy>
               </EuiFlexItem>
@@ -176,13 +176,13 @@ export function TracesTable(props: TracesTableProps) {
                 <EuiFlexItem grow={false}>
                   <EuiCopy textToCopy={item}>
                     {(copy) => (
-                      <EuiButtonIcon
+                      <EuiSmallButtonIcon
                         aria-label="Copy trace id"
                         iconType="copyClipboard"
                         onClick={copy}
                       >
                         Click to copy
-                      </EuiButtonIcon>
+                      </EuiSmallButtonIcon>
                     )}
                   </EuiCopy>
                 </EuiFlexItem>

--- a/public/components/visualizations/charts/data_table/data_table_header.tsx
+++ b/public/components/visualizations/charts/data_table/data_table_header.tsx
@@ -8,7 +8,7 @@ import {
   EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiPopover,
   EuiSwitch,
   EuiIcon,
@@ -85,7 +85,7 @@ export const GridHeader = ({
         />
       </EuiFlexItem>
       <EuiFlexItem style={{ maxWidth: GRID_HEADER_COLUMN_MAX_WIDTH }}>
-        <EuiButtonEmpty
+        <EuiSmallButtonEmpty
           iconSize="s"
           color="text"
           aria-label="Next"
@@ -93,7 +93,7 @@ export const GridHeader = ({
           onClick={() => setIsFullScreenHandler(true)}
         >
           Full screen
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
       </EuiFlexItem>
       {isFullScreen && (
         <EuiIcon
@@ -118,7 +118,7 @@ export const DensityPopover = ({
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       iconSize="s"
       color="text"
       aria-label="Next"
@@ -126,7 +126,7 @@ export const DensityPopover = ({
       onClick={onButtonClick}
     >
       Density
-    </EuiButtonEmpty>
+    </EuiSmallButtonEmpty>
   );
 
   return (
@@ -161,7 +161,7 @@ export const ColumnVisiblityPopover = ({
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       iconSize="s"
       color="text"
       aria-label="Next"
@@ -169,7 +169,7 @@ export const ColumnVisiblityPopover = ({
       onClick={onButtonClick}
     >
       Columns
-    </EuiButtonEmpty>
+    </EuiSmallButtonEmpty>
   );
 
   return (

--- a/public/components/visualizations/charts/data_table/data_table_header.tsx
+++ b/public/components/visualizations/charts/data_table/data_table_header.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, ReactChildren, ReactChild } from 'react';
 import {
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiButtonEmpty,
@@ -134,7 +134,7 @@ export const DensityPopover = ({
       <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
         {ROW_DENSITIES.map((i: RowConfigType, index: number) => (
           <EuiFlexItem key={index} grow={false}>
-            <EuiButtonIcon
+            <EuiSmallButtonIcon
               onClick={() => selectDensityHandler(i)}
               display={selectedDensity.icon === i.icon ? 'fill' : 'base'}
               iconType={i.icon}


### PR DESCRIPTION
### Description
This PR applies the Look & Feel density and consistency changes to the Observability repository:
1. Use small context menus
2. Use small tabs
3. Standardize paragraph size (15.75px next theme / 14px V7 theme)
4. Use semantic headers (H1s on main pages, H2s on modals/flyouts)
5. Modal/Flyout Typography
6. Buttons for actions, only using primary buttons for primary calls to action
7. Use small padding on popovers

## Screenshots
### Small context Menu
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboards: Overview Actions | <img width="795" alt="Dashboards Actions Before" src="https://github.com/user-attachments/assets/d6f2b6e5-d525-4817-a8e8-d1d0517cdef8"> | <img width="795" alt="Dashboards Post" src="https://github.com/user-attachments/assets/67413e5d-33c3-4f4a-b728-2251a2f3948b"> |
| Dashboards: Actions | <img width="795" alt="Dashboards SO Actions Before" src="https://github.com/user-attachments/assets/626afec3-f5b4-483a-8d79-b2160cd48b8b"> | <img width="795" alt="Dashboards SO Actions Post" src="https://github.com/user-attachments/assets/5d10d530-7581-4960-ab58-c2e474694c30"> |
| Dashboards: Vis Actions | <img width="795" alt="Dashboards Vis Actions Before" src="https://github.com/user-attachments/assets/7eb6743f-bf51-4628-827d-de297e97fc51"> | <img width="795" alt="Dashboards Vis Actions Post" src="https://github.com/user-attachments/assets/ca2ce4c6-a7b3-42ea-8434-ebd1f1c73ea7"> |
| Dashboards: Vis | <img width="795" alt="Dashboards Vis Before" src="https://github.com/user-attachments/assets/dfaa6d98-0daf-4ab6-be5c-4bb30808fbf5"> | <img width="795" alt="Dashboards Vis Post" src="https://github.com/user-attachments/assets/707240c8-1c69-4427-bea8-1e4226fb9347"> |
| Integrations | <img width="794" alt="Integration Home context menu before" src="https://github.com/user-attachments/assets/2df09128-3c9f-46fc-9b34-0d000a5505e5"> | <img width="794" alt="Integration Home context menu post" src="https://github.com/user-attachments/assets/0c190355-d2c4-48cb-9b51-5178d5501b14"> |
| Notebook: Header Reporting | <img width="952" alt="Notebook Header Reporting Before" src="https://github.com/user-attachments/assets/f3d8e5f1-c465-4cfd-8d2d-9861479503dc"> | <img width="952" alt="Notebook Header Reporting Post" src="https://github.com/user-attachments/assets/01ba4d2d-e62c-45c7-bdec-58e3ac1db89c"> |
| Notebook: Header Paragraph | <img width="952" alt="Notebook Header Paragraph Before" src="https://github.com/user-attachments/assets/d89ba6e4-a6e7-4462-af09-b6fc64ac370a"> | <img width="952" alt="Notebook Header Paragraph Post" src="https://github.com/user-attachments/assets/c93e700b-002d-4399-8de4-dec8a4f61fa7"> |
| Notebook: Header Notebook | <img width="952" alt="Notebook Header Notebook HeaderActions Before" src="https://github.com/user-attachments/assets/5ad9408a-9e23-4dfe-9474-ce3eb369f93e"> | <img width="952" alt="Notebook Header Notebook HeaderActions Post" src="https://github.com/user-attachments/assets/3d3b6dcc-33b9-4abb-b026-8b60a6da4ee0"> |
| Notebook: Add | <img width="594" alt="Notebook Add Paragraph Before" src="https://github.com/user-attachments/assets/8f57355a-0c49-4ed0-925e-b46eeb99ff37"> | <img width="594" alt="Notebook Add Paragraph Post" src="https://github.com/user-attachments/assets/d4edef02-34e6-4f26-bad4-600077d2f2f1"> |
| Notebook: Paragraph | <img width="594" alt="Notebook Paragraph Options Before" src="https://github.com/user-attachments/assets/47b73a7c-bb4a-44b9-99dd-12d09d269fc0"> | <img width="594" alt="Notebook Paragraph Options Post" src="https://github.com/user-attachments/assets/716dc8d5-f451-4efd-bd0c-a224ffb5a58e"> |
| Notebook: Listing | <img width="341" alt="Notebooks Listing Before" src="https://github.com/user-attachments/assets/eccff32c-0a23-4286-b6a2-fe610fe5c80a"> | <img width="341" alt="Notebooks Listing Post" src="https://github.com/user-attachments/assets/089ad6c3-ae09-48f2-9f97-ca3acfc3fab6"> |
| Trace: Save | <img width="798" alt="Trace Save Popover Before" src="https://github.com/user-attachments/assets/40e20959-7fde-48cc-b0a2-7fac07ea3d53"> | <img width="798" alt="Trace Save Popover Post" src="https://github.com/user-attachments/assets/7a73f209-e53c-4075-8ce4-5feeedc52479"> |
| Trace: Filters | <img width="465" alt="Trace Analytics Filters Before" src="https://github.com/user-attachments/assets/90959c83-98e7-4d0b-954e-9d9d0d6e926c"> | <img width="465" alt="Trace Analytics Post" src="https://github.com/user-attachments/assets/447b73a6-e480-445f-aca1-e4388936123d"> |
| Trace: Actions | <img width="798" alt="Trace Actions Popover Before" src="https://github.com/user-attachments/assets/e7bc093c-3670-4d92-9923-2d37de318af1"> | <img width="798" alt="Trace Actions Popover Post" src="https://github.com/user-attachments/assets/01929a18-23be-45df-b7d6-504832fbdd36"> |

#### Small tabs
| Scope | Before | After |
| ----- | ----- | ----- |
| Integration: Home | <img width="795" alt="Integration Home before" src="https://github.com/user-attachments/assets/5ad5eb8a-65e2-411c-9f2f-464071beedf4"> | <img width="795" alt="Integration Home post" src="https://github.com/user-attachments/assets/665f014d-c5af-4460-98cf-2a954a48ce0d"> |
| Integration: Details | <img width="795" alt="Integration Tab before" src="https://github.com/user-attachments/assets/43545686-fc73-42c2-8d75-0979aa06814a"> | <img width="795" alt="Integration Tab post" src="https://github.com/user-attachments/assets/d73b17f4-50bb-4edb-96db-af221c143dd6"> |

#### Paragraph size
| Scope | Before | After |
| ----- | ----- | ----- |
| Integration: Details | <img width="826" alt="Integration Details P Before" src="https://github.com/user-attachments/assets/151d0ffc-ecd0-4ba8-9b76-2d23d66665b3"> | <img width="826" alt="Integration Details P Post" src="https://github.com/user-attachments/assets/5ebef84d-787e-4db4-b339-4ae25e819768"> |
| Notebooks: Empty overview | <img width="851" alt="Notebooks Empty Before" src="https://github.com/user-attachments/assets/e266ec25-a92f-491e-8e11-4ca6419ca34d"> | <img width="851" alt="Notebooks Empty Post" src="https://github.com/user-attachments/assets/7287bc16-fa8e-484c-9e4d-cacc0918613e"> |
| Notebooks: Empty notebook | <img width="955" alt="Notebook Empty Before" src="https://github.com/user-attachments/assets/851273fe-baf0-441a-8ab9-6fa9a1a7c563"> | <img width="955" alt="Notebook Empty Post" src="https://github.com/user-attachments/assets/6f02b28d-9177-4400-bea3-a53552b833d1"> |
| Notebooks: Timestamp | <img width="955" alt="Notebook Output Timestamp Before" src="https://github.com/user-attachments/assets/87f2e1a6-b072-4db1-b901-3d8753347541"> | <img width="955" alt="Notebook Output Timestamp Post" src="https://github.com/user-attachments/assets/23cc98ab-cea2-443f-87e7-e97df7e95638"> |
| Notebooks: Created | <img width="955" alt="Notebook Created Before" src="https://github.com/user-attachments/assets/7297c016-3bee-42e3-aa31-a6662f883924"> | <img width="955" alt="Notebook Created Post" src="https://github.com/user-attachments/assets/64decc58-d443-4fdd-ba97-1f5e77414b28"> |
| Notebooks: Quickstart | <img width="955" alt="Notebook OutputMD Before" src="https://github.com/user-attachments/assets/eb8663cc-4ee9-4315-a22b-e1ca2f886f79"> | <img width="955" alt="Notebook OutputMD Post" src="https://github.com/user-attachments/assets/24bab5d2-c063-471c-900a-85dedd33304d"> |
| Traces: Empty | <img width="623" alt="Trace Empty Message Before" src="https://github.com/user-attachments/assets/2ff01df3-24f1-4a0a-ba93-43c3fb40226f"> | <img width="623" alt="Trace Empty Message Post" src="https://github.com/user-attachments/assets/a086beb5-23e8-4298-bf19-e1dafa2e9f7e"> |
| Traces: Map | <img width="742" alt="Trace Map Node Before" src="https://github.com/user-attachments/assets/6833fa9d-390b-496e-86f5-559084023391"> | <img width="742" alt="Trace Map Node Post" src="https://github.com/user-attachments/assets/18dfdbda-ba55-421c-b0e2-db499525f9e6"> |

#### Semantic Headers 
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboard: Overview | <img width="795" alt="Dashboards Before" src="https://github.com/user-attachments/assets/e27a8618-21de-4549-9fa0-2ede08b01c6c"> | <img width="795" alt="Dashboards Post" src="https://github.com/user-attachments/assets/1d64cccd-25d6-4faa-b99c-bc13b1e190fc"> |
| Dashboard: Title | <img width="548" alt="Dashboard Before" src="https://github.com/user-attachments/assets/b87095d6-a1c8-4b7c-b398-0f94b4582225"> | <img width="548" alt="Dashboard Post" src="https://github.com/user-attachments/assets/00dbb9b9-fc47-46c3-98e4-a39faaed4eba"> |
| Integrations: Overview | <img width="826" alt="Integration Overview Header Before" src="https://github.com/user-attachments/assets/bac42c22-6fbd-47dc-8b3a-191d0d1119da"> | <img width="826" alt="Integration Overview Header Post" src="https://github.com/user-attachments/assets/b7b801d5-3d0d-4648-ab57-6cf1a17cf169"> |
| Integrations: Header | <img width="826" alt="Integration Header Before" src="https://github.com/user-attachments/assets/46b3b940-4219-4c0a-8b62-0f906cdd29b0"> | <img width="826" alt="Integration Header Post" src="https://github.com/user-attachments/assets/d13bd70c-67d0-47b4-9e98-78256abdd8aa"> |
| Integrations: Setup | <img width="794" alt="Integration Set up before" src="https://github.com/user-attachments/assets/d5a46efb-b79b-41f4-8ec3-3f8d7a75e420"> | <img width="794" alt="Integration Set up post" src="https://github.com/user-attachments/assets/e19793f1-f231-4ea4-9a03-92af752a9815"> |
| Integrations: Added | <img width="794" alt="Integrations Added title before" src="https://github.com/user-attachments/assets/5a601669-4545-4796-be2a-93a8a7d1d9fb"> | <img width="794" alt="Integrations Added title post" src="https://github.com/user-attachments/assets/7b814d5f-910e-4dc8-8010-e2afca437200"> |
| Notebooks: Overview | <img width="851" alt="Notebooks Listing Before" src="https://github.com/user-attachments/assets/16f9630a-2e99-4ba8-b4cd-86818c075bad"> | <img width="851" alt="Notebooks Listing Post" src="https://github.com/user-attachments/assets/fa1b59c0-e642-4b73-9b87-5ea3ee2c66f3"> |
| Notebooks: Title | <img width="952" alt="Notebook before" src="https://github.com/user-attachments/assets/c493ea91-9e0b-4caf-b95a-05dd9e5b1b69"> | <img width="952" alt="Notebook post" src="https://github.com/user-attachments/assets/becbd176-e15f-48b6-875b-0b7fa3933375"> |
| Trace: Trace ID | <img width="954" alt="Trace View ID Before" src="https://github.com/user-attachments/assets/42fad4a4-eae8-4e49-a959-bb4dcfb6f3ad"> | <img width="954" alt="Trace View ID Post" src="https://github.com/user-attachments/assets/0795ad30-109e-4133-94de-df02617d514d"> |
| Trace: Service | <img width="584" alt="Traces Service Page Before" src="https://github.com/user-attachments/assets/c5ce830a-e8d3-4bbf-aa13-1e4ca62380ac"> | <img width="584" alt="Traces Service Page Post" src="https://github.com/user-attachments/assets/309e8552-8632-4b19-86f4-735b58ebbf1e"> 

#### Flyouts 
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboard: Select Vis | <img width="548" alt="Dashboards Select Vis Before" src="https://github.com/user-attachments/assets/31115331-9470-449f-a526-819ef8c046bd"> | <img width="548" alt="Dashboards Select Vis Post" src="https://github.com/user-attachments/assets/28887c54-7b53-4014-a596-21f53c1585a0"> |
| Integrations: Upload | <img width="490" alt="Integration Upload Before" src="https://github.com/user-attachments/assets/0983a2dd-0ba3-4604-a15e-cf3bc0fe74fa"> | <img width="490" alt="Integration Upload Post" src="https://github.com/user-attachments/assets/10ef97ab-87ba-476a-a2b2-5be5df358a46"> |
| Trace: Header | <img width="799" alt="Trace Header Before" src="https://github.com/user-attachments/assets/104f23e6-f893-4d35-85b1-ee9a2d485476"> | <img width="799" alt="Trace Header Post" src="https://github.com/user-attachments/assets/ba85cad7-01af-4e67-b3c4-190edce596d8"> |
| Trace: Span Header | <img width="419" alt="Trace Span Header Before" src="https://github.com/user-attachments/assets/623f0cbc-6685-480a-99f4-4df6aa56ec65"> | <img width="419" alt="Trace Span Header Post" src="https://github.com/user-attachments/assets/6146f313-2151-4d1b-8299-243ba5a29f61"> |

#### Modals 
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboard: Create | <img width="465" alt="Dashboards Create Before" src="https://github.com/user-attachments/assets/79c6b14a-ea1b-44c8-bd24-46db9a4ba24b"> | <img width="465" alt="Dashboards Create Post" src="https://github.com/user-attachments/assets/ea13b9ad-6d4a-4f13-ae69-f3d757340cf0"> | 
| Dashboard: Error | <img width="764" alt="Dashboard Error Header Before" src="https://github.com/user-attachments/assets/5688a486-dded-419a-9410-d207b3ea678f"> | <img width="764" alt="Dashboard Error Header Post" src="https://github.com/user-attachments/assets/11b1f2cc-ae78-4fad-9841-fc7d3466b1da"> |
| Dashboard: Error | <img width="764" alt="Dashboard Error p Before" src="https://github.com/user-attachments/assets/38e97c71-8305-4993-a584-7f58c312a2db"> | <img width="764" alt="Dashboard Error P Post" src="https://github.com/user-attachments/assets/c3962c62-b837-43db-9575-4bddc7ba31e4"> |
| Dashboard: Samples | <img width="795" alt="Dashboard Samples Before" src="https://github.com/user-attachments/assets/14a1b1aa-96e2-411f-a85d-dc83b6bc62e4"> | <img width="795" alt="Dashboard Samples Post" src="https://github.com/user-attachments/assets/d30cb267-7308-415d-85ee-9b8a21b49f71"> |
| Integrations: Delete | <img width="490" alt="Integration Delete Header Before" src="https://github.com/user-attachments/assets/2e389002-7bd9-4d66-a299-a2728be75348"> | <img width="490" alt="Integration Delete Header Post" src="https://github.com/user-attachments/assets/3a0fec35-6c42-4336-b45e-0c100113aa50"> |
| Integrations: Delete | <img width="490" alt="Integration Delete p Before" src="https://github.com/user-attachments/assets/0d9fa4d7-8aa2-49a3-9571-40a3aa2ff413"> | <img width="490" alt="Integration Delete p Post" src="https://github.com/user-attachments/assets/17dfcc17-8f99-4e89-addf-de25c7593eb0"> |
| Notebooks: Browse Vis | <img width="523" alt="Notebooks Browse Before" src="https://github.com/user-attachments/assets/53d79804-b605-4ee5-a85d-04f482f27a73"> | <img width="523" alt="Notebooks Browse Post" src="https://github.com/user-attachments/assets/a67cd9ce-01df-4d57-bd58-f848a6b550ad"> |
| Notebooks: Duplicate | <img width="478" alt="Notebooks Custom Input Modal Before" src="https://github.com/user-attachments/assets/2718b643-5e0f-4001-993f-105f63ba81eb"> | <img width="478" alt="Notebooks Custom Input Modal Post" src="https://github.com/user-attachments/assets/cd63f46c-f3d5-49a5-a451-b98effc97b83"> |
| Notebooks: Delete | <img width="787" alt="Delete Notebook Before" src="https://github.com/user-attachments/assets/4fcfe378-0b33-4b5a-8da1-08eaaee98616"> | <img width="787" alt="Delete Notebook Post" src="https://github.com/user-attachments/assets/e8003543-ac3d-417d-86b6-fa0cb8d71e1f"> |

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
