### PR TITLE
[Feature] Traces/Services UI update

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -547,7 +547,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -1810,7 +1810,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -3012,7 +3012,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -4189,7 +4189,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -5459,7 +5459,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -6636,7 +6636,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -7833,7 +7833,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -8971,7 +8971,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -10171,7 +10171,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -11314,7 +11314,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -12548,7 +12548,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -13725,7 +13725,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -14927,7 +14927,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -16104,7 +16104,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -17344,7 +17344,7 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          style="padding: 0px 16px;"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
                             class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
@@ -18607,7 +18607,7 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        style="padding: 0px 16px;"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
                           class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"

--- a/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -547,202 +547,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -1804,202 +1810,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -3000,202 +3012,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -4171,202 +4189,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -5435,202 +5459,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -6606,202 +6636,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -7797,202 +7833,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -8929,202 +8971,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -10123,202 +10171,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -11260,202 +11314,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -12488,202 +12548,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -13659,202 +13725,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -14855,202 +14927,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -16026,202 +16104,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -17260,202 +17344,208 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          style="padding: 0px 16px;"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--medium"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              >
+                                Select metric to display
+                              </legend>
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--medium"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -18517,202 +18607,208 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        style="padding: 0px 16px;"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            >
+                              Select metric to display
+                            </legend>
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -669,542 +669,542 @@ exports[`Service Config component renders empty service config 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <div
-                    style={
-                      Object {
-                        "padding": "0 16px",
-                      }
-                    }
+                  <EuiPage
+                    paddingSize="m"
                   >
-                    <EuiPanel>
-                      <div
-                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                      >
-                        <PanelTitle
-                          title="Service map"
+                    <div
+                      className="euiPage euiPage--paddingMedium euiPage--grow"
+                    >
+                      <EuiPanel>
+                        <div
+                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
-                          <EuiText
+                          <PanelTitle
+                            title="Service map"
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Service map
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                          <EuiSpacer
                             size="m"
                           >
                             <div
-                              className="euiText euiText--medium"
-                            >
-                              <span
-                                className="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                          </EuiText>
-                        </PanelTitle>
-                        <EuiSpacer
-                          size="m"
-                        >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiButtonGroup
-                          buttonSize="s"
-                          color="text"
-                          idSelected="latency"
-                          legend="Select metric to display"
-                          onChange={[Function]}
-                          options={
-                            Array [
-                              Object {
-                                "id": "latency",
-                                "label": "Duration",
-                              },
-                              Object {
-                                "id": "error_rate",
-                                "label": "Errors",
-                              },
-                              Object {
-                                "id": "throughput",
-                                "label": "Request Rate",
-                              },
-                            ]
-                          }
-                        >
-                          <fieldset
-                            className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            disabled={false}
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiButtonGroup
+                            buttonSize="s"
+                            color="text"
+                            idSelected="latency"
+                            legend="Select metric to display"
+                            onChange={[Function]}
+                            options={
+                              Array [
+                                Object {
+                                  "id": "latency",
+                                  "label": "Duration",
+                                },
+                                Object {
+                                  "id": "error_rate",
+                                  "label": "Errors",
+                                },
+                                Object {
+                                  "id": "throughput",
+                                  "label": "Request Rate",
+                                },
+                              ]
+                            }
                           >
-                            <EuiScreenReaderOnly>
-                              <legend
-                                className="euiScreenReaderOnly"
-                              >
-                                Select metric to display
-                              </legend>
-                            </EuiScreenReaderOnly>
-                            <div
-                              className="euiButtonGroup__buttons"
+                            <fieldset
+                              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                              disabled={false}
                             >
-                              <EuiButtonGroupButton
-                                color="text"
-                                element="label"
-                                id="latency"
-                                isDisabled={false}
-                                isIconOnly={false}
-                                isSelected={true}
-                                key="0"
-                                label="Duration"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButtonGroupButton"
-                                  className="euiButtonGroupButton-isSelected"
-                                  color="text"
-                                  element="label"
-                                  fill={true}
-                                  htmlFor="random_html_id"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonGroupButton__textShift",
-                                      "data-text": "Duration",
-                                      "ref": [Function],
-                                      "title": "Duration",
-                                    }
-                                  }
+                              <EuiScreenReaderOnly>
+                                <legend
+                                  className="euiScreenReaderOnly"
                                 >
-                                  <label
-                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                    disabled={false}
-                                    htmlFor="random_html_id"
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text euiButtonGroupButton__textShift",
-                                          "data-text": "Duration",
-                                          "ref": [Function],
-                                          "title": "Duration",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <span
-                                          className="euiButton__text euiButtonGroupButton__textShift"
-                                          data-text="Duration"
-                                          title="Duration"
-                                        >
-                                          <input
-                                            checked={true}
-                                            className="euiScreenReaderOnly"
-                                            data-test-subj="latency"
-                                            disabled={false}
-                                            id="random_html_id"
-                                            name="random_html_id"
-                                            onChange={[Function]}
-                                            type="radio"
-                                          />
-                                          Duration
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </label>
-                                </EuiButtonDisplay>
-                              </EuiButtonGroupButton>
-                              <EuiButtonGroupButton
-                                color="text"
-                                element="label"
-                                id="error_rate"
-                                isDisabled={false}
-                                isIconOnly={false}
-                                isSelected={false}
-                                key="1"
-                                label="Errors"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButtonGroupButton"
-                                  className=""
-                                  color="text"
-                                  element="label"
-                                  fill={false}
-                                  htmlFor="random_html_id"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonGroupButton__textShift",
-                                      "data-text": "Errors",
-                                      "ref": [Function],
-                                      "title": "Errors",
-                                    }
-                                  }
-                                >
-                                  <label
-                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                    disabled={false}
-                                    htmlFor="random_html_id"
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text euiButtonGroupButton__textShift",
-                                          "data-text": "Errors",
-                                          "ref": [Function],
-                                          "title": "Errors",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <span
-                                          className="euiButton__text euiButtonGroupButton__textShift"
-                                          data-text="Errors"
-                                          title="Errors"
-                                        >
-                                          <input
-                                            checked={false}
-                                            className="euiScreenReaderOnly"
-                                            data-test-subj="error_rate"
-                                            disabled={false}
-                                            id="random_html_id"
-                                            name="random_html_id"
-                                            onChange={[Function]}
-                                            type="radio"
-                                          />
-                                          Errors
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </label>
-                                </EuiButtonDisplay>
-                              </EuiButtonGroupButton>
-                              <EuiButtonGroupButton
-                                color="text"
-                                element="label"
-                                id="throughput"
-                                isDisabled={false}
-                                isIconOnly={false}
-                                isSelected={false}
-                                key="2"
-                                label="Request Rate"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButtonGroupButton"
-                                  className=""
-                                  color="text"
-                                  element="label"
-                                  fill={false}
-                                  htmlFor="random_html_id"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonGroupButton__textShift",
-                                      "data-text": "Request Rate",
-                                      "ref": [Function],
-                                      "title": "Request Rate",
-                                    }
-                                  }
-                                >
-                                  <label
-                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                    disabled={false}
-                                    htmlFor="random_html_id"
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text euiButtonGroupButton__textShift",
-                                          "data-text": "Request Rate",
-                                          "ref": [Function],
-                                          "title": "Request Rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <span
-                                          className="euiButton__text euiButtonGroupButton__textShift"
-                                          data-text="Request Rate"
-                                          title="Request Rate"
-                                        >
-                                          <input
-                                            checked={false}
-                                            className="euiScreenReaderOnly"
-                                            data-test-subj="throughput"
-                                            disabled={false}
-                                            id="random_html_id"
-                                            name="random_html_id"
-                                            onChange={[Function]}
-                                            type="radio"
-                                          />
-                                          Request Rate
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </label>
-                                </EuiButtonDisplay>
-                              </EuiButtonGroupButton>
-                            </div>
-                          </fieldset>
-                        </EuiButtonGroup>
-                        <EuiHorizontalRule
-                          margin="m"
-                        >
-                          <hr
-                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                        </EuiHorizontalRule>
-                        <EuiFlexGroup
-                          alignItems="center"
-                          gutterSize="s"
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                          >
-                            <EuiFlexItem
-                              grow={false}
-                            >
+                                  Select metric to display
+                                </legend>
+                              </EuiScreenReaderOnly>
                               <div
-                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                                className="euiButtonGroup__buttons"
                               >
-                                <EuiText>
-                                  <div
-                                    className="euiText euiText--medium"
-                                  >
-                                    Focus on
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </EuiFlexItem>
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFieldSearch
-                                  compressed={false}
-                                  fullWidth={false}
-                                  incremental={false}
-                                  isClearable={true}
-                                  isInvalid={false}
-                                  isLoading={false}
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="latency"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={true}
+                                  key="0"
+                                  label="Duration"
+                                  name="random_html_id"
                                   onChange={[Function]}
-                                  onSearch={[Function]}
-                                  placeholder="Service name"
-                                  value=""
+                                  size="s"
                                 >
-                                  <EuiFormControlLayout
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className="euiButtonGroupButton-isSelected"
+                                    color="text"
+                                    element="label"
+                                    fill={true}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonGroupButton__textShift",
+                                        "data-text": "Duration",
+                                        "ref": [Function],
+                                        "title": "Duration",
+                                      }
+                                    }
+                                  >
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Duration",
+                                            "ref": [Function],
+                                            "title": "Duration",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Duration"
+                                            title="Duration"
+                                          >
+                                            <input
+                                              checked={true}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="latency"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Duration
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="error_rate"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="1"
+                                  label="Errors"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
+                                >
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonGroupButton__textShift",
+                                        "data-text": "Errors",
+                                        "ref": [Function],
+                                        "title": "Errors",
+                                      }
+                                    }
+                                  >
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Errors",
+                                            "ref": [Function],
+                                            "title": "Errors",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Errors"
+                                            title="Errors"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="error_rate"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Errors
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="throughput"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="2"
+                                  label="Request Rate"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
+                                >
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonGroupButton__textShift",
+                                        "data-text": "Request Rate",
+                                        "ref": [Function],
+                                        "title": "Request Rate",
+                                      }
+                                    }
+                                  >
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Request Rate",
+                                            "ref": [Function],
+                                            "title": "Request Rate",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Request Rate"
+                                            title="Request Rate"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="throughput"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Request Rate
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                              </div>
+                            </fieldset>
+                          </EuiButtonGroup>
+                          <EuiHorizontalRule
+                            margin="m"
+                          >
+                            <hr
+                              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                          </EuiHorizontalRule>
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="s"
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiText>
+                                    <div
+                                      className="euiText euiText--medium"
+                                    >
+                                      Focus on
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiFieldSearch
                                     compressed={false}
                                     fullWidth={false}
-                                    icon="search"
+                                    incremental={false}
+                                    isClearable={true}
+                                    isInvalid={false}
                                     isLoading={false}
+                                    onChange={[Function]}
+                                    onSearch={[Function]}
+                                    placeholder="Service name"
+                                    value=""
                                   >
-                                    <div
-                                      className="euiFormControlLayout"
+                                    <EuiFormControlLayout
+                                      compressed={false}
+                                      fullWidth={false}
+                                      icon="search"
+                                      isLoading={false}
                                     >
                                       <div
-                                        className="euiFormControlLayout__childrenWrapper"
+                                        className="euiFormControlLayout"
                                       >
-                                        <EuiValidatableControl
-                                          isInvalid={false}
+                                        <div
+                                          className="euiFormControlLayout__childrenWrapper"
                                         >
-                                          <input
-                                            className="euiFieldSearch"
-                                            onChange={[Function]}
-                                            onKeyUp={[Function]}
-                                            placeholder="Service name"
-                                            type="search"
-                                            value=""
-                                          />
-                                        </EuiValidatableControl>
-                                        <EuiFormControlLayoutIcons
-                                          compressed={false}
-                                          icon="search"
-                                          isLoading={false}
-                                        >
-                                          <div
-                                            className="euiFormControlLayoutIcons"
+                                          <EuiValidatableControl
+                                            isInvalid={false}
                                           >
-                                            <EuiFormControlLayoutCustomIcon
-                                              size="m"
+                                            <input
+                                              className="euiFieldSearch"
+                                              onChange={[Function]}
+                                              onKeyUp={[Function]}
+                                              placeholder="Service name"
                                               type="search"
+                                              value=""
+                                            />
+                                          </EuiValidatableControl>
+                                          <EuiFormControlLayoutIcons
+                                            compressed={false}
+                                            icon="search"
+                                            isLoading={false}
+                                          >
+                                            <div
+                                              className="euiFormControlLayoutIcons"
                                             >
-                                              <span
-                                                className="euiFormControlLayoutCustomIcon"
+                                              <EuiFormControlLayoutCustomIcon
+                                                size="m"
+                                                type="search"
                                               >
-                                                <EuiIcon
-                                                  aria-hidden="true"
-                                                  className="euiFormControlLayoutCustomIcon__icon"
-                                                  size="m"
-                                                  type="search"
+                                                <span
+                                                  className="euiFormControlLayoutCustomIcon"
                                                 >
-                                                  <EuiIconBeaker
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiFormControlLayoutCustomIcon__icon"
+                                                    size="m"
+                                                    type="search"
                                                   >
-                                                    <svg
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                       focusable="false"
-                                                      height={16}
                                                       role="img"
                                                       style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
                                                     >
-                                                      <path
-                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconBeaker>
-                                                </EuiIcon>
-                                              </span>
-                                            </EuiFormControlLayoutCustomIcon>
-                                          </div>
-                                        </EuiFormControlLayoutIcons>
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
+                                                  </EuiIcon>
+                                                </span>
+                                              </EuiFormControlLayoutCustomIcon>
+                                            </div>
+                                          </EuiFormControlLayoutIcons>
+                                        </div>
                                       </div>
-                                    </div>
-                                  </EuiFormControlLayout>
-                                </EuiFieldSearch>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                        <EuiSpacer>
+                                    </EuiFormControlLayout>
+                                  </EuiFieldSearch>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                          <EuiSpacer>
+                            <div
+                              className="euiSpacer euiSpacer--l"
+                            />
+                          </EuiSpacer>
                           <div
-                            className="euiSpacer euiSpacer--l"
-                          />
-                        </EuiSpacer>
-                        <div
-                          style={
-                            Object {
-                              "minHeight": 434,
+                            style={
+                              Object {
+                                "minHeight": 434,
+                              }
                             }
-                          }
-                        >
-                          <NoMatchMessage
-                            size="s"
                           >
-                            <EuiSpacer
+                            <NoMatchMessage
                               size="s"
                             >
-                              <div
-                                className="euiSpacer euiSpacer--s"
-                              />
-                            </EuiSpacer>
-                            <EuiEmptyPrompt
-                              body={
-                                <EuiText>
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </EuiText>
-                              }
-                              title={
-                                <h2>
-                                  No matches
-                                </h2>
-                              }
-                            >
-                              <div
-                                className="euiEmptyPrompt"
+                              <EuiSpacer
+                                size="s"
                               >
-                                <EuiTitle
-                                  size="m"
-                                >
-                                  <h2
-                                    className="euiTitle euiTitle--medium"
-                                  >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                              <EuiEmptyPrompt
+                                body={
+                                  <EuiText>
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </EuiText>
+                                }
+                                title={
+                                  <h2>
                                     No matches
                                   </h2>
-                                </EuiTitle>
-                                <EuiTextColor
-                                  color="subdued"
+                                }
+                              >
+                                <div
+                                  className="euiEmptyPrompt"
                                 >
-                                  <span
-                                    className="euiTextColor euiTextColor--subdued"
+                                  <EuiTitle
+                                    size="m"
                                   >
-                                    <EuiSpacer
-                                      size="m"
+                                    <h2
+                                      className="euiTitle euiTitle--medium"
                                     >
-                                      <div
-                                        className="euiSpacer euiSpacer--m"
-                                      />
-                                    </EuiSpacer>
-                                    <EuiText>
-                                      <div
-                                        className="euiText euiText--medium"
+                                      No matches
+                                    </h2>
+                                  </EuiTitle>
+                                  <EuiTextColor
+                                    color="subdued"
+                                  >
+                                    <span
+                                      className="euiTextColor euiTextColor--subdued"
+                                    >
+                                      <EuiSpacer
+                                        size="m"
                                       >
-                                        <EuiText>
-                                          <div
-                                            className="euiText euiText--medium"
-                                          >
-                                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                          </div>
-                                        </EuiText>
-                                      </div>
-                                    </EuiText>
-                                  </span>
-                                </EuiTextColor>
-                              </div>
-                            </EuiEmptyPrompt>
-                            <EuiSpacer
-                              size="s"
-                            >
-                              <div
-                                className="euiSpacer euiSpacer--s"
-                              />
-                            </EuiSpacer>
-                          </NoMatchMessage>
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          <EuiText>
+                                            <div
+                                              className="euiText euiText--medium"
+                                            >
+                                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiText>
+                                    </span>
+                                  </EuiTextColor>
+                                </div>
+                              </EuiEmptyPrompt>
+                              <EuiSpacer
+                                size="s"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                            </NoMatchMessage>
+                          </div>
                         </div>
-                      </div>
-                    </EuiPanel>
-                    <EuiSpacer
-                      size="xl"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--xl"
-                      />
-                    </EuiSpacer>
-                  </div>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="xl"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--xl"
+                        />
+                      </EuiSpacer>
+                    </div>
+                  </EuiPage>
                 </ServiceMap>
               </div>
             </div>
@@ -1901,542 +1901,542 @@ exports[`Service Config component renders with one service selected 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <div
-                    style={
-                      Object {
-                        "padding": "0 16px",
-                      }
-                    }
+                  <EuiPage
+                    paddingSize="m"
                   >
-                    <EuiPanel>
-                      <div
-                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                      >
-                        <PanelTitle
-                          title="Service map"
+                    <div
+                      className="euiPage euiPage--paddingMedium euiPage--grow"
+                    >
+                      <EuiPanel>
+                        <div
+                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
-                          <EuiText
+                          <PanelTitle
+                            title="Service map"
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Service map
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                          <EuiSpacer
                             size="m"
                           >
                             <div
-                              className="euiText euiText--medium"
-                            >
-                              <span
-                                className="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                          </EuiText>
-                        </PanelTitle>
-                        <EuiSpacer
-                          size="m"
-                        >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiButtonGroup
-                          buttonSize="s"
-                          color="text"
-                          idSelected="latency"
-                          legend="Select metric to display"
-                          onChange={[Function]}
-                          options={
-                            Array [
-                              Object {
-                                "id": "latency",
-                                "label": "Duration",
-                              },
-                              Object {
-                                "id": "error_rate",
-                                "label": "Errors",
-                              },
-                              Object {
-                                "id": "throughput",
-                                "label": "Request Rate",
-                              },
-                            ]
-                          }
-                        >
-                          <fieldset
-                            className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            disabled={false}
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiButtonGroup
+                            buttonSize="s"
+                            color="text"
+                            idSelected="latency"
+                            legend="Select metric to display"
+                            onChange={[Function]}
+                            options={
+                              Array [
+                                Object {
+                                  "id": "latency",
+                                  "label": "Duration",
+                                },
+                                Object {
+                                  "id": "error_rate",
+                                  "label": "Errors",
+                                },
+                                Object {
+                                  "id": "throughput",
+                                  "label": "Request Rate",
+                                },
+                              ]
+                            }
                           >
-                            <EuiScreenReaderOnly>
-                              <legend
-                                className="euiScreenReaderOnly"
-                              >
-                                Select metric to display
-                              </legend>
-                            </EuiScreenReaderOnly>
-                            <div
-                              className="euiButtonGroup__buttons"
+                            <fieldset
+                              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                              disabled={false}
                             >
-                              <EuiButtonGroupButton
-                                color="text"
-                                element="label"
-                                id="latency"
-                                isDisabled={false}
-                                isIconOnly={false}
-                                isSelected={true}
-                                key="0"
-                                label="Duration"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButtonGroupButton"
-                                  className="euiButtonGroupButton-isSelected"
-                                  color="text"
-                                  element="label"
-                                  fill={true}
-                                  htmlFor="random_html_id"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonGroupButton__textShift",
-                                      "data-text": "Duration",
-                                      "ref": [Function],
-                                      "title": "Duration",
-                                    }
-                                  }
+                              <EuiScreenReaderOnly>
+                                <legend
+                                  className="euiScreenReaderOnly"
                                 >
-                                  <label
-                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                    disabled={false}
-                                    htmlFor="random_html_id"
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text euiButtonGroupButton__textShift",
-                                          "data-text": "Duration",
-                                          "ref": [Function],
-                                          "title": "Duration",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <span
-                                          className="euiButton__text euiButtonGroupButton__textShift"
-                                          data-text="Duration"
-                                          title="Duration"
-                                        >
-                                          <input
-                                            checked={true}
-                                            className="euiScreenReaderOnly"
-                                            data-test-subj="latency"
-                                            disabled={false}
-                                            id="random_html_id"
-                                            name="random_html_id"
-                                            onChange={[Function]}
-                                            type="radio"
-                                          />
-                                          Duration
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </label>
-                                </EuiButtonDisplay>
-                              </EuiButtonGroupButton>
-                              <EuiButtonGroupButton
-                                color="text"
-                                element="label"
-                                id="error_rate"
-                                isDisabled={false}
-                                isIconOnly={false}
-                                isSelected={false}
-                                key="1"
-                                label="Errors"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButtonGroupButton"
-                                  className=""
-                                  color="text"
-                                  element="label"
-                                  fill={false}
-                                  htmlFor="random_html_id"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonGroupButton__textShift",
-                                      "data-text": "Errors",
-                                      "ref": [Function],
-                                      "title": "Errors",
-                                    }
-                                  }
-                                >
-                                  <label
-                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                    disabled={false}
-                                    htmlFor="random_html_id"
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text euiButtonGroupButton__textShift",
-                                          "data-text": "Errors",
-                                          "ref": [Function],
-                                          "title": "Errors",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <span
-                                          className="euiButton__text euiButtonGroupButton__textShift"
-                                          data-text="Errors"
-                                          title="Errors"
-                                        >
-                                          <input
-                                            checked={false}
-                                            className="euiScreenReaderOnly"
-                                            data-test-subj="error_rate"
-                                            disabled={false}
-                                            id="random_html_id"
-                                            name="random_html_id"
-                                            onChange={[Function]}
-                                            type="radio"
-                                          />
-                                          Errors
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </label>
-                                </EuiButtonDisplay>
-                              </EuiButtonGroupButton>
-                              <EuiButtonGroupButton
-                                color="text"
-                                element="label"
-                                id="throughput"
-                                isDisabled={false}
-                                isIconOnly={false}
-                                isSelected={false}
-                                key="2"
-                                label="Request Rate"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                size="s"
-                              >
-                                <EuiButtonDisplay
-                                  baseClassName="euiButtonGroupButton"
-                                  className=""
-                                  color="text"
-                                  element="label"
-                                  fill={false}
-                                  htmlFor="random_html_id"
-                                  isDisabled={false}
-                                  onClick={[Function]}
-                                  size="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonGroupButton__textShift",
-                                      "data-text": "Request Rate",
-                                      "ref": [Function],
-                                      "title": "Request Rate",
-                                    }
-                                  }
-                                >
-                                  <label
-                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                    disabled={false}
-                                    htmlFor="random_html_id"
-                                    onClick={[Function]}
-                                    style={
-                                      Object {
-                                        "minWidth": undefined,
-                                      }
-                                    }
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButton__content"
-                                      iconSide="left"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButton__text euiButtonGroupButton__textShift",
-                                          "data-text": "Request Rate",
-                                          "ref": [Function],
-                                          "title": "Request Rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButton__content"
-                                      >
-                                        <span
-                                          className="euiButton__text euiButtonGroupButton__textShift"
-                                          data-text="Request Rate"
-                                          title="Request Rate"
-                                        >
-                                          <input
-                                            checked={false}
-                                            className="euiScreenReaderOnly"
-                                            data-test-subj="throughput"
-                                            disabled={false}
-                                            id="random_html_id"
-                                            name="random_html_id"
-                                            onChange={[Function]}
-                                            type="radio"
-                                          />
-                                          Request Rate
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </label>
-                                </EuiButtonDisplay>
-                              </EuiButtonGroupButton>
-                            </div>
-                          </fieldset>
-                        </EuiButtonGroup>
-                        <EuiHorizontalRule
-                          margin="m"
-                        >
-                          <hr
-                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                        </EuiHorizontalRule>
-                        <EuiFlexGroup
-                          alignItems="center"
-                          gutterSize="s"
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                          >
-                            <EuiFlexItem
-                              grow={false}
-                            >
+                                  Select metric to display
+                                </legend>
+                              </EuiScreenReaderOnly>
                               <div
-                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                                className="euiButtonGroup__buttons"
                               >
-                                <EuiText>
-                                  <div
-                                    className="euiText euiText--medium"
-                                  >
-                                    Focus on
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </EuiFlexItem>
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFieldSearch
-                                  compressed={false}
-                                  fullWidth={false}
-                                  incremental={false}
-                                  isClearable={true}
-                                  isInvalid={false}
-                                  isLoading={false}
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="latency"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={true}
+                                  key="0"
+                                  label="Duration"
+                                  name="random_html_id"
                                   onChange={[Function]}
-                                  onSearch={[Function]}
-                                  placeholder="Service name"
-                                  value=""
+                                  size="s"
                                 >
-                                  <EuiFormControlLayout
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className="euiButtonGroupButton-isSelected"
+                                    color="text"
+                                    element="label"
+                                    fill={true}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonGroupButton__textShift",
+                                        "data-text": "Duration",
+                                        "ref": [Function],
+                                        "title": "Duration",
+                                      }
+                                    }
+                                  >
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Duration",
+                                            "ref": [Function],
+                                            "title": "Duration",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Duration"
+                                            title="Duration"
+                                          >
+                                            <input
+                                              checked={true}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="latency"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Duration
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="error_rate"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="1"
+                                  label="Errors"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
+                                >
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonGroupButton__textShift",
+                                        "data-text": "Errors",
+                                        "ref": [Function],
+                                        "title": "Errors",
+                                      }
+                                    }
+                                  >
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Errors",
+                                            "ref": [Function],
+                                            "title": "Errors",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Errors"
+                                            title="Errors"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="error_rate"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Errors
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="throughput"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="2"
+                                  label="Request Rate"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
+                                >
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonGroupButton__textShift",
+                                        "data-text": "Request Rate",
+                                        "ref": [Function],
+                                        "title": "Request Rate",
+                                      }
+                                    }
+                                  >
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Request Rate",
+                                            "ref": [Function],
+                                            "title": "Request Rate",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Request Rate"
+                                            title="Request Rate"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="throughput"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Request Rate
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                              </div>
+                            </fieldset>
+                          </EuiButtonGroup>
+                          <EuiHorizontalRule
+                            margin="m"
+                          >
+                            <hr
+                              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                          </EuiHorizontalRule>
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="s"
+                          >
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem
+                                grow={false}
+                              >
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                >
+                                  <EuiText>
+                                    <div
+                                      className="euiText euiText--medium"
+                                    >
+                                      Focus on
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiFieldSearch
                                     compressed={false}
                                     fullWidth={false}
-                                    icon="search"
+                                    incremental={false}
+                                    isClearable={true}
+                                    isInvalid={false}
                                     isLoading={false}
+                                    onChange={[Function]}
+                                    onSearch={[Function]}
+                                    placeholder="Service name"
+                                    value=""
                                   >
-                                    <div
-                                      className="euiFormControlLayout"
+                                    <EuiFormControlLayout
+                                      compressed={false}
+                                      fullWidth={false}
+                                      icon="search"
+                                      isLoading={false}
                                     >
                                       <div
-                                        className="euiFormControlLayout__childrenWrapper"
+                                        className="euiFormControlLayout"
                                       >
-                                        <EuiValidatableControl
-                                          isInvalid={false}
+                                        <div
+                                          className="euiFormControlLayout__childrenWrapper"
                                         >
-                                          <input
-                                            className="euiFieldSearch"
-                                            onChange={[Function]}
-                                            onKeyUp={[Function]}
-                                            placeholder="Service name"
-                                            type="search"
-                                            value=""
-                                          />
-                                        </EuiValidatableControl>
-                                        <EuiFormControlLayoutIcons
-                                          compressed={false}
-                                          icon="search"
-                                          isLoading={false}
-                                        >
-                                          <div
-                                            className="euiFormControlLayoutIcons"
+                                          <EuiValidatableControl
+                                            isInvalid={false}
                                           >
-                                            <EuiFormControlLayoutCustomIcon
-                                              size="m"
+                                            <input
+                                              className="euiFieldSearch"
+                                              onChange={[Function]}
+                                              onKeyUp={[Function]}
+                                              placeholder="Service name"
                                               type="search"
+                                              value=""
+                                            />
+                                          </EuiValidatableControl>
+                                          <EuiFormControlLayoutIcons
+                                            compressed={false}
+                                            icon="search"
+                                            isLoading={false}
+                                          >
+                                            <div
+                                              className="euiFormControlLayoutIcons"
                                             >
-                                              <span
-                                                className="euiFormControlLayoutCustomIcon"
+                                              <EuiFormControlLayoutCustomIcon
+                                                size="m"
+                                                type="search"
                                               >
-                                                <EuiIcon
-                                                  aria-hidden="true"
-                                                  className="euiFormControlLayoutCustomIcon__icon"
-                                                  size="m"
-                                                  type="search"
+                                                <span
+                                                  className="euiFormControlLayoutCustomIcon"
                                                 >
-                                                  <EuiIconSearch
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiFormControlLayoutCustomIcon__icon"
+                                                    size="m"
+                                                    type="search"
                                                   >
-                                                    <svg
+                                                    <EuiIconSearch
                                                       aria-hidden={true}
                                                       className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
                                                       focusable="false"
-                                                      height={16}
                                                       role="img"
                                                       style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
                                                     >
-                                                      <path
-                                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconSearch>
-                                                </EuiIcon>
-                                              </span>
-                                            </EuiFormControlLayoutCustomIcon>
-                                          </div>
-                                        </EuiFormControlLayoutIcons>
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconSearch>
+                                                  </EuiIcon>
+                                                </span>
+                                              </EuiFormControlLayoutCustomIcon>
+                                            </div>
+                                          </EuiFormControlLayoutIcons>
+                                        </div>
                                       </div>
-                                    </div>
-                                  </EuiFormControlLayout>
-                                </EuiFieldSearch>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                        <EuiSpacer>
+                                    </EuiFormControlLayout>
+                                  </EuiFieldSearch>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                          <EuiSpacer>
+                            <div
+                              className="euiSpacer euiSpacer--l"
+                            />
+                          </EuiSpacer>
                           <div
-                            className="euiSpacer euiSpacer--l"
-                          />
-                        </EuiSpacer>
-                        <div
-                          style={
-                            Object {
-                              "minHeight": 434,
+                            style={
+                              Object {
+                                "minHeight": 434,
+                              }
                             }
-                          }
-                        >
-                          <NoMatchMessage
-                            size="s"
                           >
-                            <EuiSpacer
+                            <NoMatchMessage
                               size="s"
                             >
-                              <div
-                                className="euiSpacer euiSpacer--s"
-                              />
-                            </EuiSpacer>
-                            <EuiEmptyPrompt
-                              body={
-                                <EuiText>
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </EuiText>
-                              }
-                              title={
-                                <h2>
-                                  No matches
-                                </h2>
-                              }
-                            >
-                              <div
-                                className="euiEmptyPrompt"
+                              <EuiSpacer
+                                size="s"
                               >
-                                <EuiTitle
-                                  size="m"
-                                >
-                                  <h2
-                                    className="euiTitle euiTitle--medium"
-                                  >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                              <EuiEmptyPrompt
+                                body={
+                                  <EuiText>
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </EuiText>
+                                }
+                                title={
+                                  <h2>
                                     No matches
                                   </h2>
-                                </EuiTitle>
-                                <EuiTextColor
-                                  color="subdued"
+                                }
+                              >
+                                <div
+                                  className="euiEmptyPrompt"
                                 >
-                                  <span
-                                    className="euiTextColor euiTextColor--subdued"
+                                  <EuiTitle
+                                    size="m"
                                   >
-                                    <EuiSpacer
-                                      size="m"
+                                    <h2
+                                      className="euiTitle euiTitle--medium"
                                     >
-                                      <div
-                                        className="euiSpacer euiSpacer--m"
-                                      />
-                                    </EuiSpacer>
-                                    <EuiText>
-                                      <div
-                                        className="euiText euiText--medium"
+                                      No matches
+                                    </h2>
+                                  </EuiTitle>
+                                  <EuiTextColor
+                                    color="subdued"
+                                  >
+                                    <span
+                                      className="euiTextColor euiTextColor--subdued"
+                                    >
+                                      <EuiSpacer
+                                        size="m"
                                       >
-                                        <EuiText>
-                                          <div
-                                            className="euiText euiText--medium"
-                                          >
-                                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                          </div>
-                                        </EuiText>
-                                      </div>
-                                    </EuiText>
-                                  </span>
-                                </EuiTextColor>
-                              </div>
-                            </EuiEmptyPrompt>
-                            <EuiSpacer
-                              size="s"
-                            >
-                              <div
-                                className="euiSpacer euiSpacer--s"
-                              />
-                            </EuiSpacer>
-                          </NoMatchMessage>
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          <EuiText>
+                                            <div
+                                              className="euiText euiText--medium"
+                                            >
+                                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiText>
+                                    </span>
+                                  </EuiTextColor>
+                                </div>
+                              </EuiEmptyPrompt>
+                              <EuiSpacer
+                                size="s"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                            </NoMatchMessage>
+                          </div>
                         </div>
-                      </div>
-                    </EuiPanel>
-                    <EuiSpacer
-                      size="xl"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--xl"
-                      />
-                    </EuiSpacer>
-                  </div>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="xl"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--xl"
+                        />
+                      </EuiSpacer>
+                    </div>
+                  </EuiPage>
                 </ServiceMap>
               </div>
             </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -669,531 +669,542 @@ exports[`Service Config component renders empty service config 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <EuiPanel>
-                    <div
-                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                    >
-                      <PanelTitle
-                        title="Service map"
+                  <div
+                    style={
+                      Object {
+                        "padding": "0 16px",
+                      }
+                    }
+                  >
+                    <EuiPanel>
+                      <div
+                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
-                        <EuiText
+                        <PanelTitle
+                          title="Service map"
+                        >
+                          <EuiText
+                            size="m"
+                          >
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <span
+                                className="panel-title"
+                              >
+                                Service map
+                              </span>
+                            </div>
+                          </EuiText>
+                        </PanelTitle>
+                        <EuiSpacer
                           size="m"
                         >
                           <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiButtonGroup
-                        buttonSize="s"
-                        color="text"
-                        idSelected="latency"
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "id": "latency",
-                              "label": "Duration",
-                            },
-                            Object {
-                              "id": "error_rate",
-                              "label": "Errors",
-                            },
-                            Object {
-                              "id": "throughput",
-                              "label": "Request Rate",
-                            },
-                          ]
-                        }
-                      >
-                        <fieldset
-                          className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          disabled={false}
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiButtonGroup
+                          buttonSize="s"
+                          color="text"
+                          idSelected="latency"
+                          legend="Select metric to display"
+                          onChange={[Function]}
+                          options={
+                            Array [
+                              Object {
+                                "id": "latency",
+                                "label": "Duration",
+                              },
+                              Object {
+                                "id": "error_rate",
+                                "label": "Errors",
+                              },
+                              Object {
+                                "id": "throughput",
+                                "label": "Request Rate",
+                              },
+                            ]
+                          }
                         >
-                          <EuiScreenReaderOnly>
-                            <legend
-                              className="euiScreenReaderOnly"
-                            />
-                          </EuiScreenReaderOnly>
-                          <div
-                            className="euiButtonGroup__buttons"
+                          <fieldset
+                            className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            disabled={false}
                           >
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="latency"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={true}
-                              key="0"
-                              label="Duration"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className="euiButtonGroupButton-isSelected"
-                                color="text"
-                                element="label"
-                                fill={true}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Duration",
-                                    "ref": [Function],
-                                    "title": "Duration",
-                                  }
-                                }
+                            <EuiScreenReaderOnly>
+                              <legend
+                                className="euiScreenReaderOnly"
                               >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
-                                        "data-text": "Duration",
-                                        "ref": [Function],
-                                        "title": "Duration",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Duration"
-                                        title="Duration"
-                                      >
-                                        <input
-                                          checked={true}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="latency"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Duration
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="error_rate"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="1"
-                              label="Errors"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Errors",
-                                    "ref": [Function],
-                                    "title": "Errors",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
-                                        "data-text": "Errors",
-                                        "ref": [Function],
-                                        "title": "Errors",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Errors"
-                                        title="Errors"
-                                      >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="error_rate"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Errors
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="throughput"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="2"
-                              label="Request Rate"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Request Rate",
-                                    "ref": [Function],
-                                    "title": "Request Rate",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
-                                        "data-text": "Request Rate",
-                                        "ref": [Function],
-                                        "title": "Request Rate",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Request Rate"
-                                        title="Request Rate"
-                                      >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="throughput"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Request Rate
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                          </div>
-                        </fieldset>
-                      </EuiButtonGroup>
-                      <EuiHorizontalRule
-                        margin="m"
-                      >
-                        <hr
-                          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                      </EuiHorizontalRule>
-                      <EuiFlexGroup
-                        alignItems="center"
-                        gutterSize="s"
-                      >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
+                                Select metric to display
+                              </legend>
+                            </EuiScreenReaderOnly>
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiButtonGroup__buttons"
                             >
-                              <EuiText>
-                                <div
-                                  className="euiText euiText--medium"
-                                >
-                                  Focus on
-                                </div>
-                              </EuiText>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiFieldSearch
-                                compressed={false}
-                                fullWidth={false}
-                                incremental={false}
-                                isClearable={true}
-                                isInvalid={false}
-                                isLoading={false}
+                              <EuiButtonGroupButton
+                                color="text"
+                                element="label"
+                                id="latency"
+                                isDisabled={false}
+                                isIconOnly={false}
+                                isSelected={true}
+                                key="0"
+                                label="Duration"
+                                name="random_html_id"
                                 onChange={[Function]}
-                                onSearch={[Function]}
-                                placeholder="Service name"
-                                value=""
+                                size="s"
                               >
-                                <EuiFormControlLayout
+                                <EuiButtonDisplay
+                                  baseClassName="euiButtonGroupButton"
+                                  className="euiButtonGroupButton-isSelected"
+                                  color="text"
+                                  element="label"
+                                  fill={true}
+                                  htmlFor="random_html_id"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonGroupButton__textShift",
+                                      "data-text": "Duration",
+                                      "ref": [Function],
+                                      "title": "Duration",
+                                    }
+                                  }
+                                >
+                                  <label
+                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                    disabled={false}
+                                    htmlFor="random_html_id"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text euiButtonGroupButton__textShift",
+                                          "data-text": "Duration",
+                                          "ref": [Function],
+                                          "title": "Duration",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text euiButtonGroupButton__textShift"
+                                          data-text="Duration"
+                                          title="Duration"
+                                        >
+                                          <input
+                                            checked={true}
+                                            className="euiScreenReaderOnly"
+                                            data-test-subj="latency"
+                                            disabled={false}
+                                            id="random_html_id"
+                                            name="random_html_id"
+                                            onChange={[Function]}
+                                            type="radio"
+                                          />
+                                          Duration
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </label>
+                                </EuiButtonDisplay>
+                              </EuiButtonGroupButton>
+                              <EuiButtonGroupButton
+                                color="text"
+                                element="label"
+                                id="error_rate"
+                                isDisabled={false}
+                                isIconOnly={false}
+                                isSelected={false}
+                                key="1"
+                                label="Errors"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                size="s"
+                              >
+                                <EuiButtonDisplay
+                                  baseClassName="euiButtonGroupButton"
+                                  className=""
+                                  color="text"
+                                  element="label"
+                                  fill={false}
+                                  htmlFor="random_html_id"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonGroupButton__textShift",
+                                      "data-text": "Errors",
+                                      "ref": [Function],
+                                      "title": "Errors",
+                                    }
+                                  }
+                                >
+                                  <label
+                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                    disabled={false}
+                                    htmlFor="random_html_id"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text euiButtonGroupButton__textShift",
+                                          "data-text": "Errors",
+                                          "ref": [Function],
+                                          "title": "Errors",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text euiButtonGroupButton__textShift"
+                                          data-text="Errors"
+                                          title="Errors"
+                                        >
+                                          <input
+                                            checked={false}
+                                            className="euiScreenReaderOnly"
+                                            data-test-subj="error_rate"
+                                            disabled={false}
+                                            id="random_html_id"
+                                            name="random_html_id"
+                                            onChange={[Function]}
+                                            type="radio"
+                                          />
+                                          Errors
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </label>
+                                </EuiButtonDisplay>
+                              </EuiButtonGroupButton>
+                              <EuiButtonGroupButton
+                                color="text"
+                                element="label"
+                                id="throughput"
+                                isDisabled={false}
+                                isIconOnly={false}
+                                isSelected={false}
+                                key="2"
+                                label="Request Rate"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                size="s"
+                              >
+                                <EuiButtonDisplay
+                                  baseClassName="euiButtonGroupButton"
+                                  className=""
+                                  color="text"
+                                  element="label"
+                                  fill={false}
+                                  htmlFor="random_html_id"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonGroupButton__textShift",
+                                      "data-text": "Request Rate",
+                                      "ref": [Function],
+                                      "title": "Request Rate",
+                                    }
+                                  }
+                                >
+                                  <label
+                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                    disabled={false}
+                                    htmlFor="random_html_id"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text euiButtonGroupButton__textShift",
+                                          "data-text": "Request Rate",
+                                          "ref": [Function],
+                                          "title": "Request Rate",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text euiButtonGroupButton__textShift"
+                                          data-text="Request Rate"
+                                          title="Request Rate"
+                                        >
+                                          <input
+                                            checked={false}
+                                            className="euiScreenReaderOnly"
+                                            data-test-subj="throughput"
+                                            disabled={false}
+                                            id="random_html_id"
+                                            name="random_html_id"
+                                            onChange={[Function]}
+                                            type="radio"
+                                          />
+                                          Request Rate
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </label>
+                                </EuiButtonDisplay>
+                              </EuiButtonGroupButton>
+                            </div>
+                          </fieldset>
+                        </EuiButtonGroup>
+                        <EuiHorizontalRule
+                          margin="m"
+                        >
+                          <hr
+                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                        </EuiHorizontalRule>
+                        <EuiFlexGroup
+                          alignItems="center"
+                          gutterSize="s"
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <EuiFlexItem
+                              grow={false}
+                            >
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <EuiText>
+                                  <div
+                                    className="euiText euiText--medium"
+                                  >
+                                    Focus on
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFieldSearch
                                   compressed={false}
                                   fullWidth={false}
-                                  icon="search"
+                                  incremental={false}
+                                  isClearable={true}
+                                  isInvalid={false}
                                   isLoading={false}
+                                  onChange={[Function]}
+                                  onSearch={[Function]}
+                                  placeholder="Service name"
+                                  value=""
                                 >
-                                  <div
-                                    className="euiFormControlLayout"
+                                  <EuiFormControlLayout
+                                    compressed={false}
+                                    fullWidth={false}
+                                    icon="search"
+                                    isLoading={false}
                                   >
                                     <div
-                                      className="euiFormControlLayout__childrenWrapper"
+                                      className="euiFormControlLayout"
                                     >
-                                      <EuiValidatableControl
-                                        isInvalid={false}
+                                      <div
+                                        className="euiFormControlLayout__childrenWrapper"
                                       >
-                                        <input
-                                          className="euiFieldSearch"
-                                          onChange={[Function]}
-                                          onKeyUp={[Function]}
-                                          placeholder="Service name"
-                                          type="search"
-                                          value=""
-                                        />
-                                      </EuiValidatableControl>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={false}
-                                        icon="search"
-                                        isLoading={false}
-                                      >
-                                        <div
-                                          className="euiFormControlLayoutIcons"
+                                        <EuiValidatableControl
+                                          isInvalid={false}
                                         >
-                                          <EuiFormControlLayoutCustomIcon
-                                            size="m"
+                                          <input
+                                            className="euiFieldSearch"
+                                            onChange={[Function]}
+                                            onKeyUp={[Function]}
+                                            placeholder="Service name"
                                             type="search"
+                                            value=""
+                                          />
+                                        </EuiValidatableControl>
+                                        <EuiFormControlLayoutIcons
+                                          compressed={false}
+                                          icon="search"
+                                          isLoading={false}
+                                        >
+                                          <div
+                                            className="euiFormControlLayoutIcons"
                                           >
-                                            <span
-                                              className="euiFormControlLayoutCustomIcon"
+                                            <EuiFormControlLayoutCustomIcon
+                                              size="m"
+                                              type="search"
                                             >
-                                              <EuiIcon
-                                                aria-hidden="true"
-                                                className="euiFormControlLayoutCustomIcon__icon"
-                                                size="m"
-                                                type="search"
+                                              <span
+                                                className="euiFormControlLayoutCustomIcon"
                                               >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  aria-hidden="true"
+                                                  className="euiFormControlLayoutCustomIcon__icon"
+                                                  size="m"
+                                                  type="search"
                                                 >
-                                                  <svg
+                                                  <EuiIconBeaker
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </span>
-                                          </EuiFormControlLayoutCustomIcon>
-                                        </div>
-                                      </EuiFormControlLayoutIcons>
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                              </span>
+                                            </EuiFormControlLayoutCustomIcon>
+                                          </div>
+                                        </EuiFormControlLayoutIcons>
+                                      </div>
                                     </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </EuiFieldSearch>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                      <EuiSpacer>
+                                  </EuiFormControlLayout>
+                                </EuiFieldSearch>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                        <EuiSpacer>
+                          <div
+                            className="euiSpacer euiSpacer--l"
+                          />
+                        </EuiSpacer>
                         <div
-                          className="euiSpacer euiSpacer--l"
-                        />
-                      </EuiSpacer>
-                      <div
-                        style={
-                          Object {
-                            "minHeight": 434,
+                          style={
+                            Object {
+                              "minHeight": 434,
+                            }
                           }
-                        }
-                      >
-                        <NoMatchMessage
-                          size="s"
                         >
-                          <EuiSpacer
+                          <NoMatchMessage
                             size="s"
                           >
-                            <div
-                              className="euiSpacer euiSpacer--s"
-                            />
-                          </EuiSpacer>
-                          <EuiEmptyPrompt
-                            body={
-                              <EuiText>
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                              </EuiText>
-                            }
-                            title={
-                              <h2>
-                                No matches
-                              </h2>
-                            }
-                          >
-                            <div
-                              className="euiEmptyPrompt"
+                            <EuiSpacer
+                              size="s"
                             >
-                              <EuiTitle
-                                size="m"
-                              >
-                                <h2
-                                  className="euiTitle euiTitle--medium"
-                                >
+                              <div
+                                className="euiSpacer euiSpacer--s"
+                              />
+                            </EuiSpacer>
+                            <EuiEmptyPrompt
+                              body={
+                                <EuiText>
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </EuiText>
+                              }
+                              title={
+                                <h2>
                                   No matches
                                 </h2>
-                              </EuiTitle>
-                              <EuiTextColor
-                                color="subdued"
+                              }
+                            >
+                              <div
+                                className="euiEmptyPrompt"
                               >
-                                <span
-                                  className="euiTextColor euiTextColor--subdued"
+                                <EuiTitle
+                                  size="m"
                                 >
-                                  <EuiSpacer
-                                    size="m"
+                                  <h2
+                                    className="euiTitle euiTitle--medium"
                                   >
-                                    <div
-                                      className="euiSpacer euiSpacer--m"
-                                    />
-                                  </EuiSpacer>
-                                  <EuiText>
-                                    <div
-                                      className="euiText euiText--medium"
+                                    No matches
+                                  </h2>
+                                </EuiTitle>
+                                <EuiTextColor
+                                  color="subdued"
+                                >
+                                  <span
+                                    className="euiTextColor euiTextColor--subdued"
+                                  >
+                                    <EuiSpacer
+                                      size="m"
                                     >
-                                      <EuiText>
-                                        <div
-                                          className="euiText euiText--medium"
-                                        >
-                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                        </div>
-                                      </EuiText>
-                                    </div>
-                                  </EuiText>
-                                </span>
-                              </EuiTextColor>
-                            </div>
-                          </EuiEmptyPrompt>
-                          <EuiSpacer
-                            size="s"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--s"
-                            />
-                          </EuiSpacer>
-                        </NoMatchMessage>
+                                      <div
+                                        className="euiSpacer euiSpacer--m"
+                                      />
+                                    </EuiSpacer>
+                                    <EuiText>
+                                      <div
+                                        className="euiText euiText--medium"
+                                      >
+                                        <EuiText>
+                                          <div
+                                            className="euiText euiText--medium"
+                                          >
+                                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                          </div>
+                                        </EuiText>
+                                      </div>
+                                    </EuiText>
+                                  </span>
+                                </EuiTextColor>
+                              </div>
+                            </EuiEmptyPrompt>
+                            <EuiSpacer
+                              size="s"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--s"
+                              />
+                            </EuiSpacer>
+                          </NoMatchMessage>
+                        </div>
                       </div>
-                    </div>
-                  </EuiPanel>
-                  <EuiSpacer
-                    size="xl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
+                    </EuiPanel>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </div>
                 </ServiceMap>
               </div>
             </div>
@@ -1890,531 +1901,542 @@ exports[`Service Config component renders with one service selected 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <EuiPanel>
-                    <div
-                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-                    >
-                      <PanelTitle
-                        title="Service map"
+                  <div
+                    style={
+                      Object {
+                        "padding": "0 16px",
+                      }
+                    }
+                  >
+                    <EuiPanel>
+                      <div
+                        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
-                        <EuiText
+                        <PanelTitle
+                          title="Service map"
+                        >
+                          <EuiText
+                            size="m"
+                          >
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <span
+                                className="panel-title"
+                              >
+                                Service map
+                              </span>
+                            </div>
+                          </EuiText>
+                        </PanelTitle>
+                        <EuiSpacer
                           size="m"
                         >
                           <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiButtonGroup
-                        buttonSize="s"
-                        color="text"
-                        idSelected="latency"
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "id": "latency",
-                              "label": "Duration",
-                            },
-                            Object {
-                              "id": "error_rate",
-                              "label": "Errors",
-                            },
-                            Object {
-                              "id": "throughput",
-                              "label": "Request Rate",
-                            },
-                          ]
-                        }
-                      >
-                        <fieldset
-                          className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          disabled={false}
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiButtonGroup
+                          buttonSize="s"
+                          color="text"
+                          idSelected="latency"
+                          legend="Select metric to display"
+                          onChange={[Function]}
+                          options={
+                            Array [
+                              Object {
+                                "id": "latency",
+                                "label": "Duration",
+                              },
+                              Object {
+                                "id": "error_rate",
+                                "label": "Errors",
+                              },
+                              Object {
+                                "id": "throughput",
+                                "label": "Request Rate",
+                              },
+                            ]
+                          }
                         >
-                          <EuiScreenReaderOnly>
-                            <legend
-                              className="euiScreenReaderOnly"
-                            />
-                          </EuiScreenReaderOnly>
-                          <div
-                            className="euiButtonGroup__buttons"
+                          <fieldset
+                            className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            disabled={false}
                           >
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="latency"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={true}
-                              key="0"
-                              label="Duration"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className="euiButtonGroupButton-isSelected"
-                                color="text"
-                                element="label"
-                                fill={true}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Duration",
-                                    "ref": [Function],
-                                    "title": "Duration",
-                                  }
-                                }
+                            <EuiScreenReaderOnly>
+                              <legend
+                                className="euiScreenReaderOnly"
                               >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
-                                        "data-text": "Duration",
-                                        "ref": [Function],
-                                        "title": "Duration",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Duration"
-                                        title="Duration"
-                                      >
-                                        <input
-                                          checked={true}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="latency"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Duration
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="error_rate"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="1"
-                              label="Errors"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Errors",
-                                    "ref": [Function],
-                                    "title": "Errors",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
-                                        "data-text": "Errors",
-                                        "ref": [Function],
-                                        "title": "Errors",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Errors"
-                                        title="Errors"
-                                      >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="error_rate"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Errors
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="throughput"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="2"
-                              label="Request Rate"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Request Rate",
-                                    "ref": [Function],
-                                    "title": "Request Rate",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
-                                >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
-                                        "data-text": "Request Rate",
-                                        "ref": [Function],
-                                        "title": "Request Rate",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
-                                    >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Request Rate"
-                                        title="Request Rate"
-                                      >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="throughput"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Request Rate
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                          </div>
-                        </fieldset>
-                      </EuiButtonGroup>
-                      <EuiHorizontalRule
-                        margin="m"
-                      >
-                        <hr
-                          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                      </EuiHorizontalRule>
-                      <EuiFlexGroup
-                        alignItems="center"
-                        gutterSize="s"
-                      >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
+                                Select metric to display
+                              </legend>
+                            </EuiScreenReaderOnly>
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiButtonGroup__buttons"
                             >
-                              <EuiText>
-                                <div
-                                  className="euiText euiText--medium"
-                                >
-                                  Focus on
-                                </div>
-                              </EuiText>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiFieldSearch
-                                compressed={false}
-                                fullWidth={false}
-                                incremental={false}
-                                isClearable={true}
-                                isInvalid={false}
-                                isLoading={false}
+                              <EuiButtonGroupButton
+                                color="text"
+                                element="label"
+                                id="latency"
+                                isDisabled={false}
+                                isIconOnly={false}
+                                isSelected={true}
+                                key="0"
+                                label="Duration"
+                                name="random_html_id"
                                 onChange={[Function]}
-                                onSearch={[Function]}
-                                placeholder="Service name"
-                                value=""
+                                size="s"
                               >
-                                <EuiFormControlLayout
+                                <EuiButtonDisplay
+                                  baseClassName="euiButtonGroupButton"
+                                  className="euiButtonGroupButton-isSelected"
+                                  color="text"
+                                  element="label"
+                                  fill={true}
+                                  htmlFor="random_html_id"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonGroupButton__textShift",
+                                      "data-text": "Duration",
+                                      "ref": [Function],
+                                      "title": "Duration",
+                                    }
+                                  }
+                                >
+                                  <label
+                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                    disabled={false}
+                                    htmlFor="random_html_id"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text euiButtonGroupButton__textShift",
+                                          "data-text": "Duration",
+                                          "ref": [Function],
+                                          "title": "Duration",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text euiButtonGroupButton__textShift"
+                                          data-text="Duration"
+                                          title="Duration"
+                                        >
+                                          <input
+                                            checked={true}
+                                            className="euiScreenReaderOnly"
+                                            data-test-subj="latency"
+                                            disabled={false}
+                                            id="random_html_id"
+                                            name="random_html_id"
+                                            onChange={[Function]}
+                                            type="radio"
+                                          />
+                                          Duration
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </label>
+                                </EuiButtonDisplay>
+                              </EuiButtonGroupButton>
+                              <EuiButtonGroupButton
+                                color="text"
+                                element="label"
+                                id="error_rate"
+                                isDisabled={false}
+                                isIconOnly={false}
+                                isSelected={false}
+                                key="1"
+                                label="Errors"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                size="s"
+                              >
+                                <EuiButtonDisplay
+                                  baseClassName="euiButtonGroupButton"
+                                  className=""
+                                  color="text"
+                                  element="label"
+                                  fill={false}
+                                  htmlFor="random_html_id"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonGroupButton__textShift",
+                                      "data-text": "Errors",
+                                      "ref": [Function],
+                                      "title": "Errors",
+                                    }
+                                  }
+                                >
+                                  <label
+                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                    disabled={false}
+                                    htmlFor="random_html_id"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text euiButtonGroupButton__textShift",
+                                          "data-text": "Errors",
+                                          "ref": [Function],
+                                          "title": "Errors",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text euiButtonGroupButton__textShift"
+                                          data-text="Errors"
+                                          title="Errors"
+                                        >
+                                          <input
+                                            checked={false}
+                                            className="euiScreenReaderOnly"
+                                            data-test-subj="error_rate"
+                                            disabled={false}
+                                            id="random_html_id"
+                                            name="random_html_id"
+                                            onChange={[Function]}
+                                            type="radio"
+                                          />
+                                          Errors
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </label>
+                                </EuiButtonDisplay>
+                              </EuiButtonGroupButton>
+                              <EuiButtonGroupButton
+                                color="text"
+                                element="label"
+                                id="throughput"
+                                isDisabled={false}
+                                isIconOnly={false}
+                                isSelected={false}
+                                key="2"
+                                label="Request Rate"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                size="s"
+                              >
+                                <EuiButtonDisplay
+                                  baseClassName="euiButtonGroupButton"
+                                  className=""
+                                  color="text"
+                                  element="label"
+                                  fill={false}
+                                  htmlFor="random_html_id"
+                                  isDisabled={false}
+                                  onClick={[Function]}
+                                  size="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonGroupButton__textShift",
+                                      "data-text": "Request Rate",
+                                      "ref": [Function],
+                                      "title": "Request Rate",
+                                    }
+                                  }
+                                >
+                                  <label
+                                    className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                    disabled={false}
+                                    htmlFor="random_html_id"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "minWidth": undefined,
+                                      }
+                                    }
+                                  >
+                                    <EuiButtonContent
+                                      className="euiButton__content"
+                                      iconSide="left"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButton__text euiButtonGroupButton__textShift",
+                                          "data-text": "Request Rate",
+                                          "ref": [Function],
+                                          "title": "Request Rate",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiButtonContent euiButton__content"
+                                      >
+                                        <span
+                                          className="euiButton__text euiButtonGroupButton__textShift"
+                                          data-text="Request Rate"
+                                          title="Request Rate"
+                                        >
+                                          <input
+                                            checked={false}
+                                            className="euiScreenReaderOnly"
+                                            data-test-subj="throughput"
+                                            disabled={false}
+                                            id="random_html_id"
+                                            name="random_html_id"
+                                            onChange={[Function]}
+                                            type="radio"
+                                          />
+                                          Request Rate
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </label>
+                                </EuiButtonDisplay>
+                              </EuiButtonGroupButton>
+                            </div>
+                          </fieldset>
+                        </EuiButtonGroup>
+                        <EuiHorizontalRule
+                          margin="m"
+                        >
+                          <hr
+                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                        </EuiHorizontalRule>
+                        <EuiFlexGroup
+                          alignItems="center"
+                          gutterSize="s"
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <EuiFlexItem
+                              grow={false}
+                            >
+                              <div
+                                className="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <EuiText>
+                                  <div
+                                    className="euiText euiText--medium"
+                                  >
+                                    Focus on
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFieldSearch
                                   compressed={false}
                                   fullWidth={false}
-                                  icon="search"
+                                  incremental={false}
+                                  isClearable={true}
+                                  isInvalid={false}
                                   isLoading={false}
+                                  onChange={[Function]}
+                                  onSearch={[Function]}
+                                  placeholder="Service name"
+                                  value=""
                                 >
-                                  <div
-                                    className="euiFormControlLayout"
+                                  <EuiFormControlLayout
+                                    compressed={false}
+                                    fullWidth={false}
+                                    icon="search"
+                                    isLoading={false}
                                   >
                                     <div
-                                      className="euiFormControlLayout__childrenWrapper"
+                                      className="euiFormControlLayout"
                                     >
-                                      <EuiValidatableControl
-                                        isInvalid={false}
+                                      <div
+                                        className="euiFormControlLayout__childrenWrapper"
                                       >
-                                        <input
-                                          className="euiFieldSearch"
-                                          onChange={[Function]}
-                                          onKeyUp={[Function]}
-                                          placeholder="Service name"
-                                          type="search"
-                                          value=""
-                                        />
-                                      </EuiValidatableControl>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={false}
-                                        icon="search"
-                                        isLoading={false}
-                                      >
-                                        <div
-                                          className="euiFormControlLayoutIcons"
+                                        <EuiValidatableControl
+                                          isInvalid={false}
                                         >
-                                          <EuiFormControlLayoutCustomIcon
-                                            size="m"
+                                          <input
+                                            className="euiFieldSearch"
+                                            onChange={[Function]}
+                                            onKeyUp={[Function]}
+                                            placeholder="Service name"
                                             type="search"
+                                            value=""
+                                          />
+                                        </EuiValidatableControl>
+                                        <EuiFormControlLayoutIcons
+                                          compressed={false}
+                                          icon="search"
+                                          isLoading={false}
+                                        >
+                                          <div
+                                            className="euiFormControlLayoutIcons"
                                           >
-                                            <span
-                                              className="euiFormControlLayoutCustomIcon"
+                                            <EuiFormControlLayoutCustomIcon
+                                              size="m"
+                                              type="search"
                                             >
-                                              <EuiIcon
-                                                aria-hidden="true"
-                                                className="euiFormControlLayoutCustomIcon__icon"
-                                                size="m"
-                                                type="search"
+                                              <span
+                                                className="euiFormControlLayoutCustomIcon"
                                               >
-                                                <EuiIconSearch
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  aria-hidden="true"
+                                                  className="euiFormControlLayoutCustomIcon__icon"
+                                                  size="m"
+                                                  type="search"
                                                 >
-                                                  <svg
+                                                  <EuiIconSearch
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconSearch>
-                                              </EuiIcon>
-                                            </span>
-                                          </EuiFormControlLayoutCustomIcon>
-                                        </div>
-                                      </EuiFormControlLayoutIcons>
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconSearch>
+                                                </EuiIcon>
+                                              </span>
+                                            </EuiFormControlLayoutCustomIcon>
+                                          </div>
+                                        </EuiFormControlLayoutIcons>
+                                      </div>
                                     </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </EuiFieldSearch>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                      <EuiSpacer>
+                                  </EuiFormControlLayout>
+                                </EuiFieldSearch>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                        <EuiSpacer>
+                          <div
+                            className="euiSpacer euiSpacer--l"
+                          />
+                        </EuiSpacer>
                         <div
-                          className="euiSpacer euiSpacer--l"
-                        />
-                      </EuiSpacer>
-                      <div
-                        style={
-                          Object {
-                            "minHeight": 434,
+                          style={
+                            Object {
+                              "minHeight": 434,
+                            }
                           }
-                        }
-                      >
-                        <NoMatchMessage
-                          size="s"
                         >
-                          <EuiSpacer
+                          <NoMatchMessage
                             size="s"
                           >
-                            <div
-                              className="euiSpacer euiSpacer--s"
-                            />
-                          </EuiSpacer>
-                          <EuiEmptyPrompt
-                            body={
-                              <EuiText>
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                              </EuiText>
-                            }
-                            title={
-                              <h2>
-                                No matches
-                              </h2>
-                            }
-                          >
-                            <div
-                              className="euiEmptyPrompt"
+                            <EuiSpacer
+                              size="s"
                             >
-                              <EuiTitle
-                                size="m"
-                              >
-                                <h2
-                                  className="euiTitle euiTitle--medium"
-                                >
+                              <div
+                                className="euiSpacer euiSpacer--s"
+                              />
+                            </EuiSpacer>
+                            <EuiEmptyPrompt
+                              body={
+                                <EuiText>
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </EuiText>
+                              }
+                              title={
+                                <h2>
                                   No matches
                                 </h2>
-                              </EuiTitle>
-                              <EuiTextColor
-                                color="subdued"
+                              }
+                            >
+                              <div
+                                className="euiEmptyPrompt"
                               >
-                                <span
-                                  className="euiTextColor euiTextColor--subdued"
+                                <EuiTitle
+                                  size="m"
                                 >
-                                  <EuiSpacer
-                                    size="m"
+                                  <h2
+                                    className="euiTitle euiTitle--medium"
                                   >
-                                    <div
-                                      className="euiSpacer euiSpacer--m"
-                                    />
-                                  </EuiSpacer>
-                                  <EuiText>
-                                    <div
-                                      className="euiText euiText--medium"
+                                    No matches
+                                  </h2>
+                                </EuiTitle>
+                                <EuiTextColor
+                                  color="subdued"
+                                >
+                                  <span
+                                    className="euiTextColor euiTextColor--subdued"
+                                  >
+                                    <EuiSpacer
+                                      size="m"
                                     >
-                                      <EuiText>
-                                        <div
-                                          className="euiText euiText--medium"
-                                        >
-                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                        </div>
-                                      </EuiText>
-                                    </div>
-                                  </EuiText>
-                                </span>
-                              </EuiTextColor>
-                            </div>
-                          </EuiEmptyPrompt>
-                          <EuiSpacer
-                            size="s"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--s"
-                            />
-                          </EuiSpacer>
-                        </NoMatchMessage>
+                                      <div
+                                        className="euiSpacer euiSpacer--m"
+                                      />
+                                    </EuiSpacer>
+                                    <EuiText>
+                                      <div
+                                        className="euiText euiText--medium"
+                                      >
+                                        <EuiText>
+                                          <div
+                                            className="euiText euiText--medium"
+                                          >
+                                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                          </div>
+                                        </EuiText>
+                                      </div>
+                                    </EuiText>
+                                  </span>
+                                </EuiTextColor>
+                              </div>
+                            </EuiEmptyPrompt>
+                            <EuiSpacer
+                              size="s"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--s"
+                              />
+                            </EuiSpacer>
+                          </NoMatchMessage>
+                        </div>
                       </div>
-                    </div>
-                  </EuiPanel>
-                  <EuiSpacer
-                    size="xl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
+                    </EuiPanel>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </div>
                 </ServiceMap>
               </div>
             </div>

--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -1165,6 +1165,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                       config={
                                         Object {
                                           "cache": 60000,
+                                          "compressed": undefined,
                                           "field": "accelerations",
                                           "multiSelect": true,
                                           "name": "Accelerations",

--- a/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
+++ b/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
@@ -393,6 +393,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                       <FieldValueSelectionFilter
                         config={
                           Object {
+                            "compressed": undefined,
                             "field": "type",
                             "multiSelect": "or",
                             "name": "Type",

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -700,6 +700,7 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                                   <FieldValueSelectionFilter
                                     config={
                                       Object {
+                                        "compressed": undefined,
                                         "field": "assetType",
                                         "multiSelect": false,
                                         "name": "Type",

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
@@ -384,6 +384,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                             <FieldValueSelectionFilter
                               config={
                                 Object {
+                                  "compressed": undefined,
                                   "field": "templateName",
                                   "multiSelect": false,
                                   "name": "Type",

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -399,17 +399,18 @@ exports[`Search bar components renders search bar 1`] = `
   startTime="now-5m"
 >
   <EuiFlexGroup
+    alignItems="center"
     gutterSize="s"
   >
     <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <EuiFlexItem>
         <div
           className="euiFlexItem"
         >
           <EuiFieldSearch
-            compressed={false}
+            compressed={true}
             data-test-subj="search-bar-input-box"
             fullWidth={true}
             incremental={false}
@@ -418,23 +419,117 @@ exports[`Search bar components renders search bar 1`] = `
             onChange={[Function]}
             onSearch={[MockFunction]}
             placeholder="Trace ID, trace group name, service name"
+            prepend={
+              <GlobalFilterButton
+                filters={Array []}
+                setFilters={[MockFunction]}
+              />
+            }
             value="test"
           >
             <EuiFormControlLayout
-              compressed={false}
+              compressed={true}
               fullWidth={true}
               icon="search"
               isLoading={false}
+              prepend={
+                <GlobalFilterButton
+                  filters={Array []}
+                  setFilters={[MockFunction]}
+                />
+              }
             >
               <div
-                className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
               >
+                <GlobalFilterButton
+                  className="euiFormControlLayout__prepend"
+                  filters={Array []}
+                  key="0/.0"
+                  setFilters={[MockFunction]}
+                >
+                  <EuiPopover
+                    anchorPosition="rightUp"
+                    button={
+                      <EuiButtonIcon
+                        aria-label="Change all filters"
+                        iconType="filter"
+                        onClick={[Function]}
+                        title="Change all filters"
+                      />
+                    }
+                    closePopover={[Function]}
+                    data-test-subj="global-filter-button"
+                    display="inlineBlock"
+                    hasArrow={true}
+                    isOpen={false}
+                    ownFocus={true}
+                    panelPaddingSize="none"
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorRightUp"
+                      data-test-subj="global-filter-button"
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiButtonIcon
+                          aria-label="Change all filters"
+                          iconType="filter"
+                          onClick={[Function]}
+                          title="Change all filters"
+                        >
+                          <button
+                            aria-label="Change all filters"
+                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                            disabled={false}
+                            onClick={[Function]}
+                            title="Change all filters"
+                            type="button"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiButtonIcon__icon"
+                              color="inherit"
+                              size="m"
+                              type="filter"
+                            >
+                              <EuiIconBeaker
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
+                            </EuiIcon>
+                          </button>
+                        </EuiButtonIcon>
+                      </div>
+                    </div>
+                  </EuiPopover>
+                </GlobalFilterButton>
                 <div
                   className="euiFormControlLayout__childrenWrapper"
                 >
                   <EuiValidatableControl>
                     <input
-                      className="euiFieldSearch euiFieldSearch--fullWidth"
+                      className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
                       data-test-subj="search-bar-input-box"
                       onChange={[Function]}
                       onKeyUp={[Function]}
@@ -444,7 +539,7 @@ exports[`Search bar components renders search bar 1`] = `
                     />
                   </EuiValidatableControl>
                   <EuiFormControlLayoutIcons
-                    compressed={false}
+                    compressed={true}
                     icon="search"
                     isLoading={false}
                   >
@@ -452,7 +547,7 @@ exports[`Search bar components renders search bar 1`] = `
                       className="euiFormControlLayoutIcons"
                     >
                       <EuiFormControlLayoutCustomIcon
-                        size="m"
+                        size="s"
                         type="search"
                       >
                         <span
@@ -461,19 +556,19 @@ exports[`Search bar components renders search bar 1`] = `
                           <EuiIcon
                             aria-hidden="true"
                             className="euiFormControlLayoutCustomIcon__icon"
-                            size="m"
+                            size="s"
                             type="search"
                           >
                             <EuiIconBeaker
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                              className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -502,7 +597,7 @@ exports[`Search bar components renders search bar 1`] = `
         grow={false}
         style={
           Object {
-            "maxWidth": "40vw",
+            "maxWidth": "30vw",
           }
         }
       >
@@ -510,7 +605,7 @@ exports[`Search bar components renders search bar 1`] = `
           className="euiFlexItem euiFlexItem--flexGrowZero"
           style={
             Object {
-              "maxWidth": "40vw",
+              "maxWidth": "30vw",
             }
           }
         >
@@ -559,8 +654,8 @@ exports[`Search bar components renders search bar 1`] = `
                 },
               ]
             }
-            compressed={false}
-            dateFormat=""
+            compressed={true}
+            dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
             end="now"
             isAutoRefreshOnly={false}
             isDisabled={false}
@@ -586,7 +681,7 @@ exports[`Search bar components renders search bar 1`] = `
                   >
                     <EuiFormControlLayout
                       className="euiSuperDatePicker"
-                      compressed={false}
+                      compressed={true}
                       isDisabled={false}
                       prepend={
                         <EuiQuickSelectPopover
@@ -635,7 +730,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat=""
+                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -647,7 +742,7 @@ exports[`Search bar components renders search bar 1`] = `
                       }
                     >
                       <div
-                        className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                        className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
                       >
                         <EuiQuickSelectPopover
                           applyTime={[Function]}
@@ -696,7 +791,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat=""
+                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -865,7 +960,7 @@ exports[`Search bar components renders search bar 1`] = `
                               className="euiDatePickerRange euiDatePickerRange--inGroup"
                             >
                               <button
-                                className="euiSuperDatePicker__prettyFormat"
+                                className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
                                 data-test-subj="superDatePickerShowDatesButton"
                                 disabled={false}
                                 onClick={[Function]}
@@ -885,7 +980,7 @@ exports[`Search bar components renders search bar 1`] = `
                             </div>
                           </EuiDatePickerRange>
                           <EuiFormControlLayoutIcons
-                            compressed={false}
+                            compressed={true}
                           />
                         </div>
                       </div>
@@ -903,287 +998,60 @@ exports[`Search bar components renders search bar 1`] = `
         <div
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <EuiButton
+          <EuiButtonIcon
+            aria-label="Refresh"
             data-click-metric-element="trace_analytics.refresh_button"
             data-test-subj="superDatePickerApplyTimeButton"
+            display="base"
             iconType="refresh"
             onClick={[Function]}
+            size="s"
           >
-            <EuiButtonDisplay
-              baseClassName="euiButton"
+            <button
+              aria-label="Refresh"
+              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
               data-click-metric-element="trace_analytics.refresh_button"
               data-test-subj="superDatePickerApplyTimeButton"
               disabled={false}
-              element="button"
-              iconType="refresh"
-              isDisabled={false}
               onClick={[Function]}
               type="button"
             >
-              <button
-                className="euiButton euiButton--primary"
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                disabled={false}
-                onClick={[Function]}
-                style={
-                  Object {
-                    "minWidth": undefined,
-                  }
-                }
-                type="button"
+              <EuiIcon
+                aria-hidden="true"
+                className="euiButtonIcon__icon"
+                color="inherit"
+                size="m"
+                type="refresh"
               >
-                <EuiButtonContent
-                  className="euiButton__content"
-                  iconSide="left"
-                  iconType="refresh"
-                  textProps={
-                    Object {
-                      "className": "euiButton__text",
-                    }
-                  }
+                <EuiIconBeaker
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  role="img"
+                  style={null}
                 >
-                  <span
-                    className="euiButtonContent euiButton__content"
+                  <svg
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                    focusable="false"
+                    height={16}
+                    role="img"
+                    style={null}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="refresh"
-                    >
-                      <EuiIconBeaker
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                          />
-                        </svg>
-                      </EuiIconBeaker>
-                    </EuiIcon>
-                    <span
-                      className="euiButton__text"
-                    >
-                      Refresh
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonDisplay>
-          </EuiButton>
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                </EuiIconBeaker>
+              </EuiIcon>
+            </button>
+          </EuiButtonIcon>
         </div>
       </EuiFlexItem>
     </div>
   </EuiFlexGroup>
-  <EuiSpacer
-    size="s"
-  >
-    <div
-      className="euiSpacer euiSpacer--s"
-    />
-  </EuiSpacer>
-  <Filters
-    appConfigs={Array []}
-    attributesFilterFields={Array []}
-    filters={Array []}
-    mode="data_prepper"
-    page="dashboard"
-    setFilters={[MockFunction]}
-  >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="xs"
-      responsive={false}
-      style={
-        Object {
-          "minHeight": 32,
-        }
-      }
-    >
-      <div
-        className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        style={
-          Object {
-            "minHeight": 32,
-          }
-        }
-      >
-        <EuiFlexItem
-          grow={false}
-        >
-          <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <GlobalFilterButton>
-              <EuiPopover
-                anchorPosition="rightUp"
-                button={
-                  <EuiButtonIcon
-                    aria-label="Change all filters"
-                    iconType="filter"
-                    onClick={[Function]}
-                    title="Change all filters"
-                  />
-                }
-                closePopover={[Function]}
-                data-test-subj="global-filter-button"
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="none"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover euiPopover--anchorRightUp"
-                  data-test-subj="global-filter-button"
-                  withTitle={true}
-                >
-                  <div
-                    className="euiPopover__anchor"
-                  >
-                    <EuiButtonIcon
-                      aria-label="Change all filters"
-                      iconType="filter"
-                      onClick={[Function]}
-                      title="Change all filters"
-                    >
-                      <button
-                        aria-label="Change all filters"
-                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                        disabled={false}
-                        onClick={[Function]}
-                        title="Change all filters"
-                        type="button"
-                      >
-                        <EuiIcon
-                          aria-hidden="true"
-                          className="euiButtonIcon__icon"
-                          color="inherit"
-                          size="m"
-                          type="filter"
-                        >
-                          <EuiIconBeaker
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                      </button>
-                    </EuiButtonIcon>
-                  </div>
-                </div>
-              </EuiPopover>
-            </GlobalFilterButton>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={false}
-        >
-          <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <AddFilterButton>
-              <EuiPopover
-                anchorPosition="downLeft"
-                button={
-                  <EuiButtonEmpty
-                    onClick={[Function]}
-                    size="xs"
-                  >
-                    + Add filter
-                  </EuiButtonEmpty>
-                }
-                closePopover={[Function]}
-                data-test-subj="addfilter"
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="m"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover euiPopover--anchorDownLeft"
-                  data-test-subj="addfilter"
-                  withTitle={true}
-                >
-                  <div
-                    className="euiPopover__anchor"
-                  >
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      <button
-                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <EuiButtonContent
-                          className="euiButtonEmpty__content"
-                          iconSide="left"
-                          iconSize="s"
-                          textProps={
-                            Object {
-                              "className": "euiButtonEmpty__text",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButtonEmpty__content"
-                          >
-                            <span
-                              className="euiButtonEmpty__text"
-                            >
-                              + Add filter
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </button>
-                    </EuiButtonEmpty>
-                  </div>
-                </div>
-              </EuiPopover>
-            </AddFilterButton>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-  </Filters>
 </ForwardRef>
 `;

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Filter component renders filters 1`] = `
     style={
       Object {
         "minHeight": 32,
+        "padding": "0 16px",
       }
     }
   >
@@ -22,96 +23,10 @@ exports[`Filter component renders filters 1`] = `
       style={
         Object {
           "minHeight": 32,
+          "padding": "0 16px",
         }
       }
     >
-      <EuiFlexItem
-        grow={false}
-      >
-        <div
-          className="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <GlobalFilterButton>
-            <EuiPopover
-              anchorPosition="rightUp"
-              button={
-                <EuiButtonIcon
-                  aria-label="Change all filters"
-                  iconType="filter"
-                  onClick={[Function]}
-                  title="Change all filters"
-                />
-              }
-              closePopover={[Function]}
-              data-test-subj="global-filter-button"
-              display="inlineBlock"
-              hasArrow={true}
-              isOpen={false}
-              ownFocus={true}
-              panelPaddingSize="none"
-              withTitle={true}
-            >
-              <div
-                className="euiPopover euiPopover--anchorRightUp"
-                data-test-subj="global-filter-button"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover__anchor"
-                >
-                  <EuiButtonIcon
-                    aria-label="Change all filters"
-                    iconType="filter"
-                    onClick={[Function]}
-                    title="Change all filters"
-                  >
-                    <button
-                      aria-label="Change all filters"
-                      className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                      disabled={false}
-                      onClick={[Function]}
-                      title="Change all filters"
-                      type="button"
-                    >
-                      <EuiIcon
-                        aria-hidden="true"
-                        className="euiButtonIcon__icon"
-                        color="inherit"
-                        size="m"
-                        type="filter"
-                      >
-                        <EuiIconBeaker
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                            />
-                          </svg>
-                        </EuiIconBeaker>
-                      </EuiIcon>
-                    </button>
-                  </EuiButtonIcon>
-                </div>
-              </div>
-            </EuiPopover>
-          </GlobalFilterButton>
-        </div>
-      </EuiFlexItem>
       <EuiFlexItem
         grow={false}
       >
@@ -136,12 +51,10 @@ exports[`Filter component renders filters 1`] = `
               isOpen={false}
               ownFocus={true}
               panelPaddingSize="m"
-              withTitle={true}
             >
               <div
                 className="euiPopover euiPopover--anchorDownLeft"
                 data-test-subj="addfilter"
-                withTitle={true}
               >
                 <div
                   className="euiPopover__anchor"

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -44,8 +44,6 @@ interface FiltersOwnProps extends FiltersProps {
 }
 
 export function Filters(props: FiltersOwnProps) {
-  // set a filter at an index. if newFilter doesn't exist, remove filter at the index
-  // if index doesn't exist, append newFilter to the end
   const setFilter = (newFilter: FilterType, index: number) => {
     const newFilters = [...props.filters];
     if (newFilter) newFilters.splice(index, 1, newFilter);
@@ -64,75 +62,6 @@ export function Filters(props: FiltersOwnProps) {
       })),
     [props.page, props.mode, props.attributesFilterFields]
   );
-
-  const globalPopoverPanels = [
-    {
-      id: 0,
-      title: 'Change all filters',
-      items: [
-        {
-          name: 'Enable all',
-          icon: <EuiIcon type="eye" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : false,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Disable all',
-          icon: <EuiIcon type="eyeClosed" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : true,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Invert inclusion',
-          icon: <EuiIcon type="invert" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              // if filter.custom.query exists, it's a customized filter and "inverted" is alwasy false
-              props.filters.map((filter) => ({
-                ...filter,
-                inverted: filter.locked
-                  ? filter.inverted
-                  : filter.custom?.query
-                  ? false
-                  : !filter.inverted,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Invert enabled/disabled',
-          icon: <EuiIcon type="eye" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : !filter.disabled,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Remove all',
-          icon: <EuiIcon type="trash" size="m" />,
-          onClick: () => {
-            props.setFilters([]);
-          },
-        },
-      ],
-    },
-  ];
 
   const getFilterPopoverPanels = (
     filter: FilterType,
@@ -191,30 +120,6 @@ export function Filters(props: FiltersOwnProps) {
     },
   ];
 
-  const GlobalFilterButton = () => {
-    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-    return (
-      <EuiPopover
-        isOpen={isPopoverOpen}
-        closePopover={() => setIsPopoverOpen(false)}
-        button={
-          <EuiButtonIcon
-            onClick={() => setIsPopoverOpen(true)}
-            iconType="filter"
-            title="Change all filters"
-            aria-label="Change all filters"
-          />
-        }
-        anchorPosition="rightUp"
-        panelPaddingSize="none"
-        withTitle
-        data-test-subj="global-filter-button"
-      >
-        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} />
-      </EuiPopover>
-    );
-  };
-
   const AddFilterButton = () => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const button = (
@@ -235,7 +140,6 @@ export function Filters(props: FiltersOwnProps) {
         closePopover={() => setIsPopoverOpen(false)}
         anchorPosition="downLeft"
         data-test-subj="addfilter"
-        withTitle
       >
         <EuiPopoverTitle>{'Add filter'}</EuiPopoverTitle>
         <FilterEditPopover
@@ -318,10 +222,12 @@ export function Filters(props: FiltersOwnProps) {
   const filterComponents = useMemo(() => renderFilters(), [props.filters]);
 
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ minHeight: 32 }}>
-      <EuiFlexItem grow={false}>
-        <GlobalFilterButton />
-      </EuiFlexItem>
+    <EuiFlexGroup
+      gutterSize="xs"
+      alignItems="center"
+      responsive={false}
+      style={{ minHeight: 32, padding: '0 16px' }}
+    >
       {filterComponents}
       <EuiFlexItem grow={false}>
         <AddFilterButton />
@@ -329,3 +235,104 @@ export function Filters(props: FiltersOwnProps) {
     </EuiFlexGroup>
   );
 }
+
+export const GlobalFilterButton = ({ filters, setFilters }) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const togglePopover = () => {
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+
+  const globalPopoverPanels = [
+    {
+      id: 0,
+      title: 'Change all filters',
+      items: [
+        {
+          name: 'Enable all',
+          icon: <EuiIcon type="eye" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : false,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Disable all',
+          icon: <EuiIcon type="eyeClosed" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : true,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Invert inclusion',
+          icon: <EuiIcon type="invert" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                inverted: filter.locked
+                  ? filter.inverted
+                  : filter.custom?.query
+                  ? false
+                  : !filter.inverted,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Invert enabled/disabled',
+          icon: <EuiIcon type="eye" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : !filter.disabled,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Remove all',
+          icon: <EuiIcon type="trash" size="m" />,
+          onClick: () => {
+            setFilters([]);
+            togglePopover();
+          },
+        },
+      ],
+    },
+  ];
+
+  return (
+    <EuiPopover
+      isOpen={isPopoverOpen}
+      closePopover={() => setIsPopoverOpen(false)}
+      button={
+        <EuiButtonIcon
+          onClick={togglePopover}
+          iconType="filter"
+          title="Change all filters"
+          aria-label="Change all filters"
+        />
+      }
+      anchorPosition="rightUp"
+      panelPaddingSize="none"
+      data-test-subj="global-filter-button"
+    >
+      <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} size="s" />
+    </EuiPopover>
+  );
+};

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
@@ -2,371 +2,380 @@
 
 exports[`Service map component renders service map 1`] = `
 <Fragment>
-  <EuiPanel>
-    <PanelTitle
-      title="Service map"
-    />
-    <EuiSpacer
-      size="m"
-    />
-    <EuiButtonGroup
-      buttonSize="s"
-      color="text"
-      idSelected="latency"
-      onChange={[Function]}
-      options={
-        Array [
-          Object {
-            "id": "latency",
-            "label": "Duration",
-          },
-          Object {
-            "id": "error_rate",
-            "label": "Errors",
-          },
-          Object {
-            "id": "throughput",
-            "label": "Request Rate",
-          },
-        ]
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
       }
-    />
-    <EuiHorizontalRule
-      margin="m"
-    />
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-    >
-      <EuiFlexItem
-        grow={false}
-      >
-        <EuiText>
-          Focus on
-        </EuiText>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiFieldSearch
-          compressed={false}
-          fullWidth={false}
-          incremental={false}
-          isClearable={true}
-          isInvalid={false}
-          isLoading={false}
-          onChange={[Function]}
-          onSearch={[Function]}
-          placeholder="Service name"
-          value=""
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-    <EuiSpacer />
-    <EuiFlexGroup
-      gutterSize="none"
-      responsive={false}
-    >
-      <EuiFlexItem>
-        <div
-          style={
+    }
+  >
+    <EuiPanel>
+      <PanelTitle
+        title="Service map"
+      />
+      <EuiSpacer
+        size="m"
+      />
+      <EuiButtonGroup
+        buttonSize="s"
+        color="text"
+        idSelected="latency"
+        legend="Select metric to display"
+        onChange={[Function]}
+        options={
+          Array [
             Object {
-              "position": "relative",
-            }
-          }
-        />
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <ServiceMapScale
-          idSelected="latency"
-          serviceMap={
+              "id": "latency",
+              "label": "Duration",
+            },
             Object {
-              "analytics-service": Object {
-                "destServices": Array [
-                  "order",
-                  "inventory",
-                  "authentication",
-                  "payment",
-                  "recommendation",
-                ],
-                "error_rate": 0,
-                "id": 2,
-                "latency": 12.99,
-                "serviceName": "analytics-service",
-                "targetServices": Array [],
-                "throughput": 37,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_pay_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "authentication": Object {
-                "destServices": Array [
-                  "frontend-client",
-                ],
-                "error_rate": 8.33,
-                "id": 6,
-                "latency": 139.09,
-                "serviceName": "authentication",
-                "targetServices": Array [
-                  "analytics-service",
-                  "recommendation",
-                ],
-                "throughput": 12,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "server_request_login",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "database": Object {
-                "destServices": Array [
-                  "order",
-                  "inventory",
-                ],
-                "error_rate": 3.77,
-                "id": 3,
-                "latency": 49.54,
-                "serviceName": "database",
-                "targetServices": Array [],
-                "throughput": 53,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "cartEmpty",
-                    ],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "updateItem",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "addItemToCart",
-                    ],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "getCart",
-                    ],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "cartSold",
-                    ],
-                    "traceGroup": "client_pay_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "getIntentory",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "frontend-client": Object {
-                "destServices": Array [],
-                "error_rate": 7.41,
-                "id": 4,
-                "latency": 207.71,
-                "serviceName": "frontend-client",
-                "targetServices": Array [
-                  "order",
-                  "payment",
-                  "authentication",
-                ],
-                "throughput": 27,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_pay_order",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "inventory": Object {
-                "destServices": Array [
-                  "payment",
-                  "recommendation",
-                ],
-                "error_rate": 3.23,
-                "id": 5,
-                "latency": 183.52,
-                "serviceName": "inventory",
-                "targetServices": Array [
-                  "analytics-service",
-                  "database",
-                ],
-                "throughput": 31,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "update_inventory",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "read_inventory",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "order": Object {
-                "destServices": Array [
-                  "frontend-client",
-                ],
-                "error_rate": 4.17,
-                "id": 1,
-                "latency": 90.1,
-                "serviceName": "order",
-                "targetServices": Array [
-                  "analytics-service",
-                  "database",
-                ],
-                "throughput": 48,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "clear_order",
-                    ],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "update_order",
-                    ],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "get_order",
-                    ],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "pay_order",
-                    ],
-                    "traceGroup": "client_pay_order",
-                  },
-                ],
-              },
-              "payment": Object {
-                "destServices": Array [
-                  "frontend-client",
-                ],
-                "error_rate": 9.09,
-                "id": 7,
-                "latency": 134.36,
-                "serviceName": "payment",
-                "targetServices": Array [
-                  "analytics-service",
-                  "inventory",
-                ],
-                "throughput": 11,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "payment",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                ],
-              },
-              "recommendation": Object {
-                "destServices": Array [
-                  "authentication",
-                ],
-                "error_rate": 6.25,
-                "id": 8,
-                "latency": 176.97,
-                "serviceName": "recommendation",
-                "targetServices": Array [
-                  "analytics-service",
-                  "inventory",
-                ],
-                "throughput": 16,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "recommend",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
+              "id": "error_rate",
+              "label": "Errors",
+            },
+            Object {
+              "id": "throughput",
+              "label": "Request Rate",
+            },
+          ]
+        }
+      />
+      <EuiHorizontalRule
+        margin="m"
+      />
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiText>
+            Focus on
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFieldSearch
+            compressed={false}
+            fullWidth={false}
+            incremental={false}
+            isClearable={true}
+            isInvalid={false}
+            isLoading={false}
+            onChange={[Function]}
+            onSearch={[Function]}
+            placeholder="Service name"
+            value=""
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer />
+      <EuiFlexGroup
+        gutterSize="none"
+        responsive={false}
+      >
+        <EuiFlexItem>
+          <div
+            style={
+              Object {
+                "position": "relative",
+              }
             }
-          }
-          ticks={Array []}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiPanel>
-  <EuiSpacer
-    size="xl"
-  />
+          />
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
+        >
+          <ServiceMapScale
+            idSelected="latency"
+            serviceMap={
+              Object {
+                "analytics-service": Object {
+                  "destServices": Array [
+                    "order",
+                    "inventory",
+                    "authentication",
+                    "payment",
+                    "recommendation",
+                  ],
+                  "error_rate": 0,
+                  "id": 2,
+                  "latency": 12.99,
+                  "serviceName": "analytics-service",
+                  "targetServices": Array [],
+                  "throughput": 37,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_pay_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "authentication": Object {
+                  "destServices": Array [
+                    "frontend-client",
+                  ],
+                  "error_rate": 8.33,
+                  "id": 6,
+                  "latency": 139.09,
+                  "serviceName": "authentication",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "recommendation",
+                  ],
+                  "throughput": 12,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "server_request_login",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "database": Object {
+                  "destServices": Array [
+                    "order",
+                    "inventory",
+                  ],
+                  "error_rate": 3.77,
+                  "id": 3,
+                  "latency": 49.54,
+                  "serviceName": "database",
+                  "targetServices": Array [],
+                  "throughput": 53,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "cartEmpty",
+                      ],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "updateItem",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "addItemToCart",
+                      ],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "getCart",
+                      ],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "cartSold",
+                      ],
+                      "traceGroup": "client_pay_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "getIntentory",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "frontend-client": Object {
+                  "destServices": Array [],
+                  "error_rate": 7.41,
+                  "id": 4,
+                  "latency": 207.71,
+                  "serviceName": "frontend-client",
+                  "targetServices": Array [
+                    "order",
+                    "payment",
+                    "authentication",
+                  ],
+                  "throughput": 27,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_pay_order",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "inventory": Object {
+                  "destServices": Array [
+                    "payment",
+                    "recommendation",
+                  ],
+                  "error_rate": 3.23,
+                  "id": 5,
+                  "latency": 183.52,
+                  "serviceName": "inventory",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "database",
+                  ],
+                  "throughput": 31,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "update_inventory",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "read_inventory",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "order": Object {
+                  "destServices": Array [
+                    "frontend-client",
+                  ],
+                  "error_rate": 4.17,
+                  "id": 1,
+                  "latency": 90.1,
+                  "serviceName": "order",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "database",
+                  ],
+                  "throughput": 48,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "clear_order",
+                      ],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "update_order",
+                      ],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "get_order",
+                      ],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "pay_order",
+                      ],
+                      "traceGroup": "client_pay_order",
+                    },
+                  ],
+                },
+                "payment": Object {
+                  "destServices": Array [
+                    "frontend-client",
+                  ],
+                  "error_rate": 9.09,
+                  "id": 7,
+                  "latency": 134.36,
+                  "serviceName": "payment",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "inventory",
+                  ],
+                  "throughput": 11,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "payment",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                  ],
+                },
+                "recommendation": Object {
+                  "destServices": Array [
+                    "authentication",
+                  ],
+                  "error_rate": 6.25,
+                  "id": 8,
+                  "latency": 176.97,
+                  "serviceName": "recommendation",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "inventory",
+                  ],
+                  "throughput": 16,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "recommend",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+              }
+            }
+            ticks={Array []}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+    <EuiSpacer
+      size="xl"
+    />
+  </div>
 </Fragment>
 `;

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
@@ -2,12 +2,8 @@
 
 exports[`Service map component renders service map 1`] = `
 <Fragment>
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
     <EuiPanel>
       <PanelTitle
@@ -376,6 +372,6 @@ exports[`Service map component renders service map 1`] = `
     <EuiSpacer
       size="xl"
     />
-  </div>
+  </EuiPage>
 </Fragment>
 `;

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -12,6 +12,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiPage,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 // @ts-ignore
@@ -202,7 +203,7 @@ export function ServiceMap({
 
   return (
     <>
-      <div style={{ padding: '0 16px' }}>
+      <EuiPage paddingSize="m">
         <EuiPanel>
           {page === 'app' ? (
             <PanelTitle title="Application Composition Map" />
@@ -283,7 +284,7 @@ export function ServiceMap({
         {filterByCurrService && items?.graph && (
           <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
         )}
-      </div>
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -202,85 +202,88 @@ export function ServiceMap({
 
   return (
     <>
-      <EuiPanel>
-        {page === 'app' ? (
-          <PanelTitle title="Application Composition Map" />
-        ) : (
-          <PanelTitle title="Service map" />
-        )}
-        <EuiSpacer size="m" />
-        <EuiButtonGroup
-          options={toggleButtons}
-          idSelected={idSelected}
-          onChange={(id) => setIdSelected(id as 'latency' | 'error_rate' | 'throughput')}
-          buttonSize="s"
-          color="text"
-        />
-        <EuiHorizontalRule margin="m" />
-        <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiText>Focus on</EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFieldSearch
-              placeholder="Service name"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onSearch={(service) => onFocus(service)}
-              isInvalid={query.length > 0 && invalid}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer />
-
-        {Object.keys(serviceMap).length > 0 ? (
-          <EuiFlexGroup gutterSize="none" responsive={false}>
-            <EuiFlexItem>
-              <div style={{ position: 'relative' }}>
-                {items?.graph && (
-                  <Graph
-                    graph={items.graph}
-                    options={options}
-                    events={events}
-                    getNetwork={(networkInstance: any) => {
-                      setNetwork(networkInstance);
-                      if (currService) onFocus(currService, networkInstance);
-                    }}
-                  />
-                )}
-                {selectedNodeDetails && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      top: 20,
-                      right: 20,
-                      zIndex: 1000,
-                    }}
-                  >
-                    <ServiceMapNodeDetails
-                      selectedNodeDetails={selectedNodeDetails}
-                      setSelectedNodeDetails={setSelectedNodeDetails}
-                      addServiceFilter={addServiceFilter}
-                      setCurrentSelectedService={setCurrentSelectedService}
-                    />
-                  </div>
-                )}
-              </div>
-            </EuiFlexItem>
+      <div style={{ padding: '0 16px' }}>
+        <EuiPanel>
+          {page === 'app' ? (
+            <PanelTitle title="Application Composition Map" />
+          ) : (
+            <PanelTitle title="Service map" />
+          )}
+          <EuiSpacer size="m" />
+          <EuiButtonGroup
+            legend="Select metric to display"
+            options={toggleButtons}
+            idSelected={idSelected}
+            onChange={(id) => setIdSelected(id as 'latency' | 'error_rate' | 'throughput')}
+            buttonSize="s"
+            color="text"
+          />
+          <EuiHorizontalRule margin="m" />
+          <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <ServiceMapScale idSelected={idSelected} serviceMap={serviceMap} ticks={ticks} />
+              <EuiText>Focus on</EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFieldSearch
+                placeholder="Service name"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onSearch={(service) => onFocus(service)}
+                isInvalid={query.length > 0 && invalid}
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
-        ) : (
-          <div style={{ minHeight: 434 }}>
-            <NoMatchMessage size="s" />
-          </div>
+          <EuiSpacer />
+
+          {Object.keys(serviceMap).length > 0 ? (
+            <EuiFlexGroup gutterSize="none" responsive={false}>
+              <EuiFlexItem>
+                <div style={{ position: 'relative' }}>
+                  {items?.graph && (
+                    <Graph
+                      graph={items.graph}
+                      options={options}
+                      events={events}
+                      getNetwork={(networkInstance: any) => {
+                        setNetwork(networkInstance);
+                        if (currService) onFocus(currService, networkInstance);
+                      }}
+                    />
+                  )}
+                  {selectedNodeDetails && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: 20,
+                        right: 20,
+                        zIndex: 1000,
+                      }}
+                    >
+                      <ServiceMapNodeDetails
+                        selectedNodeDetails={selectedNodeDetails}
+                        setSelectedNodeDetails={setSelectedNodeDetails}
+                        addServiceFilter={addServiceFilter}
+                        setCurrentSelectedService={setCurrentSelectedService}
+                      />
+                    </div>
+                  )}
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <ServiceMapScale idSelected={idSelected} serviceMap={serviceMap} ticks={ticks} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <div style={{ minHeight: 434 }}>
+              <NoMatchMessage size="s" />
+            </div>
+          )}
+        </EuiPanel>
+        <EuiSpacer size="xl" />
+        {filterByCurrService && items?.graph && (
+          <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
         )}
-      </EuiPanel>
-      <EuiSpacer size="xl" />
-      {filterByCurrService && items?.graph && (
-        <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
-      )}
+      </div>
     </>
   );
 }

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -4,17 +4,17 @@
  */
 
 import {
-  EuiButton,
+  EuiButtonIcon,
   EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSpacer,
   EuiSuperDatePicker,
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
 import { uiSettingsService } from '../../../../../common/utils';
-import { Filters, FiltersProps } from './filters/filters';
+import { GlobalFilterButton } from './filters/filters'; // Import the GlobalFilterButton
+import { FilterType } from './filters/filters';
 
 export const renderDatePicker = (
   startTime: string,
@@ -36,22 +36,21 @@ export const renderDatePicker = (
   );
 };
 
-export interface SearchBarProps extends FiltersProps {
+export interface SearchBarProps {
+  filters: FilterType[];
+  setFilters: (filters: FilterType[]) => void;
   query: string;
   setQuery: (query: string) => void;
   startTime: string;
   setStartTime: (startTime: string) => void;
   endTime: string;
   setEndTime: (endTime: string) => void;
-}
-
-interface SearchBarOwnProps extends SearchBarProps {
   refresh: (currService?: string, overrideQuery?: string) => Promise<void>;
   page: 'dashboard' | 'traces' | 'services' | 'app';
   datepickerOnly?: boolean;
 }
 
-export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
+export const SearchBar = forwardRef((props: SearchBarProps, ref) => {
   // use another query state to avoid typing delay
   const [query, setQuery] = useState(props.query);
   const setGlobalQuery = debounce((q) => {
@@ -69,51 +68,53 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
 
   return (
     <>
-      <EuiFlexGroup gutterSize="s">
+      <EuiFlexGroup gutterSize="s" alignItems="center">
         {!props.datepickerOnly && (
-          <EuiFlexItem>
-            <EuiFieldSearch
-              fullWidth
-              isClearable={false}
-              placeholder="Trace ID, trace group name, service name"
-              data-test-subj="search-bar-input-box"
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setGlobalQuery(e.target.value);
-              }}
-              onSearch={props.refresh}
-            />
-          </EuiFlexItem>
+          <>
+            <EuiFlexItem>
+              <EuiFieldSearch
+                prepend={
+                  <GlobalFilterButton filters={props.filters} setFilters={props.setFilters} />
+                }
+                compressed
+                fullWidth
+                isClearable={false}
+                placeholder="Trace ID, trace group name, service name"
+                data-test-subj="search-bar-input-box"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setGlobalQuery(e.target.value);
+                }}
+                onSearch={props.refresh}
+              />
+            </EuiFlexItem>
+          </>
         )}
-        <EuiFlexItem grow={false} style={{ maxWidth: '40vw' }}>
-          {renderDatePicker(props.startTime, props.setStartTime, props.endTime, props.setEndTime)}
+        <EuiFlexItem grow={false} style={{ maxWidth: '30vw' }}>
+          <EuiSuperDatePicker
+            compressed
+            start={props.startTime}
+            end={props.endTime}
+            onTimeChange={(e) => {
+              props.setStartTime(e.start);
+              props.setEndTime(e.end);
+            }}
+            showUpdateButton={false}
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiButtonIcon
+            iconType="refresh"
+            aria-label="Refresh"
+            display="base"
+            onClick={() => props.refresh()}
+            size="s"
             data-test-subj="superDatePickerApplyTimeButton"
             data-click-metric-element="trace_analytics.refresh_button"
-            iconType="refresh"
-            onClick={() => props.refresh()}
-          >
-            Refresh
-          </EuiButton>
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
-
-      {!props.datepickerOnly && (
-        <>
-          <EuiSpacer size="s" />
-          <Filters
-            page={props.page}
-            filters={props.filters}
-            setFilters={props.setFilters}
-            appConfigs={props.appConfigs}
-            mode={props.mode}
-            attributesFilterFields={props.attributesFilterFields}
-          />
-        </>
-      )}
     </>
   );
 });

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -12,8 +12,9 @@ import {
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import { uiSettingsService } from '../../../../../common/utils';
-import { GlobalFilterButton } from './filters/filters'; // Import the GlobalFilterButton
+import { GlobalFilterButton } from './filters/filters';
 import { FilterType } from './filters/filters';
 
 export const renderDatePicker = (
@@ -70,26 +71,24 @@ export const SearchBar = forwardRef((props: SearchBarProps, ref) => {
     <>
       <EuiFlexGroup gutterSize="s" alignItems="center">
         {!props.datepickerOnly && (
-          <>
-            <EuiFlexItem>
-              <EuiFieldSearch
-                prepend={
-                  <GlobalFilterButton filters={props.filters} setFilters={props.setFilters} />
-                }
-                compressed
-                fullWidth
-                isClearable={false}
-                placeholder="Trace ID, trace group name, service name"
-                data-test-subj="search-bar-input-box"
-                value={query}
-                onChange={(e) => {
-                  setQuery(e.target.value);
-                  setGlobalQuery(e.target.value);
-                }}
-                onSearch={props.refresh}
-              />
-            </EuiFlexItem>
-          </>
+          <EuiFlexItem>
+            <EuiFieldSearch
+              prepend={<GlobalFilterButton filters={props.filters} setFilters={props.setFilters} />}
+              compressed
+              fullWidth
+              isClearable={false}
+              placeholder={i18n.translate('traceAnalytics.searchBar.placeholder', {
+                defaultMessage: 'Trace ID, trace group name, service name',
+              })}
+              data-test-subj="search-bar-input-box"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setGlobalQuery(e.target.value);
+              }}
+              onSearch={props.refresh}
+            />
+          </EuiFlexItem>
         )}
         <EuiFlexItem grow={false} style={{ maxWidth: '30vw' }}>
           <EuiSuperDatePicker

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -229,127 +229,6 @@ exports[`Services component renders empty services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <button
-              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-              data-test-subj="indexPattern-switch-link"
-              disabled={false}
-              onClick={[Function]}
-              title="data_prepper"
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButtonEmpty__content"
-                iconSide="right"
-                iconSize="m"
-                iconType="arrowDown"
-                textProps={
-                  Object {
-                    "className": "euiButtonEmpty__text",
-                  }
-                }
-              >
-                <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
-                    color="inherit"
-                    size="m"
-                    type="arrowDown"
-                  >
-                    <EuiIconBeaker
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                        />
-                      </svg>
-                    </EuiIconBeaker>
-                  </EuiIcon>
-                  <span
-                    className="euiButtonEmpty__text"
-                  >
-                    Data Prepper
-                  </span>
-                </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -578,16 +457,893 @@ exports[`Services component renders empty services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <button
+                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                        data-test-subj="indexPattern-switch-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        title="data_prepper"
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="right"
+                          iconSize="m"
+                          iconType="arrowDown"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconBeaker
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
+                            </EuiIcon>
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              Data Prepper
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="services"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <button
+                                        aria-label="Change all filters"
+                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        title="Change all filters"
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="filter"
+                                        >
+                                          <EuiIconBeaker
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconBeaker
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconBeaker
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconBeaker>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconBeaker
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -603,815 +1359,105 @@ exports[`Services component renders empty services page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiFieldSearch
-                compressed={false}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={false}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="m"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="m"
-                                type="search"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  element="button"
-                  iconType="refresh"
-                  isDisabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="euiButton euiButton--primary"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
-                    type="button"
-                  >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      iconType="refresh"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
-                    >
-                      <span
-                        className="euiButtonContent euiButton__content"
-                      >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="refresh"
-                        >
-                          <EuiIconBeaker
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Refresh
-                        </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <button
-                            aria-label="Change all filters"
-                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            title="Change all filters"
-                            type="button"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              color="inherit"
-                              size="m"
-                              type="filter"
-                            >
-                              <EuiIconBeaker
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                  />
-                                </svg>
-                              </EuiIconBeaker>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServicesTable
@@ -1429,712 +1475,186 @@ exports[`Services component renders empty services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            <EuiFlexGroup
+              justifyContent="spaceBetween"
             >
-              <EuiFlexItem
-                grow={false}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                <EuiFlexItem
+                  grow={false}
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiText
-                      size="m"
+                    <PanelTitle
+                      title="Services"
+                      totalItems={0}
                     >
-                      <div
-                        className="euiText euiText--medium"
+                      <EuiText
+                        size="m"
                       >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
                         <div
-                          className="euiFlexItem"
+                          className="euiText euiText--medium"
                         >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                          <span
+                            className="panel-title"
                           >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                            Services
+                          </span>
+                          <span
+                            className="panel-title-count"
+                          >
+                             (0)
+                          </span>
+                        </div>
+                      </EuiText>
+                    </PanelTitle>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiFlexGroup>
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      >
+                        <EuiFlexItem>
+                          <div
+                            className="euiFlexItem"
+                          >
+                            <EuiToolTip
+                              content="Select services to filter"
+                              delay="regular"
+                              position="top"
                             >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
+                              <span
+                                className="euiToolTipAnchor"
+                                onKeyUp={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
                               >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
+                                <EuiButtonEmpty
+                                  isDisabled={true}
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
-                                  type="button"
+                                  size="xs"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                    disabled={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="left"
+                                      iconSize="s"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButtonEmpty__text"
+                                        className="euiButtonContent euiButtonEmpty__content"
                                       >
-                                        Filter services
+                                        <span
+                                          className="euiButtonEmpty__text"
+                                        >
+                                          Filter services
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiButtonEmpty
-                            onClick={[Function]}
-                            size="xs"
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </span>
+                            </EuiToolTip>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <div
+                            className="euiFlexItem"
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
+                            <EuiButtonEmpty
                               onClick={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiButtonContent
+                                  className="euiButtonEmpty__content"
+                                  iconSide="left"
+                                  iconSize="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonContent euiButtonEmpty__content"
                                   >
-                                    Show 24 hour trends
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      Show 24 hour trends
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonEmpty>
                           </div>
-                        </EuiText>
+                        </EuiFlexItem>
                       </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiFlexItem>
               </div>
-            </EuiEmptyPrompt>
+            </EuiFlexGroup>
             <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </ServicesTable>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <PanelTitle
-            title="Service map"
-          >
-            <EuiText
               size="m"
             >
               <div
-                className="euiText euiText--medium"
-              >
-                <span
-                  className="panel-title"
-                >
-                  Service map
-                </span>
-              </div>
-            </EuiText>
-          </PanelTitle>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiButtonGroup
-            buttonSize="s"
-            color="text"
-            idSelected="latency"
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "id": "latency",
-                  "label": "Duration",
-                },
-                Object {
-                  "id": "error_rate",
-                  "label": "Errors",
-                },
-                Object {
-                  "id": "throughput",
-                  "label": "Request Rate",
-                },
-              ]
-            }
-          >
-            <fieldset
-              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-              disabled={false}
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiHorizontalRule
+              margin="none"
             >
-              <EuiScreenReaderOnly>
-                <legend
-                  className="euiScreenReaderOnly"
-                />
-              </EuiScreenReaderOnly>
-              <div
-                className="euiButtonGroup__buttons"
-              >
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="latency"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={true}
-                  key="0"
-                  label="Duration"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className="euiButtonGroupButton-isSelected"
-                    color="text"
-                    element="label"
-                    fill={true}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Duration",
-                        "ref": [Function],
-                        "title": "Duration",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Duration",
-                            "ref": [Function],
-                            "title": "Duration",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Duration"
-                            title="Duration"
-                          >
-                            <input
-                              checked={true}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="latency"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Duration
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="error_rate"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="1"
-                  label="Errors"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Errors",
-                        "ref": [Function],
-                        "title": "Errors",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Errors",
-                            "ref": [Function],
-                            "title": "Errors",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Errors"
-                            title="Errors"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="error_rate"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Errors
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="throughput"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="2"
-                  label="Request Rate"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Request Rate",
-                        "ref": [Function],
-                        "title": "Request Rate",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Request Rate",
-                            "ref": [Function],
-                            "title": "Request Rate",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Request Rate"
-                            title="Request Rate"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="throughput"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Request Rate
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-              </div>
-            </fieldset>
-          </EuiButtonGroup>
-          <EuiHorizontalRule
-            margin="m"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-            />
-          </EuiHorizontalRule>
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      Focus on
-                    </div>
-                  </EuiText>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiFieldSearch
-                    compressed={false}
-                    fullWidth={false}
-                    incremental={false}
-                    isClearable={true}
-                    isInvalid={false}
-                    isLoading={false}
-                    onChange={[Function]}
-                    onSearch={[Function]}
-                    placeholder="Service name"
-                    value=""
-                  >
-                    <EuiFormControlLayout
-                      compressed={false}
-                      fullWidth={false}
-                      icon="search"
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayout"
-                      >
-                        <div
-                          className="euiFormControlLayout__childrenWrapper"
-                        >
-                          <EuiValidatableControl
-                            isInvalid={false}
-                          >
-                            <input
-                              className="euiFieldSearch"
-                              onChange={[Function]}
-                              onKeyUp={[Function]}
-                              placeholder="Service name"
-                              type="search"
-                              value=""
-                            />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons
-                            compressed={false}
-                            icon="search"
-                            isLoading={false}
-                          >
-                            <div
-                              className="euiFormControlLayoutIcons"
-                            >
-                              <EuiFormControlLayoutCustomIcon
-                                size="m"
-                                type="search"
-                              >
-                                <span
-                                  className="euiFormControlLayoutCustomIcon"
-                                >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiFormControlLayoutCustomIcon__icon"
-                                    size="m"
-                                    type="search"
-                                  >
-                                    <EuiIconBeaker
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </EuiIconBeaker>
-                                  </EuiIcon>
-                                </span>
-                              </EuiFormControlLayoutCustomIcon>
-                            </div>
-                          </EuiFormControlLayoutIcons>
-                        </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiFieldSearch>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer>
-            <div
-              className="euiSpacer euiSpacer--l"
-            />
-          </EuiSpacer>
-          <div
-            style={
-              Object {
-                "minHeight": 434,
-              }
-            }
-          >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
             <NoMatchMessage
-              size="s"
+              size="xl"
             >
               <EuiSpacer
-                size="s"
+                size="xl"
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--xl"
                 />
               </EuiSpacer>
               <EuiEmptyPrompt
@@ -2192,23 +1712,568 @@ exports[`Services component renders empty services page 1`] = `
                 </div>
               </EuiEmptyPrompt>
               <EuiSpacer
-                size="s"
+                size="xl"
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--xl"
                 />
               </EuiSpacer>
             </NoMatchMessage>
           </div>
-        </div>
-      </EuiPanel>
-      <EuiSpacer
-        size="xl"
+        </EuiPanel>
+      </div>
+    </ServicesTable>
+    <EuiSpacer
+      size="s"
+    >
+      <div
+        className="euiSpacer euiSpacer--s"
+      />
+    </EuiSpacer>
+    <ServiceMap
+      addFilter={[Function]}
+      currService=""
+      idSelected="latency"
+      page="services"
+      serviceMap={Object {}}
+      setIdSelected={[Function]}
+    >
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
       >
-        <div
-          className="euiSpacer euiSpacer--xl"
-        />
-      </EuiSpacer>
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          >
+            <PanelTitle
+              title="Service map"
+            >
+              <EuiText
+                size="m"
+              >
+                <div
+                  className="euiText euiText--medium"
+                >
+                  <span
+                    className="panel-title"
+                  >
+                    Service map
+                  </span>
+                </div>
+              </EuiText>
+            </PanelTitle>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiButtonGroup
+              buttonSize="s"
+              color="text"
+              idSelected="latency"
+              legend="Select metric to display"
+              onChange={[Function]}
+              options={
+                Array [
+                  Object {
+                    "id": "latency",
+                    "label": "Duration",
+                  },
+                  Object {
+                    "id": "error_rate",
+                    "label": "Errors",
+                  },
+                  Object {
+                    "id": "throughput",
+                    "label": "Request Rate",
+                  },
+                ]
+              }
+            >
+              <fieldset
+                className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                disabled={false}
+              >
+                <EuiScreenReaderOnly>
+                  <legend
+                    className="euiScreenReaderOnly"
+                  >
+                    Select metric to display
+                  </legend>
+                </EuiScreenReaderOnly>
+                <div
+                  className="euiButtonGroup__buttons"
+                >
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="latency"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={true}
+                    key="0"
+                    label="Duration"
+                    name="random_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className="euiButtonGroupButton-isSelected"
+                      color="text"
+                      element="label"
+                      fill={true}
+                      htmlFor="random_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Duration",
+                          "ref": [Function],
+                          "title": "Duration",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                        disabled={false}
+                        htmlFor="random_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
+                              "data-text": "Duration",
+                              "ref": [Function],
+                              "title": "Duration",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Duration"
+                              title="Duration"
+                            >
+                              <input
+                                checked={true}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="latency"
+                                disabled={false}
+                                id="random_html_id"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Duration
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="error_rate"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={false}
+                    key="1"
+                    label="Errors"
+                    name="random_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className=""
+                      color="text"
+                      element="label"
+                      fill={false}
+                      htmlFor="random_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Errors",
+                          "ref": [Function],
+                          "title": "Errors",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                        disabled={false}
+                        htmlFor="random_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
+                              "data-text": "Errors",
+                              "ref": [Function],
+                              "title": "Errors",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Errors"
+                              title="Errors"
+                            >
+                              <input
+                                checked={false}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="error_rate"
+                                disabled={false}
+                                id="random_html_id"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Errors
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="throughput"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={false}
+                    key="2"
+                    label="Request Rate"
+                    name="random_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className=""
+                      color="text"
+                      element="label"
+                      fill={false}
+                      htmlFor="random_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Request Rate",
+                          "ref": [Function],
+                          "title": "Request Rate",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                        disabled={false}
+                        htmlFor="random_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
+                              "data-text": "Request Rate",
+                              "ref": [Function],
+                              "title": "Request Rate",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Request Rate"
+                              title="Request Rate"
+                            >
+                              <input
+                                checked={false}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="throughput"
+                                disabled={false}
+                                id="random_html_id"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Request Rate
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                </div>
+              </fieldset>
+            </EuiButtonGroup>
+            <EuiHorizontalRule
+              margin="m"
+            >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+              />
+            </EuiHorizontalRule>
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        Focus on
+                      </div>
+                    </EuiText>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFieldSearch
+                      compressed={false}
+                      fullWidth={false}
+                      incremental={false}
+                      isClearable={true}
+                      isInvalid={false}
+                      isLoading={false}
+                      onChange={[Function]}
+                      onSearch={[Function]}
+                      placeholder="Service name"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl
+                              isInvalid={false}
+                            >
+                              <input
+                                className="euiFieldSearch"
+                                onChange={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Service name"
+                                type="search"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              compressed={false}
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  size="m"
+                                  type="search"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      size="m"
+                                      type="search"
+                                    >
+                                      <EuiIconBeaker
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </EuiIconBeaker>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldSearch>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <div
+              style={
+                Object {
+                  "minHeight": 434,
+                }
+              }
+            >
+              <NoMatchMessage
+                size="s"
+              >
+                <EuiSpacer
+                  size="s"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--s"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText>
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h2
+                        className="euiTitle euiTitle--medium"
+                      >
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="s"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--s"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </div>
+        </EuiPanel>
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+      </div>
     </ServiceMap>
   </ServicesContent>
 </Services>
@@ -2443,128 +2508,6 @@ exports[`Services component renders jaeger services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="jaeger"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="jaeger"
-        >
-          Jaeger
-        </EuiButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="jaeger"
-          >
-            <button
-              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-              data-test-subj="indexPattern-switch-link"
-              disabled={false}
-              onClick={[Function]}
-              title="jaeger"
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButtonEmpty__content"
-                iconSide="right"
-                iconSize="m"
-                iconType="arrowDown"
-                textProps={
-                  Object {
-                    "className": "euiButtonEmpty__text",
-                  }
-                }
-              >
-                <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
-                    color="inherit"
-                    size="m"
-                    type="arrowDown"
-                  >
-                    <EuiIconArrowDown
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fillRule="non-zero"
-                        />
-                      </svg>
-                    </EuiIconArrowDown>
-                  </EuiIcon>
-                  <span
-                    className="euiButtonEmpty__text"
-                  >
-                    Jaeger
-                  </span>
-                </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -2793,16 +2736,897 @@ exports[`Services component renders jaeger services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="jaeger"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="jaeger"
+                  >
+                    Jaeger
+                  </EuiButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="jaeger"
+                    >
+                      <button
+                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                        data-test-subj="indexPattern-switch-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        title="jaeger"
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="right"
+                          iconSize="m"
+                          iconType="arrowDown"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconArrowDown
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fillRule="non-zero"
+                                  />
+                                </svg>
+                              </EuiIconArrowDown>
+                            </EuiIcon>
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              Jaeger
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="jaeger"
+              page="services"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <button
+                                        aria-label="Change all filters"
+                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        title="Change all filters"
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="filter"
+                                        >
+                                          <EuiIconFilter
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                fillRule="evenodd"
+                                              />
+                                            </svg>
+                                          </EuiIconFilter>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="jaeger"
       page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -2818,818 +3642,105 @@ exports[`Services component renders jaeger services page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiFieldSearch
-                compressed={false}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={false}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="m"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="m"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  element="button"
-                  iconType="refresh"
-                  isDisabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="euiButton euiButton--primary"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
-                    type="button"
-                  >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      iconType="refresh"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
-                    >
-                      <span
-                        className="euiButtonContent euiButton__content"
-                      >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="refresh"
-                        >
-                          <EuiIconRefresh
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                              />
-                            </svg>
-                          </EuiIconRefresh>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Refresh
-                        </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="jaeger"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <button
-                            aria-label="Change all filters"
-                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            title="Change all filters"
-                            type="button"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              color="inherit"
-                              size="m"
-                              type="filter"
-                            >
-                              <EuiIconFilter
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                    fillRule="evenodd"
-                                  />
-                                </svg>
-                              </EuiIconFilter>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServicesTable
@@ -3648,213 +3759,221 @@ exports[`Services component renders jaeger services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            <EuiFlexGroup
+              justifyContent="spaceBetween"
             >
-              <EuiFlexItem
-                grow={false}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                <EuiFlexItem
+                  grow={false}
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiText
-                      size="m"
+                    <PanelTitle
+                      title="Services"
+                      totalItems={0}
                     >
-                      <div
-                        className="euiText euiText--medium"
+                      <EuiText
+                        size="m"
                       >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
                         <div
-                          className="euiFlexItem"
+                          className="euiText euiText--medium"
                         >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                          <span
+                            className="panel-title"
                           >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                            Services
+                          </span>
+                          <span
+                            className="panel-title-count"
+                          >
+                             (0)
+                          </span>
+                        </div>
+                      </EuiText>
+                    </PanelTitle>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiFlexGroup>
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      >
+                        <EuiFlexItem>
+                          <div
+                            className="euiFlexItem"
+                          >
+                            <EuiToolTip
+                              content="Select services to filter"
+                              delay="regular"
+                              position="top"
                             >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
+                              <span
+                                className="euiToolTipAnchor"
+                                onKeyUp={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
                               >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
+                                <EuiButtonEmpty
+                                  isDisabled={true}
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
-                                  type="button"
+                                  size="xs"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                    disabled={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="left"
+                                      iconSize="s"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButtonEmpty__text"
+                                        className="euiButtonContent euiButtonEmpty__content"
                                       >
-                                        Filter services
+                                        <span
+                                          className="euiButtonEmpty__text"
+                                        >
+                                          Filter services
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </span>
+                            </EuiToolTip>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
             <EuiSpacer
-              size="xl"
+              size="m"
             >
               <div
-                className="euiSpacer euiSpacer--xl"
+                className="euiSpacer euiSpacer--m"
               />
             </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
+            <EuiHorizontalRule
+              margin="none"
             >
-              <div
-                className="euiEmptyPrompt"
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
+            <NoMatchMessage
+              size="xl"
+            >
+              <EuiSpacer
+                size="xl"
               >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <EuiEmptyPrompt
+                body={
+                  <EuiText>
+                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                  </EuiText>
+                }
+                title={
+                  <h2>
                     No matches
                   </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                }
+              >
+                <div
+                  className="euiEmptyPrompt"
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <EuiTitle
+                    size="m"
                   >
-                    <EuiSpacer
-                      size="m"
+                    <h2
+                      className="euiTitle euiTitle--medium"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      No matches
+                    </h2>
+                  </EuiTitle>
+                  <EuiTextColor
+                    color="subdued"
+                  >
+                    <span
+                      className="euiTextColor euiTextColor--subdued"
+                    >
+                      <EuiSpacer
+                        size="m"
                       >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            </div>
+                          </EuiText>
+                        </div>
+                      </EuiText>
+                    </span>
+                  </EuiTextColor>
+                </div>
+              </EuiEmptyPrompt>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+            </NoMatchMessage>
+          </div>
+        </EuiPanel>
+      </div>
     </ServicesTable>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <div />
@@ -4090,128 +4209,6 @@ exports[`Services component renders services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <button
-              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-              data-test-subj="indexPattern-switch-link"
-              disabled={false}
-              onClick={[Function]}
-              title="data_prepper"
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButtonEmpty__content"
-                iconSide="right"
-                iconSize="m"
-                iconType="arrowDown"
-                textProps={
-                  Object {
-                    "className": "euiButtonEmpty__text",
-                  }
-                }
-              >
-                <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
-                    color="inherit"
-                    size="m"
-                    type="arrowDown"
-                  >
-                    <EuiIconArrowDown
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fillRule="non-zero"
-                        />
-                      </svg>
-                    </EuiIconArrowDown>
-                  </EuiIcon>
-                  <span
-                    className="euiButtonEmpty__text"
-                  >
-                    Data Prepper
-                  </span>
-                </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -4439,16 +4436,897 @@ exports[`Services component renders services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <button
+                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                        data-test-subj="indexPattern-switch-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        title="data_prepper"
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="right"
+                          iconSize="m"
+                          iconType="arrowDown"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconArrowDown
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fillRule="non-zero"
+                                  />
+                                </svg>
+                              </EuiIconArrowDown>
+                            </EuiIcon>
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              Data Prepper
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="services"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <button
+                                        aria-label="Change all filters"
+                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        title="Change all filters"
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="filter"
+                                        >
+                                          <EuiIconFilter
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                fillRule="evenodd"
+                                              />
+                                            </svg>
+                                          </EuiIconFilter>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -4464,818 +5342,105 @@ exports[`Services component renders services page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiFieldSearch
-                compressed={false}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={false}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="m"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="m"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  element="button"
-                  iconType="refresh"
-                  isDisabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="euiButton euiButton--primary"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
-                    type="button"
-                  >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      iconType="refresh"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
-                    >
-                      <span
-                        className="euiButtonContent euiButton__content"
-                      >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="refresh"
-                        >
-                          <EuiIconRefresh
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                              />
-                            </svg>
-                          </EuiIconRefresh>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Refresh
-                        </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <button
-                            aria-label="Change all filters"
-                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            title="Change all filters"
-                            type="button"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              color="inherit"
-                              size="m"
-                              type="filter"
-                            >
-                              <EuiIconFilter
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                    fillRule="evenodd"
-                                  />
-                                </svg>
-                              </EuiIconFilter>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServicesTable
@@ -5293,712 +5458,186 @@ exports[`Services component renders services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+            <EuiFlexGroup
+              justifyContent="spaceBetween"
             >
-              <EuiFlexItem
-                grow={false}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                <EuiFlexItem
+                  grow={false}
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiText
-                      size="m"
+                    <PanelTitle
+                      title="Services"
+                      totalItems={0}
                     >
-                      <div
-                        className="euiText euiText--medium"
+                      <EuiText
+                        size="m"
                       >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
                         <div
-                          className="euiFlexItem"
+                          className="euiText euiText--medium"
                         >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                          <span
+                            className="panel-title"
                           >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                            Services
+                          </span>
+                          <span
+                            className="panel-title-count"
+                          >
+                             (0)
+                          </span>
+                        </div>
+                      </EuiText>
+                    </PanelTitle>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiFlexGroup>
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      >
+                        <EuiFlexItem>
+                          <div
+                            className="euiFlexItem"
+                          >
+                            <EuiToolTip
+                              content="Select services to filter"
+                              delay="regular"
+                              position="top"
                             >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
+                              <span
+                                className="euiToolTipAnchor"
+                                onKeyUp={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
                               >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
+                                <EuiButtonEmpty
+                                  isDisabled={true}
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
-                                  type="button"
+                                  size="xs"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                    disabled={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    type="button"
                                   >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="left"
+                                      iconSize="s"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
                                       <span
-                                        className="euiButtonEmpty__text"
+                                        className="euiButtonContent euiButtonEmpty__content"
                                       >
-                                        Filter services
+                                        <span
+                                          className="euiButtonEmpty__text"
+                                        >
+                                          Filter services
+                                        </span>
                                       </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiButtonEmpty
-                            onClick={[Function]}
-                            size="xs"
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </span>
+                            </EuiToolTip>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem>
+                          <div
+                            className="euiFlexItem"
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
+                            <EuiButtonEmpty
                               onClick={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiButtonContent
+                                  className="euiButtonEmpty__content"
+                                  iconSide="left"
+                                  iconSize="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonContent euiButtonEmpty__content"
                                   >
-                                    Show 24 hour trends
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      Show 24 hour trends
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonEmpty>
                           </div>
-                        </EuiText>
+                        </EuiFlexItem>
                       </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiFlexItem>
               </div>
-            </EuiEmptyPrompt>
+            </EuiFlexGroup>
             <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </ServicesTable>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <PanelTitle
-            title="Service map"
-          >
-            <EuiText
               size="m"
             >
               <div
-                className="euiText euiText--medium"
-              >
-                <span
-                  className="panel-title"
-                >
-                  Service map
-                </span>
-              </div>
-            </EuiText>
-          </PanelTitle>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiButtonGroup
-            buttonSize="s"
-            color="text"
-            idSelected="latency"
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "id": "latency",
-                  "label": "Duration",
-                },
-                Object {
-                  "id": "error_rate",
-                  "label": "Errors",
-                },
-                Object {
-                  "id": "throughput",
-                  "label": "Request Rate",
-                },
-              ]
-            }
-          >
-            <fieldset
-              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-              disabled={false}
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiHorizontalRule
+              margin="none"
             >
-              <EuiScreenReaderOnly>
-                <legend
-                  className="euiScreenReaderOnly"
-                />
-              </EuiScreenReaderOnly>
-              <div
-                className="euiButtonGroup__buttons"
-              >
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="latency"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={true}
-                  key="0"
-                  label="Duration"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className="euiButtonGroupButton-isSelected"
-                    color="text"
-                    element="label"
-                    fill={true}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Duration",
-                        "ref": [Function],
-                        "title": "Duration",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Duration",
-                            "ref": [Function],
-                            "title": "Duration",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Duration"
-                            title="Duration"
-                          >
-                            <input
-                              checked={true}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="latency"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Duration
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="error_rate"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="1"
-                  label="Errors"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Errors",
-                        "ref": [Function],
-                        "title": "Errors",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Errors",
-                            "ref": [Function],
-                            "title": "Errors",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Errors"
-                            title="Errors"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="error_rate"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Errors
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="throughput"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="2"
-                  label="Request Rate"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Request Rate",
-                        "ref": [Function],
-                        "title": "Request Rate",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Request Rate",
-                            "ref": [Function],
-                            "title": "Request Rate",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Request Rate"
-                            title="Request Rate"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="throughput"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Request Rate
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-              </div>
-            </fieldset>
-          </EuiButtonGroup>
-          <EuiHorizontalRule
-            margin="m"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-            />
-          </EuiHorizontalRule>
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      Focus on
-                    </div>
-                  </EuiText>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiFieldSearch
-                    compressed={false}
-                    fullWidth={false}
-                    incremental={false}
-                    isClearable={true}
-                    isInvalid={false}
-                    isLoading={false}
-                    onChange={[Function]}
-                    onSearch={[Function]}
-                    placeholder="Service name"
-                    value=""
-                  >
-                    <EuiFormControlLayout
-                      compressed={false}
-                      fullWidth={false}
-                      icon="search"
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayout"
-                      >
-                        <div
-                          className="euiFormControlLayout__childrenWrapper"
-                        >
-                          <EuiValidatableControl
-                            isInvalid={false}
-                          >
-                            <input
-                              className="euiFieldSearch"
-                              onChange={[Function]}
-                              onKeyUp={[Function]}
-                              placeholder="Service name"
-                              type="search"
-                              value=""
-                            />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons
-                            compressed={false}
-                            icon="search"
-                            isLoading={false}
-                          >
-                            <div
-                              className="euiFormControlLayoutIcons"
-                            >
-                              <EuiFormControlLayoutCustomIcon
-                                size="m"
-                                type="search"
-                              >
-                                <span
-                                  className="euiFormControlLayoutCustomIcon"
-                                >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiFormControlLayoutCustomIcon__icon"
-                                    size="m"
-                                    type="search"
-                                  >
-                                    <EuiIconSearch
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSearch>
-                                  </EuiIcon>
-                                </span>
-                              </EuiFormControlLayoutCustomIcon>
-                            </div>
-                          </EuiFormControlLayoutIcons>
-                        </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiFieldSearch>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer>
-            <div
-              className="euiSpacer euiSpacer--l"
-            />
-          </EuiSpacer>
-          <div
-            style={
-              Object {
-                "minHeight": 434,
-              }
-            }
-          >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
             <NoMatchMessage
-              size="s"
+              size="xl"
             >
               <EuiSpacer
-                size="s"
+                size="xl"
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--xl"
                 />
               </EuiSpacer>
               <EuiEmptyPrompt
@@ -6056,23 +5695,568 @@ exports[`Services component renders services page 1`] = `
                 </div>
               </EuiEmptyPrompt>
               <EuiSpacer
-                size="s"
+                size="xl"
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--xl"
                 />
               </EuiSpacer>
             </NoMatchMessage>
           </div>
-        </div>
-      </EuiPanel>
-      <EuiSpacer
-        size="xl"
+        </EuiPanel>
+      </div>
+    </ServicesTable>
+    <EuiSpacer
+      size="s"
+    >
+      <div
+        className="euiSpacer euiSpacer--s"
+      />
+    </EuiSpacer>
+    <ServiceMap
+      addFilter={[Function]}
+      currService=""
+      idSelected="latency"
+      page="services"
+      serviceMap={Object {}}
+      setIdSelected={[Function]}
+    >
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
       >
-        <div
-          className="euiSpacer euiSpacer--xl"
-        />
-      </EuiSpacer>
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          >
+            <PanelTitle
+              title="Service map"
+            >
+              <EuiText
+                size="m"
+              >
+                <div
+                  className="euiText euiText--medium"
+                >
+                  <span
+                    className="panel-title"
+                  >
+                    Service map
+                  </span>
+                </div>
+              </EuiText>
+            </PanelTitle>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiButtonGroup
+              buttonSize="s"
+              color="text"
+              idSelected="latency"
+              legend="Select metric to display"
+              onChange={[Function]}
+              options={
+                Array [
+                  Object {
+                    "id": "latency",
+                    "label": "Duration",
+                  },
+                  Object {
+                    "id": "error_rate",
+                    "label": "Errors",
+                  },
+                  Object {
+                    "id": "throughput",
+                    "label": "Request Rate",
+                  },
+                ]
+              }
+            >
+              <fieldset
+                className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                disabled={false}
+              >
+                <EuiScreenReaderOnly>
+                  <legend
+                    className="euiScreenReaderOnly"
+                  >
+                    Select metric to display
+                  </legend>
+                </EuiScreenReaderOnly>
+                <div
+                  className="euiButtonGroup__buttons"
+                >
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="latency"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={true}
+                    key="0"
+                    label="Duration"
+                    name="random_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className="euiButtonGroupButton-isSelected"
+                      color="text"
+                      element="label"
+                      fill={true}
+                      htmlFor="random_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Duration",
+                          "ref": [Function],
+                          "title": "Duration",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                        disabled={false}
+                        htmlFor="random_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
+                              "data-text": "Duration",
+                              "ref": [Function],
+                              "title": "Duration",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Duration"
+                              title="Duration"
+                            >
+                              <input
+                                checked={true}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="latency"
+                                disabled={false}
+                                id="random_html_id"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Duration
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="error_rate"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={false}
+                    key="1"
+                    label="Errors"
+                    name="random_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className=""
+                      color="text"
+                      element="label"
+                      fill={false}
+                      htmlFor="random_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Errors",
+                          "ref": [Function],
+                          "title": "Errors",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                        disabled={false}
+                        htmlFor="random_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
+                              "data-text": "Errors",
+                              "ref": [Function],
+                              "title": "Errors",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Errors"
+                              title="Errors"
+                            >
+                              <input
+                                checked={false}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="error_rate"
+                                disabled={false}
+                                id="random_html_id"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Errors
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                  <EuiButtonGroupButton
+                    color="text"
+                    element="label"
+                    id="throughput"
+                    isDisabled={false}
+                    isIconOnly={false}
+                    isSelected={false}
+                    key="2"
+                    label="Request Rate"
+                    name="random_html_id"
+                    onChange={[Function]}
+                    size="s"
+                  >
+                    <EuiButtonDisplay
+                      baseClassName="euiButtonGroupButton"
+                      className=""
+                      color="text"
+                      element="label"
+                      fill={false}
+                      htmlFor="random_html_id"
+                      isDisabled={false}
+                      onClick={[Function]}
+                      size="s"
+                      textProps={
+                        Object {
+                          "className": "euiButtonGroupButton__textShift",
+                          "data-text": "Request Rate",
+                          "ref": [Function],
+                          "title": "Request Rate",
+                        }
+                      }
+                    >
+                      <label
+                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                        disabled={false}
+                        htmlFor="random_html_id"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "minWidth": undefined,
+                          }
+                        }
+                      >
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text euiButtonGroupButton__textShift",
+                              "data-text": "Request Rate",
+                              "ref": [Function],
+                              "title": "Request Rate",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButton__content"
+                          >
+                            <span
+                              className="euiButton__text euiButtonGroupButton__textShift"
+                              data-text="Request Rate"
+                              title="Request Rate"
+                            >
+                              <input
+                                checked={false}
+                                className="euiScreenReaderOnly"
+                                data-test-subj="throughput"
+                                disabled={false}
+                                id="random_html_id"
+                                name="random_html_id"
+                                onChange={[Function]}
+                                type="radio"
+                              />
+                              Request Rate
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </label>
+                    </EuiButtonDisplay>
+                  </EuiButtonGroupButton>
+                </div>
+              </fieldset>
+            </EuiButtonGroup>
+            <EuiHorizontalRule
+              margin="m"
+            >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+              />
+            </EuiHorizontalRule>
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+            >
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={false}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        Focus on
+                      </div>
+                    </EuiText>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <EuiFieldSearch
+                      compressed={false}
+                      fullWidth={false}
+                      incremental={false}
+                      isClearable={true}
+                      isInvalid={false}
+                      isLoading={false}
+                      onChange={[Function]}
+                      onSearch={[Function]}
+                      placeholder="Service name"
+                      value=""
+                    >
+                      <EuiFormControlLayout
+                        compressed={false}
+                        fullWidth={false}
+                        icon="search"
+                        isLoading={false}
+                      >
+                        <div
+                          className="euiFormControlLayout"
+                        >
+                          <div
+                            className="euiFormControlLayout__childrenWrapper"
+                          >
+                            <EuiValidatableControl
+                              isInvalid={false}
+                            >
+                              <input
+                                className="euiFieldSearch"
+                                onChange={[Function]}
+                                onKeyUp={[Function]}
+                                placeholder="Service name"
+                                type="search"
+                                value=""
+                              />
+                            </EuiValidatableControl>
+                            <EuiFormControlLayoutIcons
+                              compressed={false}
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayoutIcons"
+                              >
+                                <EuiFormControlLayoutCustomIcon
+                                  size="m"
+                                  type="search"
+                                >
+                                  <span
+                                    className="euiFormControlLayoutCustomIcon"
+                                  >
+                                    <EuiIcon
+                                      aria-hidden="true"
+                                      className="euiFormControlLayoutCustomIcon__icon"
+                                      size="m"
+                                      type="search"
+                                    >
+                                      <EuiIconSearch
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </EuiIconSearch>
+                                    </EuiIcon>
+                                  </span>
+                                </EuiFormControlLayoutCustomIcon>
+                              </div>
+                            </EuiFormControlLayoutIcons>
+                          </div>
+                        </div>
+                      </EuiFormControlLayout>
+                    </EuiFieldSearch>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer>
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <div
+              style={
+                Object {
+                  "minHeight": 434,
+                }
+              }
+            >
+              <NoMatchMessage
+                size="s"
+              >
+                <EuiSpacer
+                  size="s"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--s"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText>
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h2
+                        className="euiTitle euiTitle--medium"
+                      >
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="s"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--s"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </div>
+        </EuiPanel>
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+      </div>
     </ServiceMap>
   </ServicesContent>
 </Services>

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -1475,730 +1475,185 @@ exports[`Services component renders empty services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
+      <EuiPage
+        paddingSize="m"
       >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiFlexGroup
-              justifyContent="spaceBetween"
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
+        >
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
               >
-                <EuiFlexItem
-                  grow={false}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <PanelTitle
-                      title="Services"
-                      totalItems={0}
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiText
-                        size="m"
+                      <PanelTitle
+                        title="Services"
+                        totalItems={0}
                       >
-                        <div
-                          className="euiText euiText--medium"
+                        <EuiText
+                          size="m"
                         >
-                          <span
-                            className="panel-title"
-                          >
-                            Services
-                          </span>
-                          <span
-                            className="panel-title-count"
-                          >
-                             (0)
-                          </span>
-                        </div>
-                      </EuiText>
-                    </PanelTitle>
-                  </div>
-                </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                  >
-                    <EuiFlexGroup>
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                      >
-                        <EuiFlexItem>
                           <div
-                            className="euiFlexItem"
+                            className="euiText euiText--medium"
                           >
-                            <EuiToolTip
-                              content="Select services to filter"
-                              delay="regular"
-                              position="top"
+                            <span
+                              className="panel-title"
                             >
-                              <span
-                                className="euiToolTipAnchor"
-                                onKeyUp={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
+                              Services
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiFlexGroup>
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiToolTip
+                                content="Select services to filter"
+                                delay="regular"
+                                position="top"
                               >
-                                <EuiButtonEmpty
-                                  isDisabled={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  size="xs"
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                    disabled={true}
+                                  <EuiButtonEmpty
+                                    isDisabled={true}
                                     onBlur={[Function]}
                                     onClick={[Function]}
                                     onFocus={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="left"
-                                      iconSize="s"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                      disabled={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
                                       >
                                         <span
-                                          className="euiButtonEmpty__text"
+                                          className="euiButtonContent euiButtonEmpty__content"
                                         >
-                                          Filter services
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Filter services
+                                          </span>
                                         </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </span>
-                            </EuiToolTip>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem>
-                          <div
-                            className="euiFlexItem"
-                          >
-                            <EuiButtonEmpty
-                              onClick={[Function]}
-                              size="xs"
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </span>
+                              </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                                disabled={false}
+                              <EuiButtonEmpty
                                 onClick={[Function]}
-                                type="button"
+                                size="xs"
                               >
-                                <EuiButtonContent
-                                  className="euiButtonEmpty__content"
-                                  iconSide="left"
-                                  iconSize="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonEmpty__text",
-                                    }
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonEmpty__content"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButtonEmpty__text"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      Show 24 hour trends
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Show 24 hour trends
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonEmpty>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiHorizontalRule
-              margin="none"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full"
-              />
-            </EuiHorizontalRule>
-            <NoMatchMessage
-              size="xl"
-            >
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText>
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
-                >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
-                      No matches
-                    </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
-                  >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
-                    >
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
-                          </EuiText>
+                          </EuiFlexItem>
                         </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiFlexItem>
                 </div>
-              </EuiEmptyPrompt>
+              </EuiFlexGroup>
               <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-            </NoMatchMessage>
-          </div>
-        </EuiPanel>
-      </div>
-    </ServicesTable>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
-      >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <PanelTitle
-              title="Service map"
-            >
-              <EuiText
                 size="m"
               >
                 <div
-                  className="euiText euiText--medium"
-                >
-                  <span
-                    className="panel-title"
-                  >
-                    Service map
-                  </span>
-                </div>
-              </EuiText>
-            </PanelTitle>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiButtonGroup
-              buttonSize="s"
-              color="text"
-              idSelected="latency"
-              legend="Select metric to display"
-              onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "id": "latency",
-                    "label": "Duration",
-                  },
-                  Object {
-                    "id": "error_rate",
-                    "label": "Errors",
-                  },
-                  Object {
-                    "id": "throughput",
-                    "label": "Request Rate",
-                  },
-                ]
-              }
-            >
-              <fieldset
-                className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                disabled={false}
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
               >
-                <EuiScreenReaderOnly>
-                  <legend
-                    className="euiScreenReaderOnly"
-                  >
-                    Select metric to display
-                  </legend>
-                </EuiScreenReaderOnly>
-                <div
-                  className="euiButtonGroup__buttons"
-                >
-                  <EuiButtonGroupButton
-                    color="text"
-                    element="label"
-                    id="latency"
-                    isDisabled={false}
-                    isIconOnly={false}
-                    isSelected={true}
-                    key="0"
-                    label="Duration"
-                    name="random_html_id"
-                    onChange={[Function]}
-                    size="s"
-                  >
-                    <EuiButtonDisplay
-                      baseClassName="euiButtonGroupButton"
-                      className="euiButtonGroupButton-isSelected"
-                      color="text"
-                      element="label"
-                      fill={true}
-                      htmlFor="random_html_id"
-                      isDisabled={false}
-                      onClick={[Function]}
-                      size="s"
-                      textProps={
-                        Object {
-                          "className": "euiButtonGroupButton__textShift",
-                          "data-text": "Duration",
-                          "ref": [Function],
-                          "title": "Duration",
-                        }
-                      }
-                    >
-                      <label
-                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                        disabled={false}
-                        htmlFor="random_html_id"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
-                      >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
-                            Object {
-                              "className": "euiButton__text euiButtonGroupButton__textShift",
-                              "data-text": "Duration",
-                              "ref": [Function],
-                              "title": "Duration",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              className="euiButton__text euiButtonGroupButton__textShift"
-                              data-text="Duration"
-                              title="Duration"
-                            >
-                              <input
-                                checked={true}
-                                className="euiScreenReaderOnly"
-                                data-test-subj="latency"
-                                disabled={false}
-                                id="random_html_id"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                type="radio"
-                              />
-                              Duration
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </label>
-                    </EuiButtonDisplay>
-                  </EuiButtonGroupButton>
-                  <EuiButtonGroupButton
-                    color="text"
-                    element="label"
-                    id="error_rate"
-                    isDisabled={false}
-                    isIconOnly={false}
-                    isSelected={false}
-                    key="1"
-                    label="Errors"
-                    name="random_html_id"
-                    onChange={[Function]}
-                    size="s"
-                  >
-                    <EuiButtonDisplay
-                      baseClassName="euiButtonGroupButton"
-                      className=""
-                      color="text"
-                      element="label"
-                      fill={false}
-                      htmlFor="random_html_id"
-                      isDisabled={false}
-                      onClick={[Function]}
-                      size="s"
-                      textProps={
-                        Object {
-                          "className": "euiButtonGroupButton__textShift",
-                          "data-text": "Errors",
-                          "ref": [Function],
-                          "title": "Errors",
-                        }
-                      }
-                    >
-                      <label
-                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                        disabled={false}
-                        htmlFor="random_html_id"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
-                      >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
-                            Object {
-                              "className": "euiButton__text euiButtonGroupButton__textShift",
-                              "data-text": "Errors",
-                              "ref": [Function],
-                              "title": "Errors",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              className="euiButton__text euiButtonGroupButton__textShift"
-                              data-text="Errors"
-                              title="Errors"
-                            >
-                              <input
-                                checked={false}
-                                className="euiScreenReaderOnly"
-                                data-test-subj="error_rate"
-                                disabled={false}
-                                id="random_html_id"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                type="radio"
-                              />
-                              Errors
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </label>
-                    </EuiButtonDisplay>
-                  </EuiButtonGroupButton>
-                  <EuiButtonGroupButton
-                    color="text"
-                    element="label"
-                    id="throughput"
-                    isDisabled={false}
-                    isIconOnly={false}
-                    isSelected={false}
-                    key="2"
-                    label="Request Rate"
-                    name="random_html_id"
-                    onChange={[Function]}
-                    size="s"
-                  >
-                    <EuiButtonDisplay
-                      baseClassName="euiButtonGroupButton"
-                      className=""
-                      color="text"
-                      element="label"
-                      fill={false}
-                      htmlFor="random_html_id"
-                      isDisabled={false}
-                      onClick={[Function]}
-                      size="s"
-                      textProps={
-                        Object {
-                          "className": "euiButtonGroupButton__textShift",
-                          "data-text": "Request Rate",
-                          "ref": [Function],
-                          "title": "Request Rate",
-                        }
-                      }
-                    >
-                      <label
-                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                        disabled={false}
-                        htmlFor="random_html_id"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
-                      >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
-                            Object {
-                              "className": "euiButton__text euiButtonGroupButton__textShift",
-                              "data-text": "Request Rate",
-                              "ref": [Function],
-                              "title": "Request Rate",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              className="euiButton__text euiButtonGroupButton__textShift"
-                              data-text="Request Rate"
-                              title="Request Rate"
-                            >
-                              <input
-                                checked={false}
-                                className="euiScreenReaderOnly"
-                                data-test-subj="throughput"
-                                disabled={false}
-                                id="random_html_id"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                type="radio"
-                              />
-                              Request Rate
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </label>
-                    </EuiButtonDisplay>
-                  </EuiButtonGroupButton>
-                </div>
-              </fieldset>
-            </EuiButtonGroup>
-            <EuiHorizontalRule
-              margin="m"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-              />
-            </EuiHorizontalRule>
-            <EuiFlexGroup
-              alignItems="center"
-              gutterSize="s"
-            >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-              >
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                  >
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        Focus on
-                      </div>
-                    </EuiText>
-                  </div>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <div
-                    className="euiFlexItem"
-                  >
-                    <EuiFieldSearch
-                      compressed={false}
-                      fullWidth={false}
-                      incremental={false}
-                      isClearable={true}
-                      isInvalid={false}
-                      isLoading={false}
-                      onChange={[Function]}
-                      onSearch={[Function]}
-                      placeholder="Service name"
-                      value=""
-                    >
-                      <EuiFormControlLayout
-                        compressed={false}
-                        fullWidth={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayout"
-                        >
-                          <div
-                            className="euiFormControlLayout__childrenWrapper"
-                          >
-                            <EuiValidatableControl
-                              isInvalid={false}
-                            >
-                              <input
-                                className="euiFieldSearch"
-                                onChange={[Function]}
-                                onKeyUp={[Function]}
-                                placeholder="Service name"
-                                type="search"
-                                value=""
-                              />
-                            </EuiValidatableControl>
-                            <EuiFormControlLayoutIcons
-                              compressed={false}
-                              icon="search"
-                              isLoading={false}
-                            >
-                              <div
-                                className="euiFormControlLayoutIcons"
-                              >
-                                <EuiFormControlLayoutCustomIcon
-                                  size="m"
-                                  type="search"
-                                >
-                                  <span
-                                    className="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <EuiIcon
-                                      aria-hidden="true"
-                                      className="euiFormControlLayoutCustomIcon__icon"
-                                      size="m"
-                                      type="search"
-                                    >
-                                      <EuiIconBeaker
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height={16}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                          />
-                                        </svg>
-                                      </EuiIconBeaker>
-                                    </EuiIcon>
-                                  </span>
-                                </EuiFormControlLayoutCustomIcon>
-                              </div>
-                            </EuiFormControlLayoutIcons>
-                          </div>
-                        </div>
-                      </EuiFormControlLayout>
-                    </EuiFieldSearch>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer>
-              <div
-                className="euiSpacer euiSpacer--l"
-              />
-            </EuiSpacer>
-            <div
-              style={
-                Object {
-                  "minHeight": 434,
-                }
-              }
-            >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
               <NoMatchMessage
-                size="s"
+                size="xl"
               >
                 <EuiSpacer
-                  size="s"
+                  size="xl"
                 >
                   <div
-                    className="euiSpacer euiSpacer--s"
+                    className="euiSpacer euiSpacer--xl"
                   />
                 </EuiSpacer>
                 <EuiEmptyPrompt
@@ -2256,24 +1711,569 @@ exports[`Services component renders empty services page 1`] = `
                   </div>
                 </EuiEmptyPrompt>
                 <EuiSpacer
-                  size="s"
+                  size="xl"
                 >
                   <div
-                    className="euiSpacer euiSpacer--s"
+                    className="euiSpacer euiSpacer--xl"
                   />
                 </EuiSpacer>
               </NoMatchMessage>
             </div>
-          </div>
-        </EuiPanel>
-        <EuiSpacer
-          size="xl"
+          </EuiPanel>
+        </div>
+      </EuiPage>
+    </ServicesTable>
+    <EuiSpacer
+      size="s"
+    >
+      <div
+        className="euiSpacer euiSpacer--s"
+      />
+    </EuiSpacer>
+    <ServiceMap
+      addFilter={[Function]}
+      currService=""
+      idSelected="latency"
+      page="services"
+      serviceMap={Object {}}
+      setIdSelected={[Function]}
+    >
+      <EuiPage
+        paddingSize="m"
+      >
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </div>
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+            >
+              <PanelTitle
+                title="Service map"
+              >
+                <EuiText
+                  size="m"
+                >
+                  <div
+                    className="euiText euiText--medium"
+                  >
+                    <span
+                      className="panel-title"
+                    >
+                      Service map
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiButtonGroup
+                buttonSize="s"
+                color="text"
+                idSelected="latency"
+                legend="Select metric to display"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "id": "latency",
+                      "label": "Duration",
+                    },
+                    Object {
+                      "id": "error_rate",
+                      "label": "Errors",
+                    },
+                    Object {
+                      "id": "throughput",
+                      "label": "Request Rate",
+                    },
+                  ]
+                }
+              >
+                <fieldset
+                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                  disabled={false}
+                >
+                  <EuiScreenReaderOnly>
+                    <legend
+                      className="euiScreenReaderOnly"
+                    >
+                      Select metric to display
+                    </legend>
+                  </EuiScreenReaderOnly>
+                  <div
+                    className="euiButtonGroup__buttons"
+                  >
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="latency"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={true}
+                      key="0"
+                      label="Duration"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className="euiButtonGroupButton-isSelected"
+                        color="text"
+                        element="label"
+                        fill={true}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Duration",
+                            "ref": [Function],
+                            "title": "Duration",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Duration",
+                                "ref": [Function],
+                                "title": "Duration",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Duration"
+                                title="Duration"
+                              >
+                                <input
+                                  checked={true}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="latency"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Duration
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="error_rate"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="1"
+                      label="Errors"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Errors",
+                            "ref": [Function],
+                            "title": "Errors",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Errors",
+                                "ref": [Function],
+                                "title": "Errors",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Errors"
+                                title="Errors"
+                              >
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="error_rate"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Errors
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="throughput"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="2"
+                      label="Request Rate"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Request Rate",
+                            "ref": [Function],
+                            "title": "Request Rate",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Request Rate",
+                                "ref": [Function],
+                                "title": "Request Rate",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Request Rate"
+                                title="Request Rate"
+                              >
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="throughput"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Request Rate
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                  </div>
+                </fieldset>
+              </EuiButtonGroup>
+              <EuiHorizontalRule
+                margin="m"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                />
+              </EuiHorizontalRule>
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          Focus on
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={false}
+                        fullWidth={false}
+                        incremental={false}
+                        isClearable={true}
+                        isInvalid={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Service name"
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={false}
+                          fullWidth={false}
+                          icon="search"
+                          isLoading={false}
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl
+                                isInvalid={false}
+                              >
+                                <input
+                                  className="euiFieldSearch"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={false}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="m"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="m"
+                                        type="search"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <div
+                style={
+                  Object {
+                    "minHeight": 434,
+                  }
+                }
+              >
+                <NoMatchMessage
+                  size="s"
+                >
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                  <EuiEmptyPrompt
+                    body={
+                      <EuiText>
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                      </EuiText>
+                    }
+                    title={
+                      <h2>
+                        No matches
+                      </h2>
+                    }
+                  >
+                    <div
+                      className="euiEmptyPrompt"
+                    >
+                      <EuiTitle
+                        size="m"
+                      >
+                        <h2
+                          className="euiTitle euiTitle--medium"
+                        >
+                          No matches
+                        </h2>
+                      </EuiTitle>
+                      <EuiTextColor
+                        color="subdued"
+                      >
+                        <span
+                          className="euiTextColor euiTextColor--subdued"
+                        >
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <EuiText>
+                                <div
+                                  className="euiText euiText--medium"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiText>
+                        </span>
+                      </EuiTextColor>
+                    </div>
+                  </EuiEmptyPrompt>
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                </NoMatchMessage>
+              </div>
+            </div>
+          </EuiPanel>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+        </div>
+      </EuiPage>
     </ServiceMap>
   </ServicesContent>
 </Services>
@@ -3759,215 +3759,215 @@ exports[`Services component renders jaeger services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
+      <EuiPage
+        paddingSize="m"
       >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiFlexGroup
-              justifyContent="spaceBetween"
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
+        >
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
               >
-                <EuiFlexItem
-                  grow={false}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <PanelTitle
-                      title="Services"
-                      totalItems={0}
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiText
-                        size="m"
+                      <PanelTitle
+                        title="Services"
+                        totalItems={0}
                       >
-                        <div
-                          className="euiText euiText--medium"
+                        <EuiText
+                          size="m"
                         >
-                          <span
-                            className="panel-title"
-                          >
-                            Services
-                          </span>
-                          <span
-                            className="panel-title-count"
-                          >
-                             (0)
-                          </span>
-                        </div>
-                      </EuiText>
-                    </PanelTitle>
-                  </div>
-                </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                  >
-                    <EuiFlexGroup>
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                      >
-                        <EuiFlexItem>
                           <div
-                            className="euiFlexItem"
+                            className="euiText euiText--medium"
                           >
-                            <EuiToolTip
-                              content="Select services to filter"
-                              delay="regular"
-                              position="top"
+                            <span
+                              className="panel-title"
                             >
-                              <span
-                                className="euiToolTipAnchor"
-                                onKeyUp={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
+                              Services
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiFlexGroup>
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiToolTip
+                                content="Select services to filter"
+                                delay="regular"
+                                position="top"
                               >
-                                <EuiButtonEmpty
-                                  isDisabled={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  size="xs"
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                    disabled={true}
+                                  <EuiButtonEmpty
+                                    isDisabled={true}
                                     onBlur={[Function]}
                                     onClick={[Function]}
                                     onFocus={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="left"
-                                      iconSize="s"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                      disabled={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
                                       >
                                         <span
-                                          className="euiButtonEmpty__text"
+                                          className="euiButtonContent euiButtonEmpty__content"
                                         >
-                                          Filter services
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Filter services
+                                          </span>
                                         </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </span>
-                            </EuiToolTip>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiHorizontalRule
-              margin="none"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full"
-              />
-            </EuiHorizontalRule>
-            <NoMatchMessage
-              size="xl"
-            >
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </span>
+                              </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
               <EuiSpacer
-                size="xl"
+                size="m"
               >
                 <div
-                  className="euiSpacer euiSpacer--xl"
+                  className="euiSpacer euiSpacer--m"
                 />
               </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText>
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
+              <EuiHorizontalRule
+                margin="none"
               >
-                <div
-                  className="euiEmptyPrompt"
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
                 >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText>
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
                       No matches
                     </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
                   >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
+                    <EuiTitle
+                      size="m"
                     >
-                      <EuiSpacer
-                        size="m"
+                      <h2
+                        className="euiTitle euiTitle--medium"
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
                         >
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
-                          </EuiText>
-                        </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
-                </div>
-              </EuiEmptyPrompt>
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-            </NoMatchMessage>
-          </div>
-        </EuiPanel>
-      </div>
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
+        </div>
+      </EuiPage>
     </ServicesTable>
     <EuiSpacer
       size="s"
@@ -5458,730 +5458,185 @@ exports[`Services component renders services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
+      <EuiPage
+        paddingSize="m"
       >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiFlexGroup
-              justifyContent="spaceBetween"
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
+        >
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
               >
-                <EuiFlexItem
-                  grow={false}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <PanelTitle
-                      title="Services"
-                      totalItems={0}
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiText
-                        size="m"
+                      <PanelTitle
+                        title="Services"
+                        totalItems={0}
                       >
-                        <div
-                          className="euiText euiText--medium"
+                        <EuiText
+                          size="m"
                         >
-                          <span
-                            className="panel-title"
-                          >
-                            Services
-                          </span>
-                          <span
-                            className="panel-title-count"
-                          >
-                             (0)
-                          </span>
-                        </div>
-                      </EuiText>
-                    </PanelTitle>
-                  </div>
-                </EuiFlexItem>
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                  >
-                    <EuiFlexGroup>
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                      >
-                        <EuiFlexItem>
                           <div
-                            className="euiFlexItem"
+                            className="euiText euiText--medium"
                           >
-                            <EuiToolTip
-                              content="Select services to filter"
-                              delay="regular"
-                              position="top"
+                            <span
+                              className="panel-title"
                             >
-                              <span
-                                className="euiToolTipAnchor"
-                                onKeyUp={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
+                              Services
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiFlexGroup>
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiToolTip
+                                content="Select services to filter"
+                                delay="regular"
+                                position="top"
                               >
-                                <EuiButtonEmpty
-                                  isDisabled={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  size="xs"
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                    disabled={true}
+                                  <EuiButtonEmpty
+                                    isDisabled={true}
                                     onBlur={[Function]}
                                     onClick={[Function]}
                                     onFocus={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="left"
-                                      iconSize="s"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                      disabled={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
                                       >
                                         <span
-                                          className="euiButtonEmpty__text"
+                                          className="euiButtonContent euiButtonEmpty__content"
                                         >
-                                          Filter services
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Filter services
+                                          </span>
                                         </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </span>
-                            </EuiToolTip>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem>
-                          <div
-                            className="euiFlexItem"
-                          >
-                            <EuiButtonEmpty
-                              onClick={[Function]}
-                              size="xs"
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </span>
+                              </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                                disabled={false}
+                              <EuiButtonEmpty
                                 onClick={[Function]}
-                                type="button"
+                                size="xs"
                               >
-                                <EuiButtonContent
-                                  className="euiButtonEmpty__content"
-                                  iconSide="left"
-                                  iconSize="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonEmpty__text",
-                                    }
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonEmpty__content"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButtonEmpty__text"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      Show 24 hour trends
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Show 24 hour trends
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonEmpty>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiHorizontalRule
-              margin="none"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full"
-              />
-            </EuiHorizontalRule>
-            <NoMatchMessage
-              size="xl"
-            >
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText>
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
-                >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
-                      No matches
-                    </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
-                  >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
-                    >
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
-                          </EuiText>
+                          </EuiFlexItem>
                         </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiFlexItem>
                 </div>
-              </EuiEmptyPrompt>
+              </EuiFlexGroup>
               <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-            </NoMatchMessage>
-          </div>
-        </EuiPanel>
-      </div>
-    </ServicesTable>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
-      >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <PanelTitle
-              title="Service map"
-            >
-              <EuiText
                 size="m"
               >
                 <div
-                  className="euiText euiText--medium"
-                >
-                  <span
-                    className="panel-title"
-                  >
-                    Service map
-                  </span>
-                </div>
-              </EuiText>
-            </PanelTitle>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiButtonGroup
-              buttonSize="s"
-              color="text"
-              idSelected="latency"
-              legend="Select metric to display"
-              onChange={[Function]}
-              options={
-                Array [
-                  Object {
-                    "id": "latency",
-                    "label": "Duration",
-                  },
-                  Object {
-                    "id": "error_rate",
-                    "label": "Errors",
-                  },
-                  Object {
-                    "id": "throughput",
-                    "label": "Request Rate",
-                  },
-                ]
-              }
-            >
-              <fieldset
-                className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                disabled={false}
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
               >
-                <EuiScreenReaderOnly>
-                  <legend
-                    className="euiScreenReaderOnly"
-                  >
-                    Select metric to display
-                  </legend>
-                </EuiScreenReaderOnly>
-                <div
-                  className="euiButtonGroup__buttons"
-                >
-                  <EuiButtonGroupButton
-                    color="text"
-                    element="label"
-                    id="latency"
-                    isDisabled={false}
-                    isIconOnly={false}
-                    isSelected={true}
-                    key="0"
-                    label="Duration"
-                    name="random_html_id"
-                    onChange={[Function]}
-                    size="s"
-                  >
-                    <EuiButtonDisplay
-                      baseClassName="euiButtonGroupButton"
-                      className="euiButtonGroupButton-isSelected"
-                      color="text"
-                      element="label"
-                      fill={true}
-                      htmlFor="random_html_id"
-                      isDisabled={false}
-                      onClick={[Function]}
-                      size="s"
-                      textProps={
-                        Object {
-                          "className": "euiButtonGroupButton__textShift",
-                          "data-text": "Duration",
-                          "ref": [Function],
-                          "title": "Duration",
-                        }
-                      }
-                    >
-                      <label
-                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                        disabled={false}
-                        htmlFor="random_html_id"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
-                      >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
-                            Object {
-                              "className": "euiButton__text euiButtonGroupButton__textShift",
-                              "data-text": "Duration",
-                              "ref": [Function],
-                              "title": "Duration",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              className="euiButton__text euiButtonGroupButton__textShift"
-                              data-text="Duration"
-                              title="Duration"
-                            >
-                              <input
-                                checked={true}
-                                className="euiScreenReaderOnly"
-                                data-test-subj="latency"
-                                disabled={false}
-                                id="random_html_id"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                type="radio"
-                              />
-                              Duration
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </label>
-                    </EuiButtonDisplay>
-                  </EuiButtonGroupButton>
-                  <EuiButtonGroupButton
-                    color="text"
-                    element="label"
-                    id="error_rate"
-                    isDisabled={false}
-                    isIconOnly={false}
-                    isSelected={false}
-                    key="1"
-                    label="Errors"
-                    name="random_html_id"
-                    onChange={[Function]}
-                    size="s"
-                  >
-                    <EuiButtonDisplay
-                      baseClassName="euiButtonGroupButton"
-                      className=""
-                      color="text"
-                      element="label"
-                      fill={false}
-                      htmlFor="random_html_id"
-                      isDisabled={false}
-                      onClick={[Function]}
-                      size="s"
-                      textProps={
-                        Object {
-                          "className": "euiButtonGroupButton__textShift",
-                          "data-text": "Errors",
-                          "ref": [Function],
-                          "title": "Errors",
-                        }
-                      }
-                    >
-                      <label
-                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                        disabled={false}
-                        htmlFor="random_html_id"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
-                      >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
-                            Object {
-                              "className": "euiButton__text euiButtonGroupButton__textShift",
-                              "data-text": "Errors",
-                              "ref": [Function],
-                              "title": "Errors",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              className="euiButton__text euiButtonGroupButton__textShift"
-                              data-text="Errors"
-                              title="Errors"
-                            >
-                              <input
-                                checked={false}
-                                className="euiScreenReaderOnly"
-                                data-test-subj="error_rate"
-                                disabled={false}
-                                id="random_html_id"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                type="radio"
-                              />
-                              Errors
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </label>
-                    </EuiButtonDisplay>
-                  </EuiButtonGroupButton>
-                  <EuiButtonGroupButton
-                    color="text"
-                    element="label"
-                    id="throughput"
-                    isDisabled={false}
-                    isIconOnly={false}
-                    isSelected={false}
-                    key="2"
-                    label="Request Rate"
-                    name="random_html_id"
-                    onChange={[Function]}
-                    size="s"
-                  >
-                    <EuiButtonDisplay
-                      baseClassName="euiButtonGroupButton"
-                      className=""
-                      color="text"
-                      element="label"
-                      fill={false}
-                      htmlFor="random_html_id"
-                      isDisabled={false}
-                      onClick={[Function]}
-                      size="s"
-                      textProps={
-                        Object {
-                          "className": "euiButtonGroupButton__textShift",
-                          "data-text": "Request Rate",
-                          "ref": [Function],
-                          "title": "Request Rate",
-                        }
-                      }
-                    >
-                      <label
-                        className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                        disabled={false}
-                        htmlFor="random_html_id"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "minWidth": undefined,
-                          }
-                        }
-                      >
-                        <EuiButtonContent
-                          className="euiButton__content"
-                          iconSide="left"
-                          textProps={
-                            Object {
-                              "className": "euiButton__text euiButtonGroupButton__textShift",
-                              "data-text": "Request Rate",
-                              "ref": [Function],
-                              "title": "Request Rate",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButton__content"
-                          >
-                            <span
-                              className="euiButton__text euiButtonGroupButton__textShift"
-                              data-text="Request Rate"
-                              title="Request Rate"
-                            >
-                              <input
-                                checked={false}
-                                className="euiScreenReaderOnly"
-                                data-test-subj="throughput"
-                                disabled={false}
-                                id="random_html_id"
-                                name="random_html_id"
-                                onChange={[Function]}
-                                type="radio"
-                              />
-                              Request Rate
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </label>
-                    </EuiButtonDisplay>
-                  </EuiButtonGroupButton>
-                </div>
-              </fieldset>
-            </EuiButtonGroup>
-            <EuiHorizontalRule
-              margin="m"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-              />
-            </EuiHorizontalRule>
-            <EuiFlexGroup
-              alignItems="center"
-              gutterSize="s"
-            >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-              >
-                <EuiFlexItem
-                  grow={false}
-                >
-                  <div
-                    className="euiFlexItem euiFlexItem--flexGrowZero"
-                  >
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        Focus on
-                      </div>
-                    </EuiText>
-                  </div>
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <div
-                    className="euiFlexItem"
-                  >
-                    <EuiFieldSearch
-                      compressed={false}
-                      fullWidth={false}
-                      incremental={false}
-                      isClearable={true}
-                      isInvalid={false}
-                      isLoading={false}
-                      onChange={[Function]}
-                      onSearch={[Function]}
-                      placeholder="Service name"
-                      value=""
-                    >
-                      <EuiFormControlLayout
-                        compressed={false}
-                        fullWidth={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayout"
-                        >
-                          <div
-                            className="euiFormControlLayout__childrenWrapper"
-                          >
-                            <EuiValidatableControl
-                              isInvalid={false}
-                            >
-                              <input
-                                className="euiFieldSearch"
-                                onChange={[Function]}
-                                onKeyUp={[Function]}
-                                placeholder="Service name"
-                                type="search"
-                                value=""
-                              />
-                            </EuiValidatableControl>
-                            <EuiFormControlLayoutIcons
-                              compressed={false}
-                              icon="search"
-                              isLoading={false}
-                            >
-                              <div
-                                className="euiFormControlLayoutIcons"
-                              >
-                                <EuiFormControlLayoutCustomIcon
-                                  size="m"
-                                  type="search"
-                                >
-                                  <span
-                                    className="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <EuiIcon
-                                      aria-hidden="true"
-                                      className="euiFormControlLayoutCustomIcon__icon"
-                                      size="m"
-                                      type="search"
-                                    >
-                                      <EuiIconSearch
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height={16}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </EuiIconSearch>
-                                    </EuiIcon>
-                                  </span>
-                                </EuiFormControlLayoutCustomIcon>
-                              </div>
-                            </EuiFormControlLayoutIcons>
-                          </div>
-                        </div>
-                      </EuiFormControlLayout>
-                    </EuiFieldSearch>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer>
-              <div
-                className="euiSpacer euiSpacer--l"
-              />
-            </EuiSpacer>
-            <div
-              style={
-                Object {
-                  "minHeight": 434,
-                }
-              }
-            >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
               <NoMatchMessage
-                size="s"
+                size="xl"
               >
                 <EuiSpacer
-                  size="s"
+                  size="xl"
                 >
                   <div
-                    className="euiSpacer euiSpacer--s"
+                    className="euiSpacer euiSpacer--xl"
                   />
                 </EuiSpacer>
                 <EuiEmptyPrompt
@@ -6239,24 +5694,569 @@ exports[`Services component renders services page 1`] = `
                   </div>
                 </EuiEmptyPrompt>
                 <EuiSpacer
-                  size="s"
+                  size="xl"
                 >
                   <div
-                    className="euiSpacer euiSpacer--s"
+                    className="euiSpacer euiSpacer--xl"
                   />
                 </EuiSpacer>
               </NoMatchMessage>
             </div>
-          </div>
-        </EuiPanel>
-        <EuiSpacer
-          size="xl"
+          </EuiPanel>
+        </div>
+      </EuiPage>
+    </ServicesTable>
+    <EuiSpacer
+      size="s"
+    >
+      <div
+        className="euiSpacer euiSpacer--s"
+      />
+    </EuiSpacer>
+    <ServiceMap
+      addFilter={[Function]}
+      currService=""
+      idSelected="latency"
+      page="services"
+      serviceMap={Object {}}
+      setIdSelected={[Function]}
+    >
+      <EuiPage
+        paddingSize="m"
+      >
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </div>
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+            >
+              <PanelTitle
+                title="Service map"
+              >
+                <EuiText
+                  size="m"
+                >
+                  <div
+                    className="euiText euiText--medium"
+                  >
+                    <span
+                      className="panel-title"
+                    >
+                      Service map
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiButtonGroup
+                buttonSize="s"
+                color="text"
+                idSelected="latency"
+                legend="Select metric to display"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "id": "latency",
+                      "label": "Duration",
+                    },
+                    Object {
+                      "id": "error_rate",
+                      "label": "Errors",
+                    },
+                    Object {
+                      "id": "throughput",
+                      "label": "Request Rate",
+                    },
+                  ]
+                }
+              >
+                <fieldset
+                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                  disabled={false}
+                >
+                  <EuiScreenReaderOnly>
+                    <legend
+                      className="euiScreenReaderOnly"
+                    >
+                      Select metric to display
+                    </legend>
+                  </EuiScreenReaderOnly>
+                  <div
+                    className="euiButtonGroup__buttons"
+                  >
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="latency"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={true}
+                      key="0"
+                      label="Duration"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className="euiButtonGroupButton-isSelected"
+                        color="text"
+                        element="label"
+                        fill={true}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Duration",
+                            "ref": [Function],
+                            "title": "Duration",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Duration",
+                                "ref": [Function],
+                                "title": "Duration",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Duration"
+                                title="Duration"
+                              >
+                                <input
+                                  checked={true}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="latency"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Duration
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="error_rate"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="1"
+                      label="Errors"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Errors",
+                            "ref": [Function],
+                            "title": "Errors",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Errors",
+                                "ref": [Function],
+                                "title": "Errors",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Errors"
+                                title="Errors"
+                              >
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="error_rate"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Errors
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="throughput"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="2"
+                      label="Request Rate"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
+                        textProps={
+                          Object {
+                            "className": "euiButtonGroupButton__textShift",
+                            "data-text": "Request Rate",
+                            "ref": [Function],
+                            "title": "Request Rate",
+                          }
+                        }
+                      >
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
+                        >
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Request Rate",
+                                "ref": [Function],
+                                "title": "Request Rate",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Request Rate"
+                                title="Request Rate"
+                              >
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="throughput"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Request Rate
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                  </div>
+                </fieldset>
+              </EuiButtonGroup>
+              <EuiHorizontalRule
+                margin="m"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                />
+              </EuiHorizontalRule>
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          Focus on
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={false}
+                        fullWidth={false}
+                        incremental={false}
+                        isClearable={true}
+                        isInvalid={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Service name"
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={false}
+                          fullWidth={false}
+                          icon="search"
+                          isLoading={false}
+                        >
+                          <div
+                            className="euiFormControlLayout"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl
+                                isInvalid={false}
+                              >
+                                <input
+                                  className="euiFieldSearch"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={false}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="m"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="m"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer>
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <div
+                style={
+                  Object {
+                    "minHeight": 434,
+                  }
+                }
+              >
+                <NoMatchMessage
+                  size="s"
+                >
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                  <EuiEmptyPrompt
+                    body={
+                      <EuiText>
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                      </EuiText>
+                    }
+                    title={
+                      <h2>
+                        No matches
+                      </h2>
+                    }
+                  >
+                    <div
+                      className="euiEmptyPrompt"
+                    >
+                      <EuiTitle
+                        size="m"
+                      >
+                        <h2
+                          className="euiTitle euiTitle--medium"
+                        >
+                          No matches
+                        </h2>
+                      </EuiTitle>
+                      <EuiTextColor
+                        color="subdued"
+                      >
+                        <span
+                          className="euiTextColor euiTextColor--subdued"
+                        >
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <EuiText>
+                                <div
+                                  className="euiText euiText--medium"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiText>
+                        </span>
+                      </EuiTextColor>
+                    </div>
+                  </EuiEmptyPrompt>
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                </NoMatchMessage>
+              </div>
+            </div>
+          </EuiPanel>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+        </div>
+      </EuiPage>
     </ServiceMap>
   </ServicesContent>
 </Services>

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -12,213 +12,213 @@ exports[`Services table component renders empty jaeger services table message 1`
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
+              <EuiFlexItem
+                grow={false}
               >
-                <PanelTitle
-                  title="Services"
-                  totalItems={0}
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiText
-                    size="m"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={0}
                   >
-                    <div
-                      className="euiText euiText--medium"
+                    <EuiText
+                      size="m"
                     >
-                      <span
-                        className="panel-title"
-                      >
-                        Services
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (0)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <EuiFlexGroup>
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                  >
-                    <EuiFlexItem>
                       <div
-                        className="euiFlexItem"
+                        className="euiText euiText--medium"
                       >
-                        <EuiToolTip
-                          content="Select services to filter"
-                          delay="regular"
-                          position="top"
+                        <span
+                          className="panel-title"
                         >
-                          <span
-                            className="euiToolTipAnchor"
-                            onKeyUp={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
                           >
-                            <EuiButtonEmpty
-                              isDisabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              size="xs"
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                disabled={true}
+                              <EuiButtonEmpty
+                                isDisabled={true}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
-                                type="button"
+                                size="xs"
                               >
-                                <EuiButtonContent
-                                  className="euiButtonEmpty__content"
-                                  iconSide="left"
-                                  iconSize="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonEmpty__text",
-                                    }
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonEmpty__content"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButtonEmpty__text"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      Filter services
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonEmpty>
-                          </span>
-                        </EuiToolTip>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <NoMatchMessage
-          size="xl"
-        >
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
           <EuiSpacer
-            size="xl"
+            size="m"
           >
             <div
-              className="euiSpacer euiSpacer--xl"
+              className="euiSpacer euiSpacer--m"
             />
           </EuiSpacer>
-          <EuiEmptyPrompt
-            body={
-              <EuiText>
-                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-              </EuiText>
-            }
-            title={
-              <h2>
-                No matches
-              </h2>
-            }
+          <EuiHorizontalRule
+            margin="none"
           >
-            <div
-              className="euiEmptyPrompt"
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <NoMatchMessage
+            size="xl"
+          >
+            <EuiSpacer
+              size="xl"
             >
-              <EuiTitle
-                size="m"
-              >
-                <h2
-                  className="euiTitle euiTitle--medium"
-                >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiEmptyPrompt
+              body={
+                <EuiText>
+                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                </EuiText>
+              }
+              title={
+                <h2>
                   No matches
                 </h2>
-              </EuiTitle>
-              <EuiTextColor
-                color="subdued"
+              }
+            >
+              <div
+                className="euiEmptyPrompt"
               >
-                <span
-                  className="euiTextColor euiTextColor--subdued"
+                <EuiTitle
+                  size="m"
                 >
-                  <EuiSpacer
-                    size="m"
+                  <h2
+                    className="euiTitle euiTitle--medium"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
+                    No matches
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
                     >
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                        </div>
-                      </EuiText>
-                    </div>
-                  </EuiText>
-                </span>
-              </EuiTextColor>
-            </div>
-          </EuiEmptyPrompt>
-          <EuiSpacer
-            size="xl"
-          >
-            <div
-              className="euiSpacer euiSpacer--xl"
-            />
-          </EuiSpacer>
-        </NoMatchMessage>
-      </div>
-    </EuiPanel>
-  </div>
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+              </div>
+            </EuiEmptyPrompt>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+          </NoMatchMessage>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </ServicesTable>
 `;
 
@@ -234,251 +234,251 @@ exports[`Services table component renders empty services table message 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
+              <EuiFlexItem
+                grow={false}
               >
-                <PanelTitle
-                  title="Services"
-                  totalItems={0}
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiText
-                    size="m"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={0}
                   >
-                    <div
-                      className="euiText euiText--medium"
+                    <EuiText
+                      size="m"
                     >
-                      <span
-                        className="panel-title"
-                      >
-                        Services
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (0)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <EuiFlexGroup>
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                  >
-                    <EuiFlexItem>
                       <div
-                        className="euiFlexItem"
+                        className="euiText euiText--medium"
                       >
-                        <EuiToolTip
-                          content="Select services to filter"
-                          delay="regular"
-                          position="top"
+                        <span
+                          className="panel-title"
                         >
-                          <span
-                            className="euiToolTipAnchor"
-                            onKeyUp={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
                           >
-                            <EuiButtonEmpty
-                              isDisabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              size="xs"
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                disabled={true}
+                              <EuiButtonEmpty
+                                isDisabled={true}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
-                                type="button"
+                                size="xs"
                               >
-                                <EuiButtonContent
-                                  className="euiButtonEmpty__content"
-                                  iconSide="left"
-                                  iconSize="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonEmpty__text",
-                                    }
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonEmpty__content"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButtonEmpty__text"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      Filter services
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonEmpty>
-                          </span>
-                        </EuiToolTip>
-                      </div>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
+                          <EuiButtonEmpty
                             onClick={[Function]}
-                            type="button"
+                            size="xs"
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <button
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              disabled={false}
+                              onClick={[Function]}
+                              type="button"
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                              <EuiButtonContent
+                                className="euiButtonEmpty__content"
+                                iconSide="left"
+                                iconSize="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonEmpty__text",
+                                  }
+                                }
                               >
                                 <span
-                                  className="euiButtonEmpty__text"
+                                  className="euiButtonContent euiButtonEmpty__content"
                                 >
-                                  Show 24 hour trends
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    Show 24 hour trends
+                                  </span>
                                 </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <NoMatchMessage
-          size="xl"
-        >
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonEmpty>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
           <EuiSpacer
-            size="xl"
+            size="m"
           >
             <div
-              className="euiSpacer euiSpacer--xl"
+              className="euiSpacer euiSpacer--m"
             />
           </EuiSpacer>
-          <EuiEmptyPrompt
-            body={
-              <EuiText>
-                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-              </EuiText>
-            }
-            title={
-              <h2>
-                No matches
-              </h2>
-            }
+          <EuiHorizontalRule
+            margin="none"
           >
-            <div
-              className="euiEmptyPrompt"
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <NoMatchMessage
+            size="xl"
+          >
+            <EuiSpacer
+              size="xl"
             >
-              <EuiTitle
-                size="m"
-              >
-                <h2
-                  className="euiTitle euiTitle--medium"
-                >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiEmptyPrompt
+              body={
+                <EuiText>
+                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                </EuiText>
+              }
+              title={
+                <h2>
                   No matches
                 </h2>
-              </EuiTitle>
-              <EuiTextColor
-                color="subdued"
+              }
+            >
+              <div
+                className="euiEmptyPrompt"
               >
-                <span
-                  className="euiTextColor euiTextColor--subdued"
+                <EuiTitle
+                  size="m"
                 >
-                  <EuiSpacer
-                    size="m"
+                  <h2
+                    className="euiTitle euiTitle--medium"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
+                    No matches
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
                     >
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                        </div>
-                      </EuiText>
-                    </div>
-                  </EuiText>
-                </span>
-              </EuiTextColor>
-            </div>
-          </EuiEmptyPrompt>
-          <EuiSpacer
-            size="xl"
-          >
-            <div
-              className="euiSpacer euiSpacer--xl"
-            />
-          </EuiSpacer>
-        </NoMatchMessage>
-      </div>
-    </EuiPanel>
-  </div>
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+              </div>
+            </EuiEmptyPrompt>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+          </NoMatchMessage>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </ServicesTable>
 `;
 
@@ -504,227 +504,138 @@ exports[`Services table component renders jaeger services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
+              <EuiFlexItem
+                grow={false}
               >
-                <PanelTitle
-                  title="Services"
-                  totalItems={1}
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiText
-                    size="m"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={1}
                   >
-                    <div
-                      className="euiText euiText--medium"
+                    <EuiText
+                      size="m"
                     >
-                      <span
-                        className="panel-title"
-                      >
-                        Services
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (1)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <EuiFlexGroup>
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                  >
-                    <EuiFlexItem>
                       <div
-                        className="euiFlexItem"
+                        className="euiText euiText--medium"
                       >
-                        <EuiToolTip
-                          content="Select services to filter"
-                          delay="regular"
-                          position="top"
+                        <span
+                          className="panel-title"
                         >
-                          <span
-                            className="euiToolTipAnchor"
-                            onKeyUp={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
                           >
-                            <EuiButtonEmpty
-                              isDisabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              size="xs"
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                disabled={true}
+                              <EuiButtonEmpty
+                                isDisabled={true}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
-                                type="button"
+                                size="xs"
                               >
-                                <EuiButtonContent
-                                  className="euiButtonEmpty__content"
-                                  iconSide="left"
-                                  iconSize="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonEmpty__text",
-                                    }
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonEmpty__content"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButtonEmpty__text"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      Filter services
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonEmpty>
-                          </span>
-                        </EuiToolTip>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <EuiInMemoryTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "name",
-                "name": "Name",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "average_latency",
-                "name": "Average duration (ms)",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_rate",
-                "name": "Error rate",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "throughput",
-                "name": "Request rate",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "traces",
-                "name": "Traces",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "center",
-                "field": "actions",
-                "name": "Actions",
-                "render": [Function],
-              },
-            ]
-          }
-          isSelectable={true}
-          itemId="itemId"
-          items={
-            Array [
-              Object {
-                "average_latency": 49.54,
-                "error_rate": 3.77,
-                "name": "database",
-                "throughput": 53,
-                "traces": 31,
-              },
-            ]
-          }
-          loading={false}
-          pagination={
-            Object {
-              "initialPageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-            }
-          }
-          responsive={true}
-          selection={
-            Object {
-              "onSelectionChange": [Function],
-            }
-          }
-          sorting={
-            Object {
-              "sort": Object {
-                "direction": "asc",
-                "field": "name",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <EuiBasicTable
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
             columns={
               Array [
                 Object {
@@ -786,19 +697,14 @@ exports[`Services table component renders jaeger services table 1`] = `
               ]
             }
             loading={false}
-            noItemsMessage="No items found"
-            onChange={[Function]}
             pagination={
               Object {
-                "hidePerPageOptions": undefined,
-                "pageIndex": 0,
-                "pageSize": 10,
+                "initialPageSize": 10,
                 "pageSizeOptions": Array [
                   5,
                   10,
                   15,
                 ],
-                "totalItemCount": 1,
               }
             }
             responsive={true}
@@ -809,156 +715,223 @@ exports[`Services table component renders jaeger services table 1`] = `
             }
             sorting={
               Object {
-                "allowNeutralSort": true,
                 "sort": Object {
                   "direction": "asc",
-                  "field": "Name",
+                  "field": "name",
                 },
               }
             }
             tableLayout="auto"
           >
-            <div
-              className="euiBasicTable"
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "name",
+                    "name": "Name",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "average_latency",
+                    "name": "Average duration (ms)",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_rate",
+                    "name": "Error rate",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "throughput",
+                    "name": "Request rate",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "traces",
+                    "name": "Traces",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "center",
+                    "field": "actions",
+                    "name": "Actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              isSelectable={true}
+              itemId="itemId"
+              items={
+                Array [
+                  Object {
+                    "average_latency": 49.54,
+                    "error_rate": 3.77,
+                    "name": "database",
+                    "throughput": 53,
+                    "traces": 31,
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              selection={
+                Object {
+                  "onSelectionChange": [Function],
+                }
+              }
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Name",
+                  },
+                }
+              }
+              tableLayout="auto"
             >
-              <div>
-                <EuiTableHeaderMobile>
-                  <div
-                    className="euiTableHeaderMobile"
-                  >
-                    <EuiFlexGroup
-                      alignItems="baseline"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
                     >
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiI18n
-                              default="Select all rows"
-                              token="euiBasicTable.selectAllRows"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiCheckbox
-                                aria-label="Select all rows"
-                                checked={false}
-                                compressed={false}
-                                disabled={false}
-                                id="_selection_column-checkbox_random_html_id"
-                                indeterminate={false}
-                                label="Select all rows"
-                                onChange={[Function]}
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
+                              >
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label="Select all rows"
+                                  onChange={[Function]}
+                                >
+                                  <div
+                                    className="euiCheckbox"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                    <label
+                                      className="euiCheckbox__label"
+                                      htmlFor="_selection_column-checkbox_random_html_id"
+                                    >
+                                      Select all rows
+                                    </label>
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_name_0",
+                                      "name": "Name",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_average_latency_1",
+                                      "name": "Average duration (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_rate_2",
+                                      "name": "Error rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_throughput_3",
+                                      "name": "Request rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_traces_4",
+                                      "name": "Traces",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
                               >
                                 <div
-                                  className="euiCheckbox"
+                                  className="euiTableSortMobile"
                                 >
-                                  <input
-                                    aria-label="Select all rows"
-                                    checked={false}
-                                    className="euiCheckbox__input"
-                                    disabled={false}
-                                    id="_selection_column-checkbox_random_html_id"
-                                    onChange={[Function]}
-                                    type="checkbox"
-                                  />
-                                  <div
-                                    className="euiCheckbox__square"
-                                  />
-                                  <label
-                                    className="euiCheckbox__label"
-                                    htmlFor="_selection_column-checkbox_random_html_id"
-                                  >
-                                    Select all rows
-                                  </label>
-                                </div>
-                              </EuiCheckbox>
-                            </EuiI18n>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiTableSortMobile
-                              items={
-                                Array [
-                                  Object {
-                                    "isSortAscending": true,
-                                    "isSorted": true,
-                                    "key": "_data_s_name_0",
-                                    "name": "Name",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_average_latency_1",
-                                    "name": "Average duration (ms)",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_error_rate_2",
-                                    "name": "Error rate",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_throughput_3",
-                                    "name": "Request rate",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_traces_4",
-                                    "name": "Traces",
-                                    "onSort": [Function],
-                                  },
-                                ]
-                              }
-                            >
-                              <div
-                                className="euiTableSortMobile"
-                              >
-                                <EuiPopover
-                                  anchorPosition="downRight"
-                                  button={
-                                    <EuiButtonEmpty
-                                      flush="right"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      onClick={[Function]}
-                                      size="xs"
-                                    >
-                                      <EuiI18n
-                                        default="Sorting"
-                                        token="euiTableSortMobile.sorting"
-                                      />
-                                    </EuiButtonEmpty>
-                                  }
-                                  closePopover={[Function]}
-                                  display="inlineBlock"
-                                  hasArrow={true}
-                                  isOpen={false}
-                                  ownFocus={true}
-                                  panelPaddingSize="none"
-                                >
-                                  <div
-                                    className="euiPopover euiPopover--anchorDownRight"
-                                  >
-                                    <div
-                                      className="euiPopover__anchor"
-                                    >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
                                       <EuiButtonEmpty
                                         flush="right"
                                         iconSide="right"
@@ -966,575 +939,172 @@ exports[`Services table component renders jaeger services table 1`] = `
                                         onClick={[Function]}
                                         size="xs"
                                       >
-                                        <button
-                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                          disabled={false}
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
                                           onClick={[Function]}
-                                          type="button"
+                                          size="xs"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButtonEmpty__content"
-                                            iconSide="right"
-                                            iconSize="s"
-                                            iconType="arrowDown"
-                                            textProps={
-                                              Object {
-                                                "className": "euiButtonEmpty__text",
-                                              }
-                                            }
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
                                             >
-                                              <EuiIcon
-                                                className="euiButtonContent__icon"
-                                                color="inherit"
-                                                size="s"
-                                                type="arrowDown"
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                               >
-                                                <EuiIconArrowDown
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
                                                 >
-                                                  <svg
+                                                  <EuiIconArrowDown
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                      fillRule="non-zero"
-                                                    />
-                                                  </svg>
-                                                </EuiIconArrowDown>
-                                              </EuiIcon>
-                                              <span
-                                                className="euiButtonEmpty__text"
-                                              >
-                                                <EuiI18n
-                                                  default="Sorting"
-                                                  token="euiTableSortMobile.sorting"
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                        fillRule="non-zero"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconArrowDown>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
                                                 >
-                                                  Sorting
-                                                </EuiI18n>
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonEmpty>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
                                     </div>
-                                  </div>
-                                </EuiPopover>
-                              </div>
-                            </EuiTableSortMobile>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiTableHeaderMobile>
-                <EuiTable
-                  id="random_html_id"
-                  responsive={true}
-                  tableLayout="auto"
-                >
-                  <table
-                    className="euiTable euiTable--responsive euiTable--auto"
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
                     id="random_html_id"
-                    tabIndex={-1}
+                    responsive={true}
+                    tableLayout="auto"
                   >
-                    <EuiScreenReaderOnly>
-                      <caption
-                        className="euiScreenReaderOnly euiTableCaption"
-                      >
-                        <EuiDelayRender
-                          delay={500}
-                        />
-                      </caption>
-                    </EuiScreenReaderOnly>
-                    <EuiTableHeader>
-                      <thead>
-                        <tr>
-                          <EuiTableHeaderCellCheckbox
-                            key="_selection_column_h"
-                          >
-                            <th
-                              className="euiTableHeaderCellCheckbox"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableCellContent"
-                              >
-                                <EuiI18n
-                                  default="Select all rows"
-                                  token="euiBasicTable.selectAllRows"
-                                >
-                                  <EuiCheckbox
-                                    aria-label="Select all rows"
-                                    checked={false}
-                                    compressed={false}
-                                    data-test-subj="checkboxSelectAll"
-                                    disabled={false}
-                                    id="_selection_column-checkbox_random_html_id"
-                                    indeterminate={false}
-                                    label={null}
-                                    onChange={[Function]}
-                                    type="inList"
-                                  >
-                                    <div
-                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                    >
-                                      <input
-                                        aria-label="Select all rows"
-                                        checked={false}
-                                        className="euiCheckbox__input"
-                                        data-test-subj="checkboxSelectAll"
-                                        disabled={false}
-                                        id="_selection_column-checkbox_random_html_id"
-                                        onChange={[Function]}
-                                        type="checkbox"
-                                      />
-                                      <div
-                                        className="euiCheckbox__square"
-                                      />
-                                    </div>
-                                  </EuiCheckbox>
-                                </EuiI18n>
-                              </div>
-                            </th>
-                          </EuiTableHeaderCellCheckbox>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_name_0"
-                            isSortAscending={true}
-                            isSorted={true}
-                            key="_data_h_name_0"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="ascending"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_name_0"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSortAscending={true}
-                                  isSorted={true}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Name",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Name"
-                                        >
-                                          Name
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                    <EuiIcon
-                                      className="euiTableSortIcon"
-                                      size="m"
-                                      type="sortUp"
-                                    >
-                                      <EuiIconSortUp
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiTableSortIcon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiTableSortIcon"
-                                          focusable="false"
-                                          height={16}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                          />
-                                        </svg>
-                                      </EuiIconSortUp>
-                                    </EuiIcon>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_average_latency_1"
-                            isSorted={false}
-                            key="_data_h_average_latency_1"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_average_latency_1"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Average duration (ms)",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Average duration (ms)"
-                                        >
-                                          Average duration (ms)
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_error_rate_2"
-                            isSorted={false}
-                            key="_data_h_error_rate_2"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_error_rate_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Error rate",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Error rate"
-                                        >
-                                          Error rate
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_throughput_3"
-                            isSorted={false}
-                            key="_data_h_throughput_3"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_throughput_3"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Request rate",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Request rate"
-                                        >
-                                          Request rate
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_traces_4"
-                            isSorted={false}
-                            key="_data_h_traces_4"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_traces_4"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Traces",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Traces"
-                                        >
-                                          Traces
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="center"
-                            data-test-subj="tableHeaderCell_actions_5"
-                            key="_data_h_actions_5"
-                          >
-                            <th
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_actions_5"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignCenter"
-                                showSortMsg={false}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignCenter"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Actions",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Actions"
-                                      >
-                                        Actions
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </th>
-                          </EuiTableHeaderCell>
-                        </tr>
-                      </thead>
-                    </EuiTableHeader>
-                    <EuiTableBody
-                      bodyRef={[Function]}
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
                     >
-                      <tbody>
-                        <EuiTableRow
-                          isSelectable={true}
-                          isSelected={false}
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
                         >
-                          <tr
-                            className="euiTableRow euiTableRow-isSelectable"
-                          >
-                            <EuiTableRowCellCheckbox
-                              key="_selection_column_0"
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCellCheckbox
+                              key="_selection_column_h"
                             >
-                              <td
-                                className="euiTableRowCellCheckbox"
+                              <th
+                                className="euiTableHeaderCellCheckbox"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
                                 <div
                                   className="euiTableCellContent"
                                 >
                                   <EuiI18n
-                                    default="Select this row"
-                                    token="euiBasicTable.selectThisRow"
+                                    default="Select all rows"
+                                    token="euiBasicTable.selectAllRows"
                                   >
                                     <EuiCheckbox
-                                      aria-label="Select this row"
+                                      aria-label="Select all rows"
                                       checked={false}
                                       compressed={false}
-                                      data-test-subj="checkboxSelectRow-0"
+                                      data-test-subj="checkboxSelectAll"
                                       disabled={false}
-                                      id="_selection_column_0-checkbox"
+                                      id="_selection_column-checkbox_random_html_id"
                                       indeterminate={false}
+                                      label={null}
                                       onChange={[Function]}
-                                      title="Select this row"
                                       type="inList"
                                     >
                                       <div
                                         className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
                                       >
                                         <input
-                                          aria-label="Select this row"
+                                          aria-label="Select all rows"
                                           checked={false}
                                           className="euiCheckbox__input"
-                                          data-test-subj="checkboxSelectRow-0"
+                                          data-test-subj="checkboxSelectAll"
                                           disabled={false}
-                                          id="_selection_column_0-checkbox"
+                                          id="_selection_column-checkbox_random_html_id"
                                           onChange={[Function]}
-                                          title="Select this row"
                                           type="checkbox"
                                         />
                                         <div
@@ -1544,558 +1114,958 @@ exports[`Services table component renders jaeger services table 1`] = `
                                     </EuiCheckbox>
                                   </EuiI18n>
                                 </div>
-                              </td>
-                            </EuiTableRowCellCheckbox>
-                            <EuiTableRowCell
+                              </th>
+                            </EuiTableHeaderCellCheckbox>
+                            <EuiTableHeaderCell
                               align="left"
-                              key="_data_column_name_0_0"
-                              mobileOptions={
-                                Object {
-                                  "header": "Name",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
+                              data-test-subj="tableHeaderCell_name_0"
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_name_0"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_name_0"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Name
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiLink
-                                    className=""
-                                    data-test-subj="service-link"
-                                    key=".0"
-                                    onClick={[Function]}
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
                                   >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      data-test-subj="service-link"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <span
+                                      className="euiTableCellContent"
                                     >
-                                      database
-                                    </button>
-                                  </EuiLink>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_average_latency_0_1"
-                              mobileOptions={
-                                Object {
-                                  "header": "Average duration (ms)",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                >
-                                  Average duration (ms)
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  <ServiceTrendsPlots
-                                    className=""
-                                    fieldType="average_latency"
-                                    item={49.54}
-                                    key=".0"
-                                    row={
-                                      Object {
-                                        "average_latency": 49.54,
-                                        "error_rate": 3.77,
-                                        "name": "database",
-                                        "throughput": 53,
-                                        "traces": 31,
-                                      }
-                                    }
-                                  >
-                                    <EuiFlexGroup
-                                      gutterSize="s"
-                                      justifyContent="flexEnd"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Name",
+                                            }
+                                          }
                                         >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Name"
                                           >
-                                            <EuiText
-                                              color="default"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <div
-                                                className="euiText euiText--medium"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <EuiTextColor
-                                                  color="default"
-                                                  component="div"
-                                                >
-                                                  <div
-                                                    className="euiTextColor euiTextColor--default"
-                                                  >
-                                                    49.54
-                                                  </div>
-                                                </EuiTextColor>
-                                              </div>
-                                            </EuiText>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </ServiceTrendsPlots>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_error_rate_0_2"
-                              mobileOptions={
-                                Object {
-                                  "header": "Error rate",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                >
-                                  Error rate
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  <ServiceTrendsPlots
-                                    className=""
-                                    fieldType="error_rate"
-                                    item={3.77}
-                                    key=".0"
-                                    row={
-                                      Object {
-                                        "average_latency": 49.54,
-                                        "error_rate": 3.77,
-                                        "name": "database",
-                                        "throughput": 53,
-                                        "traces": 31,
-                                      }
-                                    }
-                                  >
-                                    <EuiFlexGroup
-                                      gutterSize="s"
-                                      justifyContent="flexEnd"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                            Name
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
                                       >
-                                        <EuiFlexItem
-                                          grow={false}
+                                        <EuiIconSortUp
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
                                         >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <EuiText
-                                              color="default"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <div
-                                                className="euiText euiText--medium"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <EuiTextColor
-                                                  color="default"
-                                                  component="div"
-                                                >
-                                                  <div
-                                                    className="euiTextColor euiTextColor--default"
-                                                  >
-                                                    <EuiText
-                                                      size="s"
-                                                    >
-                                                      <div
-                                                        className="euiText euiText--small"
-                                                      >
-                                                        3.77%
-                                                      </div>
-                                                    </EuiText>
-                                                  </div>
-                                                </EuiTextColor>
-                                              </div>
-                                            </EuiText>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </ServiceTrendsPlots>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                            <path
+                                              d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSortUp>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="right"
-                              key="_data_column_throughput_0_3"
-                              mobileOptions={
-                                Object {
-                                  "header": "Request rate",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              data-test-subj="tableHeaderCell_average_latency_1"
+                              isSorted={false}
+                              key="_data_h_average_latency_1"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_average_latency_1"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Request rate
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <ServiceTrendsPlots
-                                    className=""
-                                    fieldType="throughput"
-                                    item={53}
-                                    key=".0"
-                                    row={
-                                      Object {
-                                        "average_latency": 49.54,
-                                        "error_rate": 3.77,
-                                        "name": "database",
-                                        "throughput": 53,
-                                        "traces": 31,
-                                      }
-                                    }
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <EuiFlexGroup
-                                      gutterSize="s"
-                                      justifyContent="flexEnd"
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
                                     >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Average duration (ms)",
+                                            }
+                                          }
                                         >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Average duration (ms)"
                                           >
-                                            <EuiText
-                                              color="default"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <div
-                                                className="euiText euiText--medium"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <EuiTextColor
-                                                  color="default"
-                                                  component="div"
-                                                >
-                                                  <div
-                                                    className="euiTextColor euiTextColor--default"
-                                                  >
-                                                    <EuiI18nNumber
-                                                      value={53}
-                                                    >
-                                                      53
-                                                    </EuiI18nNumber>
-                                                  </div>
-                                                </EuiTextColor>
-                                              </div>
-                                            </EuiText>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </ServiceTrendsPlots>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                            Average duration (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="right"
-                              key="_data_column_traces_0_4"
-                              mobileOptions={
-                                Object {
-                                  "header": "Traces",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              data-test-subj="tableHeaderCell_error_rate_2"
+                              isSorted={false}
+                              key="_data_h_error_rate_2"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_rate_2"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Traces
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiLink
-                                    onClick={[Function]}
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
                                     >
-                                      <EuiI18nNumber
-                                        value={31}
-                                      >
-                                        31
-                                      </EuiI18nNumber>
-                                    </button>
-                                  </EuiLink>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Error rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Error rate"
+                                          >
+                                            Error rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_throughput_3"
+                              isSorted={false}
+                              key="_data_h_throughput_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_throughput_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Request rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Request rate"
+                                          >
+                                            Request rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_traces_4"
+                              isSorted={false}
+                              key="_data_h_traces_4"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_traces_4"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Traces",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Traces"
+                                          >
+                                            Traces
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="center"
-                              key="_data_column_actions_0_5"
-                              mobileOptions={
-                                Object {
-                                  "header": "Actions",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
+                              data-test-subj="tableHeaderCell_actions_5"
+                              key="_data_h_actions_5"
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_actions_5"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                  showSortMsg={false}
                                 >
-                                  Actions
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiFlexGroup
-                                    className=""
-                                    justifyContent="center"
-                                    key=".0"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignCenter"
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Actions",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Actions"
+                                        >
+                                          Actions
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelectable={true}
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow euiTableRow-isSelectable"
+                            >
+                              <EuiTableRowCellCheckbox
+                                key="_selection_column_0"
+                              >
+                                <td
+                                  className="euiTableRowCellCheckbox"
+                                >
+                                  <div
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiI18n
+                                      default="Select this row"
+                                      token="euiBasicTable.selectThisRow"
                                     >
-                                      <EuiFlexItem
-                                        grow={false}
-                                        onClick={[Function]}
+                                      <EuiCheckbox
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        compressed={false}
+                                        data-test-subj="checkboxSelectRow-0"
+                                        disabled={false}
+                                        id="_selection_column_0-checkbox"
+                                        indeterminate={false}
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="inList"
                                       >
                                         <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                        >
+                                          <input
+                                            aria-label="Select this row"
+                                            checked={false}
+                                            className="euiCheckbox__input"
+                                            data-test-subj="checkboxSelectRow-0"
+                                            disabled={false}
+                                            id="_selection_column_0-checkbox"
+                                            onChange={[Function]}
+                                            title="Select this row"
+                                            type="checkbox"
+                                          />
+                                          <div
+                                            className="euiCheckbox__square"
+                                          />
+                                        </div>
+                                      </EuiCheckbox>
+                                    </EuiI18n>
+                                  </div>
+                                </td>
+                              </EuiTableRowCellCheckbox>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_name_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Name",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Name
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      className=""
+                                      data-test-subj="service-link"
+                                      key=".0"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        data-test-subj="service-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        database
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_average_latency_0_1"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Average duration (ms)",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Average duration (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="average_latency"
+                                      item={49.54}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      49.54
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_rate_0_2"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Error rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Error rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="error_rate"
+                                      item={3.77}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiText
+                                                        size="s"
+                                                      >
+                                                        <div
+                                                          className="euiText euiText--small"
+                                                        >
+                                                          3.77%
+                                                        </div>
+                                                      </EuiText>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_throughput_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Request rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Request rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="throughput"
+                                      item={53}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiI18nNumber
+                                                        value={53}
+                                                      >
+                                                        53
+                                                      </EuiI18nNumber>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_traces_0_4"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Traces",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Traces
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiI18nNumber
+                                          value={31}
+                                        >
+                                          31
+                                        </EuiI18nNumber>
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="center"
+                                key="_data_column_actions_0_5"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Actions",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Actions
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      className=""
+                                      justifyContent="center"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
                                           onClick={[Function]}
                                         >
-                                          <EuiLink
-                                            data-test-subj="service-flyout-action-btnundefined"
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            onClick={[Function]}
                                           >
-                                            <button
-                                              className="euiLink euiLink--primary"
+                                            <EuiLink
                                               data-test-subj="service-flyout-action-btnundefined"
-                                              disabled={false}
-                                              type="button"
                                             >
-                                              <EuiIcon
-                                                color="primary"
-                                                type="inspect"
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                data-test-subj="service-flyout-action-btnundefined"
+                                                disabled={false}
+                                                type="button"
                                               >
-                                                <EuiIconInspect
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon--primary"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  color="primary"
+                                                  type="inspect"
                                                 >
-                                                  <svg
+                                                  <EuiIconInspect
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--medium euiIcon--primary"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconInspect>
-                                              </EuiIcon>
-                                            </button>
-                                          </EuiLink>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                          </tr>
-                        </EuiTableRow>
-                      </tbody>
-                    </EuiTableBody>
-                  </table>
-                </EuiTable>
-              </div>
-              <PaginationBar
-                aria-controls="random_html_id"
-                onPageChange={[Function]}
-                onPageSizeChange={[Function]}
-                pagination={
-                  Object {
-                    "hidePerPageOptions": undefined,
-                    "pageIndex": 0,
-                    "pageSize": 10,
-                    "pageSizeOptions": Array [
-                      5,
-                      10,
-                      15,
-                    ],
-                    "totalItemCount": 1,
-                  }
-                }
-              >
-                <div>
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiTablePagination
-                    activePage={0}
-                    aria-controls="random_html_id"
-                    itemsPerPage={10}
-                    itemsPerPageOptions={
-                      Array [
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--primary"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconInspect>
+                                                </EuiIcon>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
                         5,
                         10,
                         15,
-                      ]
+                      ],
+                      "totalItemCount": 1,
                     }
-                    onChangeItemsPerPage={[Function]}
-                    onChangePage={[Function]}
-                    pageCount={1}
-                  >
-                    <EuiFlexGroup
-                      alignItems="center"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiPopover
-                              anchorPosition="upRight"
-                              button={
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
-                                >
-                                  <EuiI18n
-                                    default="Rows per page"
-                                    token="euiTablePagination.rowsPerPage"
-                                  />
-                                  : 
-                                  10
-                                </EuiButtonEmpty>
-                              }
-                              closePopover={[Function]}
-                              display="inlineBlock"
-                              hasArrow={true}
-                              isOpen={false}
-                              ownFocus={true}
-                              panelPaddingSize="none"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiPopover euiPopover--anchorUpRight"
-                              >
-                                <div
-                                  className="euiPopover__anchor"
-                                >
+                              <EuiPopover
+                                anchorPosition="upRight"
+                                button={
                                   <EuiButtonEmpty
                                     color="text"
                                     data-test-subj="tablePaginationPopoverButton"
@@ -2104,43 +2074,169 @@ exports[`Services table component renders jaeger services table 1`] = `
                                     onClick={[Function]}
                                     size="xs"
                                   >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    <EuiI18n
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
+                                    />
+                                    : 
+                                    10
+                                  </EuiButtonEmpty>
+                                }
+                                closePopover={[Function]}
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorUpRight"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonEmpty
+                                      color="text"
                                       data-test-subj="tablePaginationPopoverButton"
-                                      disabled={false}
+                                      iconSide="right"
+                                      iconType="arrowDown"
                                       onClick={[Function]}
-                                      type="button"
+                                      size="xs"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="right"
-                                        iconSize="s"
-                                        iconType="arrowDown"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
+                                      <button
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        <EuiButtonContent
+                                          className="euiButtonEmpty__content"
+                                          iconSide="right"
+                                          iconSize="s"
+                                          iconType="arrowDown"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          >
+                                            <EuiIcon
+                                              className="euiButtonContent__icon"
+                                              color="inherit"
+                                              size="s"
+                                              type="arrowDown"
+                                            >
+                                              <EuiIconArrowDown
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                focusable="false"
+                                                role="img"
+                                                style={null}
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                  focusable="false"
+                                                  height={16}
+                                                  role="img"
+                                                  style={null}
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                    fillRule="non-zero"
+                                                  />
+                                                </svg>
+                                              </EuiIconArrowDown>
+                                            </EuiIcon>
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              <EuiI18n
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
+                                              >
+                                                Rows per page
+                                              </EuiI18n>
+                                              : 
+                                              10
+                                            </span>
+                                          </span>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonEmpty>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
+                              >
+                                <nav
+                                  className="euiPagination"
+                                >
+                                  <EuiI18n
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
+                                    values={
+                                      Object {
+                                        "page": 0,
+                                      }
+                                    }
+                                  >
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
                                           <EuiIcon
-                                            className="euiButtonContent__icon"
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
                                             color="inherit"
-                                            size="s"
-                                            type="arrowDown"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
-                                            <EuiIconArrowDown
+                                            <EuiIconArrowLeft
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
                                               role="img"
                                               style={null}
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                                 focusable="false"
                                                 height={16}
                                                 role="img"
@@ -2150,280 +2246,184 @@ exports[`Services table component renders jaeger services table 1`] = `
                                                 xmlns="http://www.w3.org/2000/svg"
                                               >
                                                 <path
-                                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                  fillRule="non-zero"
+                                                  d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                                  fillRule="nonzero"
                                                 />
                                               </svg>
-                                            </EuiIconArrowDown>
+                                            </EuiIconArrowLeft>
                                           </EuiIcon>
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            <EuiI18n
-                                              default="Rows per page"
-                                              token="euiTablePagination.rowsPerPage"
-                                            >
-                                              Rows per page
-                                            </EuiI18n>
-                                            : 
-                                            10
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </div>
-                              </div>
-                            </EuiPopover>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiPagination
-                              activePage={0}
-                              aria-controls="random_html_id"
-                              onPageClick={[Function]}
-                              pageCount={1}
-                            >
-                              <nav
-                                className="euiPagination"
-                              >
-                                <EuiI18n
-                                  default="Previous page, {page}"
-                                  token="euiPagination.previousPage"
-                                  values={
-                                    Object {
-                                      "page": 0,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Previous page"
-                                    token="euiPagination.disabledPreviousPage"
-                                  >
-                                    <EuiButtonIcon
-                                      aria-label="Previous page"
-                                      color="text"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      iconType="arrowLeft"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        aria-label="Previous page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowLeft"
-                                        >
-                                          <EuiIconArrowLeft
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              height={16}
-                                              role="img"
-                                              style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                                fillRule="nonzero"
-                                              />
-                                            </svg>
-                                          </EuiIconArrowLeft>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                                <ul
-                                  className="euiPagination__list"
-                                >
-                                  <PaginationButton
-                                    key="0"
-                                    pageIndex={0}
+                                  <ul
+                                    className="euiPagination__list"
                                   >
-                                    <li
-                                      className="euiPagination__item"
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
                                     >
-                                      <EuiPaginationButton
-                                        aria-controls="random_html_id"
-                                        hideOnMobile={true}
-                                        isActive={true}
-                                        onClick={[Function]}
-                                        pageIndex={0}
-                                        totalPages={1}
+                                      <li
+                                        className="euiPagination__item"
                                       >
-                                        <EuiI18n
-                                          default="Page {page} of {totalPages}"
-                                          token="euiPaginationButton.longPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
-                                              "totalPages": 1,
-                                            }
-                                          }
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Page {page}"
-                                            token="euiPaginationButton.shortPageString"
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
                                             values={
                                               Object {
                                                 "page": 1,
+                                                "totalPages": 1,
                                               }
                                             }
                                           >
-                                            <EuiButtonEmpty
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              color="text"
-                                              data-test-subj="pagination-button-0"
-                                              href="#random_html_id"
-                                              isDisabled={true}
-                                              onClick={[Function]}
-                                              size="s"
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
+                                                }
+                                              }
                                             >
-                                              <button
+                                              <EuiButtonEmpty
                                                 aria-controls="random_html_id"
                                                 aria-current={true}
                                                 aria-label="Page 1 of 1"
-                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
                                                 data-test-subj="pagination-button-0"
-                                                disabled={true}
+                                                href="#random_html_id"
+                                                isDisabled={true}
                                                 onClick={[Function]}
-                                                type="button"
+                                                size="s"
                                               >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="left"
-                                                  iconSize="m"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text",
-                                                    }
-                                                  }
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonContent euiButtonEmpty__content"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
                                                     <span
-                                                      className="euiButtonEmpty__text"
+                                                      className="euiButtonContent euiButtonEmpty__content"
                                                     >
-                                                      1
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
                                                     </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
                                           </EuiI18n>
-                                        </EuiI18n>
-                                      </EuiPaginationButton>
-                                    </li>
-                                  </PaginationButton>
-                                </ul>
-                                <EuiI18n
-                                  default="Next page, {page}"
-                                  token="euiPagination.nextPage"
-                                  values={
-                                    Object {
-                                      "page": 2,
-                                    }
-                                  }
-                                >
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
                                   <EuiI18n
-                                    default="Next page"
-                                    token="euiPagination.disabledNextPage"
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <EuiButtonIcon
-                                      aria-label="Next page"
-                                      color="text"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      iconType="arrowRight"
-                                      onClick={[Function]}
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <button
+                                      <EuiButtonIcon
                                         aria-label="Next page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        color="text"
                                         data-test-subj="pagination-button-next"
                                         disabled={true}
+                                        iconType="arrowRight"
                                         onClick={[Function]}
-                                        type="button"
                                       >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowRight"
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <EuiIconArrowRight
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <svg
+                                            <EuiIconArrowRight
                                               aria-hidden={true}
                                               className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                                fillRule="nonzero"
-                                              />
-                                            </svg>
-                                          </EuiIconArrowRight>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                                  fillRule="nonzero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowRight>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                              </nav>
-                            </EuiPagination>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </EuiTablePagination>
-                </div>
-              </PaginationBar>
-            </div>
-          </EuiBasicTable>
-        </EuiInMemoryTable>
-      </div>
-    </EuiPanel>
-  </div>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
+              </div>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </ServicesTable>
 `;
 
@@ -2454,287 +2454,176 @@ exports[`Services table component renders services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          justifyContent="spaceBetween"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
+              <EuiFlexItem
+                grow={false}
               >
-                <PanelTitle
-                  title="Services"
-                  totalItems={1}
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiText
-                    size="m"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={1}
                   >
-                    <div
-                      className="euiText euiText--medium"
+                    <EuiText
+                      size="m"
                     >
-                      <span
-                        className="panel-title"
-                      >
-                        Services
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (1)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <EuiFlexGroup>
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                  >
-                    <EuiFlexItem>
                       <div
-                        className="euiFlexItem"
+                        className="euiText euiText--medium"
                       >
-                        <EuiToolTip
-                          content="Select services to filter"
-                          delay="regular"
-                          position="top"
+                        <span
+                          className="panel-title"
                         >
-                          <span
-                            className="euiToolTipAnchor"
-                            onKeyUp={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
                           >
-                            <EuiButtonEmpty
-                              isDisabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              size="xs"
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                             >
-                              <button
-                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                disabled={true}
+                              <EuiButtonEmpty
+                                isDisabled={true}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
-                                type="button"
+                                size="xs"
                               >
-                                <EuiButtonContent
-                                  className="euiButtonEmpty__content"
-                                  iconSide="left"
-                                  iconSize="s"
-                                  textProps={
-                                    Object {
-                                      "className": "euiButtonEmpty__text",
-                                    }
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
                                 >
-                                  <span
-                                    className="euiButtonContent euiButtonEmpty__content"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiButtonEmpty__text"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      Filter services
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
                                     </span>
-                                  </span>
-                                </EuiButtonContent>
-                              </button>
-                            </EuiButtonEmpty>
-                          </span>
-                        </EuiToolTip>
-                      </div>
-                    </EuiFlexItem>
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
+                          <EuiButtonEmpty
                             onClick={[Function]}
-                            type="button"
+                            size="xs"
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <button
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              disabled={false}
+                              onClick={[Function]}
+                              type="button"
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                              <EuiButtonContent
+                                className="euiButtonEmpty__content"
+                                iconSide="left"
+                                iconSize="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonEmpty__text",
+                                  }
+                                }
                               >
                                 <span
-                                  className="euiButtonEmpty__text"
+                                  className="euiButtonContent euiButtonEmpty__content"
                                 >
-                                  Show 24 hour trends
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    Show 24 hour trends
+                                  </span>
                                 </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <EuiInMemoryTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "name",
-                "name": "Name",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "average_latency",
-                "name": "Average duration (ms)",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_rate",
-                "name": "Error rate",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "throughput",
-                "name": "Request rate",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "number_of_connected_services",
-                "name": "No. of connected services",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-                "width": "80px",
-              },
-              Object {
-                "align": "left",
-                "field": "connected_services",
-                "name": "Connected services",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "traces",
-                "name": "Traces",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "center",
-                "field": "actions",
-                "name": "Actions",
-                "render": [Function],
-              },
-            ]
-          }
-          isSelectable={true}
-          itemId="itemId"
-          items={
-            Array [
-              Object {
-                "average_latency": 49.54,
-                "connected_services": Array [
-                  "order",
-                  "inventory",
-                ],
-                "error_rate": 3.77,
-                "name": "database",
-                "number_of_connected_services": 2,
-                "throughput": 53,
-                "traces": 31,
-              },
-            ]
-          }
-          loading={false}
-          pagination={
-            Object {
-              "initialPageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-            }
-          }
-          responsive={true}
-          selection={
-            Object {
-              "onSelectionChange": [Function],
-            }
-          }
-          sorting={
-            Object {
-              "sort": Object {
-                "direction": "asc",
-                "field": "name",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <EuiBasicTable
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonEmpty>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
             columns={
               Array [
                 Object {
@@ -2818,19 +2707,14 @@ exports[`Services table component renders services table 1`] = `
               ]
             }
             loading={false}
-            noItemsMessage="No items found"
-            onChange={[Function]}
             pagination={
               Object {
-                "hidePerPageOptions": undefined,
-                "pageIndex": 0,
-                "pageSize": 10,
+                "initialPageSize": 10,
                 "pageSizeOptions": Array [
                   5,
                   10,
                   15,
                 ],
-                "totalItemCount": 1,
               }
             }
             responsive={true}
@@ -2841,170 +2725,259 @@ exports[`Services table component renders services table 1`] = `
             }
             sorting={
               Object {
-                "allowNeutralSort": true,
                 "sort": Object {
                   "direction": "asc",
-                  "field": "Name",
+                  "field": "name",
                 },
               }
             }
             tableLayout="auto"
           >
-            <div
-              className="euiBasicTable"
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "name",
+                    "name": "Name",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "average_latency",
+                    "name": "Average duration (ms)",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_rate",
+                    "name": "Error rate",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "throughput",
+                    "name": "Request rate",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "number_of_connected_services",
+                    "name": "No. of connected services",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                    "width": "80px",
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "connected_services",
+                    "name": "Connected services",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "traces",
+                    "name": "Traces",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "center",
+                    "field": "actions",
+                    "name": "Actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              isSelectable={true}
+              itemId="itemId"
+              items={
+                Array [
+                  Object {
+                    "average_latency": 49.54,
+                    "connected_services": Array [
+                      "order",
+                      "inventory",
+                    ],
+                    "error_rate": 3.77,
+                    "name": "database",
+                    "number_of_connected_services": 2,
+                    "throughput": 53,
+                    "traces": 31,
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              selection={
+                Object {
+                  "onSelectionChange": [Function],
+                }
+              }
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Name",
+                  },
+                }
+              }
+              tableLayout="auto"
             >
-              <div>
-                <EuiTableHeaderMobile>
-                  <div
-                    className="euiTableHeaderMobile"
-                  >
-                    <EuiFlexGroup
-                      alignItems="baseline"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
                     >
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiI18n
-                              default="Select all rows"
-                              token="euiBasicTable.selectAllRows"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiCheckbox
-                                aria-label="Select all rows"
-                                checked={false}
-                                compressed={false}
-                                disabled={false}
-                                id="_selection_column-checkbox_random_html_id"
-                                indeterminate={false}
-                                label="Select all rows"
-                                onChange={[Function]}
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
+                              >
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label="Select all rows"
+                                  onChange={[Function]}
+                                >
+                                  <div
+                                    className="euiCheckbox"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                    <label
+                                      className="euiCheckbox__label"
+                                      htmlFor="_selection_column-checkbox_random_html_id"
+                                    >
+                                      Select all rows
+                                    </label>
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_name_0",
+                                      "name": "Name",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_average_latency_1",
+                                      "name": "Average duration (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_rate_2",
+                                      "name": "Error rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_throughput_3",
+                                      "name": "Request rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_number_of_connected_services_4",
+                                      "name": "No. of connected services",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_connected_services_5",
+                                      "name": "Connected services",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_traces_6",
+                                      "name": "Traces",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
                               >
                                 <div
-                                  className="euiCheckbox"
+                                  className="euiTableSortMobile"
                                 >
-                                  <input
-                                    aria-label="Select all rows"
-                                    checked={false}
-                                    className="euiCheckbox__input"
-                                    disabled={false}
-                                    id="_selection_column-checkbox_random_html_id"
-                                    onChange={[Function]}
-                                    type="checkbox"
-                                  />
-                                  <div
-                                    className="euiCheckbox__square"
-                                  />
-                                  <label
-                                    className="euiCheckbox__label"
-                                    htmlFor="_selection_column-checkbox_random_html_id"
-                                  >
-                                    Select all rows
-                                  </label>
-                                </div>
-                              </EuiCheckbox>
-                            </EuiI18n>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiTableSortMobile
-                              items={
-                                Array [
-                                  Object {
-                                    "isSortAscending": true,
-                                    "isSorted": true,
-                                    "key": "_data_s_name_0",
-                                    "name": "Name",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_average_latency_1",
-                                    "name": "Average duration (ms)",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_error_rate_2",
-                                    "name": "Error rate",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_throughput_3",
-                                    "name": "Request rate",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_number_of_connected_services_4",
-                                    "name": "No. of connected services",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_connected_services_5",
-                                    "name": "Connected services",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_traces_6",
-                                    "name": "Traces",
-                                    "onSort": [Function],
-                                  },
-                                ]
-                              }
-                            >
-                              <div
-                                className="euiTableSortMobile"
-                              >
-                                <EuiPopover
-                                  anchorPosition="downRight"
-                                  button={
-                                    <EuiButtonEmpty
-                                      flush="right"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      onClick={[Function]}
-                                      size="xs"
-                                    >
-                                      <EuiI18n
-                                        default="Sorting"
-                                        token="euiTableSortMobile.sorting"
-                                      />
-                                    </EuiButtonEmpty>
-                                  }
-                                  closePopover={[Function]}
-                                  display="inlineBlock"
-                                  hasArrow={true}
-                                  isOpen={false}
-                                  ownFocus={true}
-                                  panelPaddingSize="none"
-                                >
-                                  <div
-                                    className="euiPopover euiPopover--anchorDownRight"
-                                  >
-                                    <div
-                                      className="euiPopover__anchor"
-                                    >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
                                       <EuiButtonEmpty
                                         flush="right"
                                         iconSide="right"
@@ -3012,691 +2985,171 @@ exports[`Services table component renders services table 1`] = `
                                         onClick={[Function]}
                                         size="xs"
                                       >
-                                        <button
-                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                          disabled={false}
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
                                           onClick={[Function]}
-                                          type="button"
+                                          size="xs"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButtonEmpty__content"
-                                            iconSide="right"
-                                            iconSize="s"
-                                            iconType="arrowDown"
-                                            textProps={
-                                              Object {
-                                                "className": "euiButtonEmpty__text",
-                                              }
-                                            }
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
                                             >
-                                              <EuiIcon
-                                                className="euiButtonContent__icon"
-                                                color="inherit"
-                                                size="s"
-                                                type="arrowDown"
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                               >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
                                                 >
-                                                  <svg
+                                                  <EuiIconBeaker
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                              <span
-                                                className="euiButtonEmpty__text"
-                                              >
-                                                <EuiI18n
-                                                  default="Sorting"
-                                                  token="euiTableSortMobile.sorting"
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
                                                 >
-                                                  Sorting
-                                                </EuiI18n>
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonEmpty>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
                                     </div>
-                                  </div>
-                                </EuiPopover>
-                              </div>
-                            </EuiTableSortMobile>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiTableHeaderMobile>
-                <EuiTable
-                  id="random_html_id"
-                  responsive={true}
-                  tableLayout="auto"
-                >
-                  <table
-                    className="euiTable euiTable--responsive euiTable--auto"
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
                     id="random_html_id"
-                    tabIndex={-1}
+                    responsive={true}
+                    tableLayout="auto"
                   >
-                    <EuiScreenReaderOnly>
-                      <caption
-                        className="euiScreenReaderOnly euiTableCaption"
-                      >
-                        <EuiDelayRender
-                          delay={500}
-                        />
-                      </caption>
-                    </EuiScreenReaderOnly>
-                    <EuiTableHeader>
-                      <thead>
-                        <tr>
-                          <EuiTableHeaderCellCheckbox
-                            key="_selection_column_h"
-                          >
-                            <th
-                              className="euiTableHeaderCellCheckbox"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableCellContent"
-                              >
-                                <EuiI18n
-                                  default="Select all rows"
-                                  token="euiBasicTable.selectAllRows"
-                                >
-                                  <EuiCheckbox
-                                    aria-label="Select all rows"
-                                    checked={false}
-                                    compressed={false}
-                                    data-test-subj="checkboxSelectAll"
-                                    disabled={false}
-                                    id="_selection_column-checkbox_random_html_id"
-                                    indeterminate={false}
-                                    label={null}
-                                    onChange={[Function]}
-                                    type="inList"
-                                  >
-                                    <div
-                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                    >
-                                      <input
-                                        aria-label="Select all rows"
-                                        checked={false}
-                                        className="euiCheckbox__input"
-                                        data-test-subj="checkboxSelectAll"
-                                        disabled={false}
-                                        id="_selection_column-checkbox_random_html_id"
-                                        onChange={[Function]}
-                                        type="checkbox"
-                                      />
-                                      <div
-                                        className="euiCheckbox__square"
-                                      />
-                                    </div>
-                                  </EuiCheckbox>
-                                </EuiI18n>
-                              </div>
-                            </th>
-                          </EuiTableHeaderCellCheckbox>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_name_0"
-                            isSortAscending={true}
-                            isSorted={true}
-                            key="_data_h_name_0"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="ascending"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_name_0"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSortAscending={true}
-                                  isSorted={true}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Name",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Name"
-                                        >
-                                          Name
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                    <EuiIcon
-                                      className="euiTableSortIcon"
-                                      size="m"
-                                      type="sortUp"
-                                    >
-                                      <EuiIconBeaker
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                          focusable="false"
-                                          height={16}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                          />
-                                        </svg>
-                                      </EuiIconBeaker>
-                                    </EuiIcon>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_average_latency_1"
-                            isSorted={false}
-                            key="_data_h_average_latency_1"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_average_latency_1"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Average duration (ms)",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Average duration (ms)"
-                                        >
-                                          Average duration (ms)
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_error_rate_2"
-                            isSorted={false}
-                            key="_data_h_error_rate_2"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_error_rate_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Error rate",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Error rate"
-                                        >
-                                          Error rate
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_throughput_3"
-                            isSorted={false}
-                            key="_data_h_throughput_3"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_throughput_3"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Request rate",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Request rate"
-                                        >
-                                          Request rate
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                            isSorted={false}
-                            key="_data_h_number_of_connected_services_4"
-                            onSort={[Function]}
-                            width="80px"
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": "80px",
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "No. of connected services",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="No. of connected services"
-                                        >
-                                          No. of connected services
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_connected_services_5"
-                            isSorted={false}
-                            key="_data_h_connected_services_5"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_connected_services_5"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Connected services",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Connected services"
-                                        >
-                                          Connected services
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_traces_6"
-                            isSorted={false}
-                            key="_data_h_traces_6"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_traces_6"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Traces",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Traces"
-                                        >
-                                          Traces
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="center"
-                            data-test-subj="tableHeaderCell_actions_7"
-                            key="_data_h_actions_7"
-                          >
-                            <th
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_actions_7"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignCenter"
-                                showSortMsg={false}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignCenter"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Actions",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Actions"
-                                      >
-                                        Actions
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </th>
-                          </EuiTableHeaderCell>
-                        </tr>
-                      </thead>
-                    </EuiTableHeader>
-                    <EuiTableBody
-                      bodyRef={[Function]}
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
                     >
-                      <tbody>
-                        <EuiTableRow
-                          isSelectable={true}
-                          isSelected={false}
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
                         >
-                          <tr
-                            className="euiTableRow euiTableRow-isSelectable"
-                          >
-                            <EuiTableRowCellCheckbox
-                              key="_selection_column_0"
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCellCheckbox
+                              key="_selection_column_h"
                             >
-                              <td
-                                className="euiTableRowCellCheckbox"
+                              <th
+                                className="euiTableHeaderCellCheckbox"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
                                 <div
                                   className="euiTableCellContent"
                                 >
                                   <EuiI18n
-                                    default="Select this row"
-                                    token="euiBasicTable.selectThisRow"
+                                    default="Select all rows"
+                                    token="euiBasicTable.selectAllRows"
                                   >
                                     <EuiCheckbox
-                                      aria-label="Select this row"
+                                      aria-label="Select all rows"
                                       checked={false}
                                       compressed={false}
-                                      data-test-subj="checkboxSelectRow-0"
+                                      data-test-subj="checkboxSelectAll"
                                       disabled={false}
-                                      id="_selection_column_0-checkbox"
+                                      id="_selection_column-checkbox_random_html_id"
                                       indeterminate={false}
+                                      label={null}
                                       onChange={[Function]}
-                                      title="Select this row"
                                       type="inList"
                                     >
                                       <div
                                         className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
                                       >
                                         <input
-                                          aria-label="Select this row"
+                                          aria-label="Select all rows"
                                           checked={false}
                                           className="euiCheckbox__input"
-                                          data-test-subj="checkboxSelectRow-0"
+                                          data-test-subj="checkboxSelectAll"
                                           disabled={false}
-                                          id="_selection_column_0-checkbox"
+                                          id="_selection_column-checkbox_random_html_id"
                                           onChange={[Function]}
-                                          title="Select this row"
                                           type="checkbox"
                                         />
                                         <div
@@ -3706,650 +3159,1167 @@ exports[`Services table component renders services table 1`] = `
                                     </EuiCheckbox>
                                   </EuiI18n>
                                 </div>
-                              </td>
-                            </EuiTableRowCellCheckbox>
-                            <EuiTableRowCell
+                              </th>
+                            </EuiTableHeaderCellCheckbox>
+                            <EuiTableHeaderCell
                               align="left"
-                              key="_data_column_name_0_0"
-                              mobileOptions={
-                                Object {
-                                  "header": "Name",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
+                              data-test-subj="tableHeaderCell_name_0"
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_name_0"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_name_0"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Name
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiLink
-                                    className=""
-                                    data-test-subj="service-link"
-                                    key=".0"
-                                    onClick={[Function]}
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
                                   >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      data-test-subj="service-link"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <span
+                                      className="euiTableCellContent"
                                     >
-                                      database
-                                    </button>
-                                  </EuiLink>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_average_latency_0_1"
-                              mobileOptions={
-                                Object {
-                                  "header": "Average duration (ms)",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                >
-                                  Average duration (ms)
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  <ServiceTrendsPlots
-                                    className=""
-                                    fieldType="average_latency"
-                                    item={49.54}
-                                    key=".0"
-                                    row={
-                                      Object {
-                                        "average_latency": 49.54,
-                                        "connected_services": Array [
-                                          "order",
-                                          "inventory",
-                                        ],
-                                        "error_rate": 3.77,
-                                        "name": "database",
-                                        "number_of_connected_services": 2,
-                                        "throughput": 53,
-                                        "traces": 31,
-                                      }
-                                    }
-                                  >
-                                    <EuiFlexGroup
-                                      gutterSize="s"
-                                      justifyContent="flexEnd"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Name",
+                                            }
+                                          }
                                         >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Name"
                                           >
-                                            <EuiText
-                                              color="default"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <div
-                                                className="euiText euiText--medium"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <EuiTextColor
-                                                  color="default"
-                                                  component="div"
-                                                >
-                                                  <div
-                                                    className="euiTextColor euiTextColor--default"
-                                                  >
-                                                    49.54
-                                                  </div>
-                                                </EuiTextColor>
-                                              </div>
-                                            </EuiText>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </ServiceTrendsPlots>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                            Name
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="right"
-                              key="_data_column_error_rate_0_2"
-                              mobileOptions={
-                                Object {
-                                  "header": "Error rate",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
+                              data-test-subj="tableHeaderCell_average_latency_1"
+                              isSorted={false}
+                              key="_data_h_average_latency_1"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_average_latency_1"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Error rate
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  <ServiceTrendsPlots
-                                    className=""
-                                    fieldType="error_rate"
-                                    item={3.77}
-                                    key=".0"
-                                    row={
-                                      Object {
-                                        "average_latency": 49.54,
-                                        "connected_services": Array [
-                                          "order",
-                                          "inventory",
-                                        ],
-                                        "error_rate": 3.77,
-                                        "name": "database",
-                                        "number_of_connected_services": 2,
-                                        "throughput": 53,
-                                        "traces": 31,
-                                      }
-                                    }
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <EuiFlexGroup
-                                      gutterSize="s"
-                                      justifyContent="flexEnd"
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
                                     >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Average duration (ms)",
+                                            }
+                                          }
                                         >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Average duration (ms)"
                                           >
-                                            <EuiText
-                                              color="default"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <div
-                                                className="euiText euiText--medium"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <EuiTextColor
-                                                  color="default"
-                                                  component="div"
-                                                >
-                                                  <div
-                                                    className="euiTextColor euiTextColor--default"
-                                                  >
-                                                    <EuiText
-                                                      size="s"
-                                                    >
-                                                      <div
-                                                        className="euiText euiText--small"
-                                                      >
-                                                        3.77%
-                                                      </div>
-                                                    </EuiText>
-                                                  </div>
-                                                </EuiTextColor>
-                                              </div>
-                                            </EuiText>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </ServiceTrendsPlots>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                            Average duration (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="right"
-                              key="_data_column_throughput_0_3"
-                              mobileOptions={
-                                Object {
-                                  "header": "Request rate",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              data-test-subj="tableHeaderCell_error_rate_2"
+                              isSorted={false}
+                              key="_data_h_error_rate_2"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_rate_2"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Request rate
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <ServiceTrendsPlots
-                                    className=""
-                                    fieldType="throughput"
-                                    item={53}
-                                    key=".0"
-                                    row={
-                                      Object {
-                                        "average_latency": 49.54,
-                                        "connected_services": Array [
-                                          "order",
-                                          "inventory",
-                                        ],
-                                        "error_rate": 3.77,
-                                        "name": "database",
-                                        "number_of_connected_services": 2,
-                                        "throughput": 53,
-                                        "traces": 31,
-                                      }
-                                    }
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <EuiFlexGroup
-                                      gutterSize="s"
-                                      justifyContent="flexEnd"
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
                                     >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Error rate",
+                                            }
+                                          }
                                         >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Error rate"
                                           >
-                                            <EuiText
-                                              color="default"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <div
-                                                className="euiText euiText--medium"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <EuiTextColor
-                                                  color="default"
-                                                  component="div"
-                                                >
-                                                  <div
-                                                    className="euiTextColor euiTextColor--default"
-                                                  >
-                                                    <EuiI18nNumber
-                                                      value={53}
-                                                    >
-                                                      53
-                                                    </EuiI18nNumber>
-                                                  </div>
-                                                </EuiTextColor>
-                                              </div>
-                                            </EuiText>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </ServiceTrendsPlots>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                            Error rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="right"
-                              key="_data_column_number_of_connected_services_0_4"
-                              mobileOptions={
-                                Object {
-                                  "header": "No. of connected services",
-                                  "render": undefined,
+                              data-test-subj="tableHeaderCell_throughput_3"
+                              isSorted={false}
+                              key="_data_h_throughput_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_throughput_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
                                 }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Request rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Request rate"
+                                          >
+                                            Request rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                              isSorted={false}
+                              key="_data_h_number_of_connected_services_4"
+                              onSort={[Function]}
                               width="80px"
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": "80px",
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  No. of connected services
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  2
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "No. of connected services",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="No. of connected services"
+                                          >
+                                            No. of connected services
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="left"
-                              key="_data_column_connected_services_0_5"
-                              mobileOptions={
-                                Object {
-                                  "header": "Connected services",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              data-test-subj="tableHeaderCell_connected_services_5"
+                              isSorted={false}
+                              key="_data_h_connected_services_5"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_connected_services_5"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Connected services
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiText
-                                    className=""
-                                    key=".0"
-                                    size="s"
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <div
-                                      className="euiText euiText--small"
+                                    <span
+                                      className="euiTableCellContent"
                                     >
-                                      order, inventory
-                                    </div>
-                                  </EuiText>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Connected services",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Connected services"
+                                          >
+                                            Connected services
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="right"
-                              key="_data_column_traces_0_6"
-                              mobileOptions={
-                                Object {
-                                  "header": "Traces",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              data-test-subj="tableHeaderCell_traces_6"
+                              isSorted={false}
+                              key="_data_h_traces_6"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_traces_6"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Traces
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiLink
-                                    onClick={[Function]}
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <button
-                                      className="euiLink euiLink--primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
                                     >
-                                      <EuiI18nNumber
-                                        value={31}
-                                      >
-                                        31
-                                      </EuiI18nNumber>
-                                    </button>
-                                  </EuiLink>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Traces",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Traces"
+                                          >
+                                            Traces
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="center"
-                              key="_data_column_actions_0_7"
-                              mobileOptions={
-                                Object {
-                                  "header": "Actions",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
+                              data-test-subj="tableHeaderCell_actions_7"
+                              key="_data_h_actions_7"
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_actions_7"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                  showSortMsg={false}
                                 >
-                                  Actions
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiFlexGroup
-                                    className=""
-                                    justifyContent="center"
-                                    key=".0"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignCenter"
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Actions",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Actions"
+                                        >
+                                          Actions
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelectable={true}
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow euiTableRow-isSelectable"
+                            >
+                              <EuiTableRowCellCheckbox
+                                key="_selection_column_0"
+                              >
+                                <td
+                                  className="euiTableRowCellCheckbox"
+                                >
+                                  <div
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiI18n
+                                      default="Select this row"
+                                      token="euiBasicTable.selectThisRow"
                                     >
-                                      <EuiFlexItem
-                                        grow={false}
-                                        onClick={[Function]}
+                                      <EuiCheckbox
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        compressed={false}
+                                        data-test-subj="checkboxSelectRow-0"
+                                        disabled={false}
+                                        id="_selection_column_0-checkbox"
+                                        indeterminate={false}
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="inList"
                                       >
                                         <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                        >
+                                          <input
+                                            aria-label="Select this row"
+                                            checked={false}
+                                            className="euiCheckbox__input"
+                                            data-test-subj="checkboxSelectRow-0"
+                                            disabled={false}
+                                            id="_selection_column_0-checkbox"
+                                            onChange={[Function]}
+                                            title="Select this row"
+                                            type="checkbox"
+                                          />
+                                          <div
+                                            className="euiCheckbox__square"
+                                          />
+                                        </div>
+                                      </EuiCheckbox>
+                                    </EuiI18n>
+                                  </div>
+                                </td>
+                              </EuiTableRowCellCheckbox>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_name_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Name",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Name
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      className=""
+                                      data-test-subj="service-link"
+                                      key=".0"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        data-test-subj="service-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        database
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_average_latency_0_1"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Average duration (ms)",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Average duration (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="average_latency"
+                                      item={49.54}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "connected_services": Array [
+                                            "order",
+                                            "inventory",
+                                          ],
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "number_of_connected_services": 2,
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      49.54
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_rate_0_2"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Error rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Error rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="error_rate"
+                                      item={3.77}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "connected_services": Array [
+                                            "order",
+                                            "inventory",
+                                          ],
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "number_of_connected_services": 2,
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiText
+                                                        size="s"
+                                                      >
+                                                        <div
+                                                          className="euiText euiText--small"
+                                                        >
+                                                          3.77%
+                                                        </div>
+                                                      </EuiText>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_throughput_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Request rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Request rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="throughput"
+                                      item={53}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "connected_services": Array [
+                                            "order",
+                                            "inventory",
+                                          ],
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "number_of_connected_services": 2,
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiI18nNumber
+                                                        value={53}
+                                                      >
+                                                        53
+                                                      </EuiI18nNumber>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_number_of_connected_services_0_4"
+                                mobileOptions={
+                                  Object {
+                                    "header": "No. of connected services",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                                width="80px"
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": "80px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    No. of connected services
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    2
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_connected_services_0_5"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Connected services",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Connected services
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiText
+                                      className=""
+                                      key=".0"
+                                      size="s"
+                                    >
+                                      <div
+                                        className="euiText euiText--small"
+                                      >
+                                        order, inventory
+                                      </div>
+                                    </EuiText>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_traces_0_6"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Traces",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Traces
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiI18nNumber
+                                          value={31}
+                                        >
+                                          31
+                                        </EuiI18nNumber>
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="center"
+                                key="_data_column_actions_0_7"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Actions",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Actions
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      className=""
+                                      justifyContent="center"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
                                           onClick={[Function]}
                                         >
-                                          <EuiLink
-                                            data-test-subj="service-flyout-action-btnundefined"
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            onClick={[Function]}
                                           >
-                                            <button
-                                              className="euiLink euiLink--primary"
+                                            <EuiLink
                                               data-test-subj="service-flyout-action-btnundefined"
-                                              disabled={false}
-                                              type="button"
                                             >
-                                              <EuiIcon
-                                                color="primary"
-                                                type="inspect"
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                data-test-subj="service-flyout-action-btnundefined"
+                                                disabled={false}
+                                                type="button"
                                               >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  color="primary"
+                                                  type="inspect"
                                                 >
-                                                  <svg
+                                                  <EuiIconBeaker
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </button>
-                                          </EuiLink>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                          </tr>
-                        </EuiTableRow>
-                      </tbody>
-                    </EuiTableBody>
-                  </table>
-                </EuiTable>
-              </div>
-              <PaginationBar
-                aria-controls="random_html_id"
-                onPageChange={[Function]}
-                onPageSizeChange={[Function]}
-                pagination={
-                  Object {
-                    "hidePerPageOptions": undefined,
-                    "pageIndex": 0,
-                    "pageSize": 10,
-                    "pageSizeOptions": Array [
-                      5,
-                      10,
-                      15,
-                    ],
-                    "totalItemCount": 1,
-                  }
-                }
-              >
-                <div>
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiTablePagination
-                    activePage={0}
-                    aria-controls="random_html_id"
-                    itemsPerPage={10}
-                    itemsPerPageOptions={
-                      Array [
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
                         5,
                         10,
                         15,
-                      ]
+                      ],
+                      "totalItemCount": 1,
                     }
-                    onChangeItemsPerPage={[Function]}
-                    onChangePage={[Function]}
-                    pageCount={1}
-                  >
-                    <EuiFlexGroup
-                      alignItems="center"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiPopover
-                              anchorPosition="upRight"
-                              button={
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
-                                >
-                                  <EuiI18n
-                                    default="Rows per page"
-                                    token="euiTablePagination.rowsPerPage"
-                                  />
-                                  : 
-                                  10
-                                </EuiButtonEmpty>
-                              }
-                              closePopover={[Function]}
-                              display="inlineBlock"
-                              hasArrow={true}
-                              isOpen={false}
-                              ownFocus={true}
-                              panelPaddingSize="none"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiPopover euiPopover--anchorUpRight"
-                              >
-                                <div
-                                  className="euiPopover__anchor"
-                                >
+                              <EuiPopover
+                                anchorPosition="upRight"
+                                button={
                                   <EuiButtonEmpty
                                     color="text"
                                     data-test-subj="tablePaginationPopoverButton"
@@ -4358,43 +4328,168 @@ exports[`Services table component renders services table 1`] = `
                                     onClick={[Function]}
                                     size="xs"
                                   >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    <EuiI18n
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
+                                    />
+                                    : 
+                                    10
+                                  </EuiButtonEmpty>
+                                }
+                                closePopover={[Function]}
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorUpRight"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonEmpty
+                                      color="text"
                                       data-test-subj="tablePaginationPopoverButton"
-                                      disabled={false}
+                                      iconSide="right"
+                                      iconType="arrowDown"
                                       onClick={[Function]}
-                                      type="button"
+                                      size="xs"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="right"
-                                        iconSize="s"
-                                        iconType="arrowDown"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
+                                      <button
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        <EuiButtonContent
+                                          className="euiButtonEmpty__content"
+                                          iconSide="right"
+                                          iconSize="s"
+                                          iconType="arrowDown"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          >
+                                            <EuiIcon
+                                              className="euiButtonContent__icon"
+                                              color="inherit"
+                                              size="s"
+                                              type="arrowDown"
+                                            >
+                                              <EuiIconBeaker
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                focusable="false"
+                                                role="img"
+                                                style={null}
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                  focusable="false"
+                                                  height={16}
+                                                  role="img"
+                                                  style={null}
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
+                                              </EuiIconBeaker>
+                                            </EuiIcon>
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              <EuiI18n
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
+                                              >
+                                                Rows per page
+                                              </EuiI18n>
+                                              : 
+                                              10
+                                            </span>
+                                          </span>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonEmpty>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
+                              >
+                                <nav
+                                  className="euiPagination"
+                                >
+                                  <EuiI18n
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
+                                    values={
+                                      Object {
+                                        "page": 0,
+                                      }
+                                    }
+                                  >
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
                                           <EuiIcon
-                                            className="euiButtonContent__icon"
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
                                             color="inherit"
-                                            size="s"
-                                            type="arrowDown"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
                                             <EuiIconBeaker
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
                                               role="img"
                                               style={null}
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                 focusable="false"
                                                 height={16}
                                                 role="img"
@@ -4409,271 +4504,176 @@ exports[`Services table component renders services table 1`] = `
                                               </svg>
                                             </EuiIconBeaker>
                                           </EuiIcon>
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            <EuiI18n
-                                              default="Rows per page"
-                                              token="euiTablePagination.rowsPerPage"
-                                            >
-                                              Rows per page
-                                            </EuiI18n>
-                                            : 
-                                            10
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </div>
-                              </div>
-                            </EuiPopover>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiPagination
-                              activePage={0}
-                              aria-controls="random_html_id"
-                              onPageClick={[Function]}
-                              pageCount={1}
-                            >
-                              <nav
-                                className="euiPagination"
-                              >
-                                <EuiI18n
-                                  default="Previous page, {page}"
-                                  token="euiPagination.previousPage"
-                                  values={
-                                    Object {
-                                      "page": 0,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Previous page"
-                                    token="euiPagination.disabledPreviousPage"
-                                  >
-                                    <EuiButtonIcon
-                                      aria-label="Previous page"
-                                      color="text"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      iconType="arrowLeft"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        aria-label="Previous page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowLeft"
-                                        >
-                                          <EuiIconBeaker
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              height={16}
-                                              role="img"
-                                              style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                              />
-                                            </svg>
-                                          </EuiIconBeaker>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                                <ul
-                                  className="euiPagination__list"
-                                >
-                                  <PaginationButton
-                                    key="0"
-                                    pageIndex={0}
+                                  <ul
+                                    className="euiPagination__list"
                                   >
-                                    <li
-                                      className="euiPagination__item"
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
                                     >
-                                      <EuiPaginationButton
-                                        aria-controls="random_html_id"
-                                        hideOnMobile={true}
-                                        isActive={true}
-                                        onClick={[Function]}
-                                        pageIndex={0}
-                                        totalPages={1}
+                                      <li
+                                        className="euiPagination__item"
                                       >
-                                        <EuiI18n
-                                          default="Page {page} of {totalPages}"
-                                          token="euiPaginationButton.longPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
-                                              "totalPages": 1,
-                                            }
-                                          }
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Page {page}"
-                                            token="euiPaginationButton.shortPageString"
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
                                             values={
                                               Object {
                                                 "page": 1,
+                                                "totalPages": 1,
                                               }
                                             }
                                           >
-                                            <EuiButtonEmpty
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              color="text"
-                                              data-test-subj="pagination-button-0"
-                                              href="#random_html_id"
-                                              isDisabled={true}
-                                              onClick={[Function]}
-                                              size="s"
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
+                                                }
+                                              }
                                             >
-                                              <button
+                                              <EuiButtonEmpty
                                                 aria-controls="random_html_id"
                                                 aria-current={true}
                                                 aria-label="Page 1 of 1"
-                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
                                                 data-test-subj="pagination-button-0"
-                                                disabled={true}
+                                                href="#random_html_id"
+                                                isDisabled={true}
                                                 onClick={[Function]}
-                                                type="button"
+                                                size="s"
                                               >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="left"
-                                                  iconSize="m"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text",
-                                                    }
-                                                  }
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonContent euiButtonEmpty__content"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
                                                     <span
-                                                      className="euiButtonEmpty__text"
+                                                      className="euiButtonContent euiButtonEmpty__content"
                                                     >
-                                                      1
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
                                                     </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
                                           </EuiI18n>
-                                        </EuiI18n>
-                                      </EuiPaginationButton>
-                                    </li>
-                                  </PaginationButton>
-                                </ul>
-                                <EuiI18n
-                                  default="Next page, {page}"
-                                  token="euiPagination.nextPage"
-                                  values={
-                                    Object {
-                                      "page": 2,
-                                    }
-                                  }
-                                >
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
                                   <EuiI18n
-                                    default="Next page"
-                                    token="euiPagination.disabledNextPage"
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <EuiButtonIcon
-                                      aria-label="Next page"
-                                      color="text"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      iconType="arrowRight"
-                                      onClick={[Function]}
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <button
+                                      <EuiButtonIcon
                                         aria-label="Next page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        color="text"
                                         data-test-subj="pagination-button-next"
                                         disabled={true}
+                                        iconType="arrowRight"
                                         onClick={[Function]}
-                                        type="button"
                                       >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowRight"
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <EuiIconBeaker
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <svg
+                                            <EuiIconBeaker
                                               aria-hidden={true}
                                               className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                              />
-                                            </svg>
-                                          </EuiIconBeaker>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                              </nav>
-                            </EuiPagination>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </EuiTablePagination>
-                </div>
-              </PaginationBar>
-            </div>
-          </EuiBasicTable>
-        </EuiInMemoryTable>
-      </div>
-    </EuiPanel>
-  </div>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
+              </div>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </ServicesTable>
 `;

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -12,205 +12,213 @@ exports[`Services table component renders empty jaeger services table message 1`
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+            <EuiFlexItem
+              grow={false}
             >
-              <PanelTitle
-                title="Services"
-                totalItems={0}
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiText
-                  size="m"
+                <PanelTitle
+                  title="Services"
+                  totalItems={0}
                 >
-                  <div
-                    className="euiText euiText--medium"
+                  <EuiText
+                    size="m"
                   >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem>
                     <div
-                      className="euiFlexItem"
+                      className="euiText euiText--medium"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <span
+                        className="panel-title"
                       >
-                        <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                        Services
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (0)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiToolTip
+                          content="Select services to filter"
+                          delay="regular"
+                          position="top"
                         >
-                          <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            size="xs"
+                          <span
+                            className="euiToolTipAnchor"
+                            onKeyUp={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
+                            <EuiButtonEmpty
+                              isDisabled={true}
                               onBlur={[Function]}
                               onFocus={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                disabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiButtonContent
+                                  className="euiButtonEmpty__content"
+                                  iconSide="left"
+                                  iconSize="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonContent euiButtonEmpty__content"
                                   >
-                                    Filter services
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      Filter services
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <NoMatchMessage
-        size="xl"
-      >
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonEmpty>
+                          </span>
+                        </EuiToolTip>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
         <EuiSpacer
-          size="xl"
+          size="m"
         >
           <div
-            className="euiSpacer euiSpacer--xl"
+            className="euiSpacer euiSpacer--m"
           />
         </EuiSpacer>
-        <EuiEmptyPrompt
-          body={
-            <EuiText>
-              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-            </EuiText>
-          }
-          title={
-            <h2>
-              No matches
-            </h2>
-          }
+        <EuiHorizontalRule
+          margin="none"
         >
-          <div
-            className="euiEmptyPrompt"
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <NoMatchMessage
+          size="xl"
+        >
+          <EuiSpacer
+            size="xl"
           >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+          <EuiEmptyPrompt
+            body={
+              <EuiText>
+                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+              </EuiText>
+            }
+            title={
+              <h2>
                 No matches
               </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
+            }
+          >
+            <div
+              className="euiEmptyPrompt"
             >
-              <span
-                className="euiTextColor euiTextColor--subdued"
+              <EuiTitle
+                size="m"
               >
-                <EuiSpacer
-                  size="m"
+                <h2
+                  className="euiTitle euiTitle--medium"
                 >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  No matches
+                </h2>
+              </EuiTitle>
+              <EuiTextColor
+                color="subdued"
+              >
+                <span
+                  className="euiTextColor euiTextColor--subdued"
+                >
+                  <EuiSpacer
+                    size="m"
                   >
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </div>
-                    </EuiText>
-                  </div>
-                </EuiText>
-              </span>
-            </EuiTextColor>
-          </div>
-        </EuiEmptyPrompt>
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </NoMatchMessage>
-    </div>
-  </EuiPanel>
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiText>
+                </span>
+              </EuiTextColor>
+            </div>
+          </EuiEmptyPrompt>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+        </NoMatchMessage>
+      </div>
+    </EuiPanel>
+  </div>
 </ServicesTable>
 `;
 
@@ -226,243 +234,251 @@ exports[`Services table component renders empty services table message 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+            <EuiFlexItem
+              grow={false}
             >
-              <PanelTitle
-                title="Services"
-                totalItems={0}
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiText
-                  size="m"
+                <PanelTitle
+                  title="Services"
+                  totalItems={0}
                 >
-                  <div
-                    className="euiText euiText--medium"
+                  <EuiText
+                    size="m"
                   >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem>
                     <div
-                      className="euiFlexItem"
+                      className="euiText euiText--medium"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <span
+                        className="panel-title"
                       >
-                        <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                        Services
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (0)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiToolTip
+                          content="Select services to filter"
+                          delay="regular"
+                          position="top"
                         >
-                          <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            size="xs"
+                          <span
+                            className="euiToolTipAnchor"
+                            onKeyUp={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
+                            <EuiButtonEmpty
+                              isDisabled={true}
                               onBlur={[Function]}
                               onFocus={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                disabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiButtonContent
+                                  className="euiButtonEmpty__content"
+                                  iconSide="left"
+                                  iconSize="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonContent euiButtonEmpty__content"
                                   >
-                                    Filter services
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      Filter services
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonEmpty>
+                          </span>
+                        </EuiToolTip>
+                      </div>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
                       >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
+                        <EuiButtonEmpty
                           onClick={[Function]}
-                          type="button"
+                          size="xs"
                         >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
+                          <button
+                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
+                            <EuiButtonContent
+                              className="euiButtonEmpty__content"
+                              iconSide="left"
+                              iconSize="s"
+                              textProps={
+                                Object {
+                                  "className": "euiButtonEmpty__text",
+                                }
+                              }
                             >
                               <span
-                                className="euiButtonEmpty__text"
+                                className="euiButtonContent euiButtonEmpty__content"
                               >
-                                Show 24 hour trends
+                                <span
+                                  className="euiButtonEmpty__text"
+                                >
+                                  Show 24 hour trends
+                                </span>
                               </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <NoMatchMessage
-        size="xl"
-      >
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonEmpty>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
         <EuiSpacer
-          size="xl"
+          size="m"
         >
           <div
-            className="euiSpacer euiSpacer--xl"
+            className="euiSpacer euiSpacer--m"
           />
         </EuiSpacer>
-        <EuiEmptyPrompt
-          body={
-            <EuiText>
-              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-            </EuiText>
-          }
-          title={
-            <h2>
-              No matches
-            </h2>
-          }
+        <EuiHorizontalRule
+          margin="none"
         >
-          <div
-            className="euiEmptyPrompt"
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <NoMatchMessage
+          size="xl"
+        >
+          <EuiSpacer
+            size="xl"
           >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+          <EuiEmptyPrompt
+            body={
+              <EuiText>
+                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+              </EuiText>
+            }
+            title={
+              <h2>
                 No matches
               </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
+            }
+          >
+            <div
+              className="euiEmptyPrompt"
             >
-              <span
-                className="euiTextColor euiTextColor--subdued"
+              <EuiTitle
+                size="m"
               >
-                <EuiSpacer
-                  size="m"
+                <h2
+                  className="euiTitle euiTitle--medium"
                 >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  No matches
+                </h2>
+              </EuiTitle>
+              <EuiTextColor
+                color="subdued"
+              >
+                <span
+                  className="euiTextColor euiTextColor--subdued"
+                >
+                  <EuiSpacer
+                    size="m"
                   >
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </div>
-                    </EuiText>
-                  </div>
-                </EuiText>
-              </span>
-            </EuiTextColor>
-          </div>
-        </EuiEmptyPrompt>
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </NoMatchMessage>
-    </div>
-  </EuiPanel>
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiText>
+                </span>
+              </EuiTextColor>
+            </div>
+          </EuiEmptyPrompt>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+        </NoMatchMessage>
+      </div>
+    </EuiPanel>
+  </div>
 </ServicesTable>
 `;
 
@@ -488,220 +504,139 @@ exports[`Services table component renders jaeger services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+            <EuiFlexItem
+              grow={false}
             >
-              <PanelTitle
-                title="Services"
-                totalItems={1}
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiText
-                  size="m"
+                <PanelTitle
+                  title="Services"
+                  totalItems={1}
                 >
-                  <div
-                    className="euiText euiText--medium"
+                  <EuiText
+                    size="m"
                   >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem>
                     <div
-                      className="euiFlexItem"
+                      className="euiText euiText--medium"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <span
+                        className="panel-title"
                       >
-                        <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                        Services
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (1)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiToolTip
+                          content="Select services to filter"
+                          delay="regular"
+                          position="top"
                         >
-                          <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            size="xs"
+                          <span
+                            className="euiToolTipAnchor"
+                            onKeyUp={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
+                            <EuiButtonEmpty
+                              isDisabled={true}
                               onBlur={[Function]}
                               onFocus={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                disabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiButtonContent
+                                  className="euiButtonEmpty__content"
+                                  iconSide="left"
+                                  iconSize="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonContent euiButtonEmpty__content"
                                   >
-                                    Filter services
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      Filter services
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "name",
-              "name": "Name",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "average_latency",
-              "name": "Average duration (ms)",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_rate",
-              "name": "Error rate",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "throughput",
-              "name": "Request rate",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "traces",
-              "name": "Traces",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "center",
-              "field": "actions",
-              "name": "Actions",
-              "render": [Function],
-            },
-          ]
-        }
-        isSelectable={true}
-        itemId="itemId"
-        items={
-          Array [
-            Object {
-              "average_latency": 49.54,
-              "error_rate": 3.77,
-              "name": "database",
-              "throughput": 53,
-              "traces": 31,
-            },
-          ]
-        }
-        loading={false}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        selection={
-          Object {
-            "onSelectionChange": [Function],
-          }
-        }
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "name",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonEmpty>
+                          </span>
+                        </EuiToolTip>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiSpacer
+          size="m"
+        >
+          <div
+            className="euiSpacer euiSpacer--m"
+          />
+        </EuiSpacer>
+        <EuiHorizontalRule
+          margin="none"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <EuiInMemoryTable
           columns={
             Array [
               Object {
@@ -763,19 +698,14 @@ exports[`Services table component renders jaeger services table 1`] = `
             ]
           }
           loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
           pagination={
             Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
+              "initialPageSize": 10,
               "pageSizeOptions": Array [
                 5,
                 10,
                 15,
               ],
-              "totalItemCount": 1,
             }
           }
           responsive={true}
@@ -786,156 +716,223 @@ exports[`Services table component renders jaeger services table 1`] = `
           }
           sorting={
             Object {
-              "allowNeutralSort": true,
               "sort": Object {
                 "direction": "asc",
-                "field": "Name",
+                "field": "name",
               },
             }
           }
           tableLayout="auto"
         >
-          <div
-            className="euiBasicTable"
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "name",
+                  "name": "Name",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "average_latency",
+                  "name": "Average duration (ms)",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_rate",
+                  "name": "Error rate",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "throughput",
+                  "name": "Request rate",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "traces",
+                  "name": "Traces",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "center",
+                  "field": "actions",
+                  "name": "Actions",
+                  "render": [Function],
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId="itemId"
+            items={
+              Array [
+                Object {
+                  "average_latency": 49.54,
+                  "error_rate": 3.77,
+                  "name": "database",
+                  "throughput": 53,
+                  "traces": 31,
+                },
+              ]
+            }
+            loading={false}
+            noItemsMessage="No items found"
+            onChange={[Function]}
+            pagination={
+              Object {
+                "hidePerPageOptions": undefined,
+                "pageIndex": 0,
+                "pageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+                "totalItemCount": 1,
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "allowNeutralSort": true,
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "Name",
+                },
+              }
+            }
+            tableLayout="auto"
           >
-            <div>
-              <EuiTableHeaderMobile>
-                <div
-                  className="euiTableHeaderMobile"
-                >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
                   >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiI18n
-                            default="Select all rows"
-                            token="euiBasicTable.selectAllRows"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <EuiCheckbox
-                              aria-label="Select all rows"
-                              checked={false}
-                              compressed={false}
-                              disabled={false}
-                              id="_selection_column-checkbox_random_html_id"
-                              indeterminate={false}
-                              label="Select all rows"
-                              onChange={[Function]}
+                            <EuiI18n
+                              default="Select all rows"
+                              token="euiBasicTable.selectAllRows"
+                            >
+                              <EuiCheckbox
+                                aria-label="Select all rows"
+                                checked={false}
+                                compressed={false}
+                                disabled={false}
+                                id="_selection_column-checkbox_random_html_id"
+                                indeterminate={false}
+                                label="Select all rows"
+                                onChange={[Function]}
+                              >
+                                <div
+                                  className="euiCheckbox"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    disabled={false}
+                                    id="_selection_column-checkbox_random_html_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                  <label
+                                    className="euiCheckbox__label"
+                                    htmlFor="_selection_column-checkbox_random_html_id"
+                                  >
+                                    Select all rows
+                                  </label>
+                                </div>
+                              </EuiCheckbox>
+                            </EuiI18n>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": true,
+                                    "isSorted": true,
+                                    "key": "_data_s_name_0",
+                                    "name": "Name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_average_latency_1",
+                                    "name": "Average duration (ms)",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_error_rate_2",
+                                    "name": "Error rate",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_throughput_3",
+                                    "name": "Request rate",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_traces_4",
+                                    "name": "Traces",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
                             >
                               <div
-                                className="euiCheckbox"
+                                className="euiTableSortMobile"
                               >
-                                <input
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  className="euiCheckbox__input"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  onChange={[Function]}
-                                  type="checkbox"
-                                />
-                                <div
-                                  className="euiCheckbox__square"
-                                />
-                                <label
-                                  className="euiCheckbox__label"
-                                  htmlFor="_selection_column-checkbox_random_html_id"
-                                >
-                                  Select all rows
-                                </label>
-                              </div>
-                            </EuiCheckbox>
-                          </EuiI18n>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_name_0",
-                                  "name": "Name",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_average_latency_1",
-                                  "name": "Average duration (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_rate_2",
-                                  "name": "Error rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_throughput_3",
-                                  "name": "Request rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_traces_4",
-                                  "name": "Traces",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
-                          >
-                            <div
-                              className="euiTableSortMobile"
-                            >
-                              <EuiPopover
-                                anchorPosition="downRight"
-                                button={
-                                  <EuiButtonEmpty
-                                    flush="right"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    onClick={[Function]}
-                                    size="xs"
-                                  >
-                                    <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownRight"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
                                     <EuiButtonEmpty
                                       flush="right"
                                       iconSide="right"
@@ -943,575 +940,172 @@ exports[`Services table component renders jaeger services table 1`] = `
                                       onClick={[Function]}
                                       size="xs"
                                     >
-                                      <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                        disabled={false}
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorDownRight"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
+                                    >
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
                                         onClick={[Function]}
-                                        type="button"
+                                        size="xs"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="right"
+                                            iconSize="s"
+                                            iconType="arrowDown"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <span
+                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                             >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiIcon
+                                                className="euiButtonContent__icon"
+                                                color="inherit"
+                                                size="s"
+                                                type="arrowDown"
                                               >
-                                                <svg
+                                                <EuiIconArrowDown
                                                   aria-hidden={true}
                                                   className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
                                                   focusable="false"
-                                                  height={16}
                                                   role="img"
                                                   style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                      fillRule="non-zero"
+                                                    />
+                                                  </svg>
+                                                </EuiIconArrowDown>
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButtonEmpty__text"
                                               >
-                                                Sorting
-                                              </EuiI18n>
+                                                <EuiI18n
+                                                  default="Sorting"
+                                                  token="euiTableSortMobile.sorting"
+                                                >
+                                                  Sorting
+                                                </EuiI18n>
+                                              </span>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
                   id="random_html_id"
-                  tabIndex={-1}
+                  responsive={true}
+                  tableLayout="auto"
                 >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCellCheckbox
-                          key="_selection_column_h"
-                        >
-                          <th
-                            className="euiTableHeaderCellCheckbox"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <div
-                              className="euiTableCellContent"
-                            >
-                              <EuiI18n
-                                default="Select all rows"
-                                token="euiBasicTable.selectAllRows"
-                              >
-                                <EuiCheckbox
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  compressed={false}
-                                  data-test-subj="checkboxSelectAll"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  indeterminate={false}
-                                  label={null}
-                                  onChange={[Function]}
-                                  type="inList"
-                                >
-                                  <div
-                                    className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                  >
-                                    <input
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      className="euiCheckbox__input"
-                                      data-test-subj="checkboxSelectAll"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      onChange={[Function]}
-                                      type="checkbox"
-                                    />
-                                    <div
-                                      className="euiCheckbox__square"
-                                    />
-                                  </div>
-                                </EuiCheckbox>
-                              </EuiI18n>
-                            </div>
-                          </th>
-                        </EuiTableHeaderCellCheckbox>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_name_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_name_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_name_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Name",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Name"
-                                      >
-                                        Name
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
-                                  >
-                                    <EuiIconSortUp
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiTableSortIcon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSortUp>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_average_latency_1"
-                          isSorted={false}
-                          key="_data_h_average_latency_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_average_latency_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Average duration (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Average duration (ms)"
-                                      >
-                                        Average duration (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_rate_2"
-                          isSorted={false}
-                          key="_data_h_error_rate_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_rate_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Error rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Error rate"
-                                      >
-                                        Error rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_throughput_3"
-                          isSorted={false}
-                          key="_data_h_throughput_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_throughput_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Request rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Request rate"
-                                      >
-                                        Request rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_traces_4"
-                          isSorted={false}
-                          key="_data_h_traces_4"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_traces_4"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Traces",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Traces"
-                                      >
-                                        Traces
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="center"
-                          data-test-subj="tableHeaderCell_actions_5"
-                          key="_data_h_actions_5"
-                        >
-                          <th
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_actions_5"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <CellContents
-                              className="euiTableCellContent euiTableCellContent--alignCenter"
-                              showSortMsg={false}
-                            >
-                              <span
-                                className="euiTableCellContent euiTableCellContent--alignCenter"
-                              >
-                                <EuiInnerText>
-                                  <EuiI18n
-                                    default="{innerText}; {description}"
-                                    token="euiTableHeaderCell.titleTextWithDesc"
-                                    values={
-                                      Object {
-                                        "description": undefined,
-                                        "innerText": "Actions",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiTableCellContent__text"
-                                      title="Actions"
-                                    >
-                                      Actions
-                                    </span>
-                                  </EuiI18n>
-                                </EuiInnerText>
-                              </span>
-                            </CellContents>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
+                  <table
+                    className="euiTable euiTable--responsive euiTable--auto"
+                    id="random_html_id"
+                    tabIndex={-1}
                   >
-                    <tbody>
-                      <EuiTableRow
-                        isSelectable={true}
-                        isSelected={false}
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
                       >
-                        <tr
-                          className="euiTableRow euiTableRow-isSelectable"
-                        >
-                          <EuiTableRowCellCheckbox
-                            key="_selection_column_0"
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCellCheckbox
+                            key="_selection_column_h"
                           >
-                            <td
-                              className="euiTableRowCellCheckbox"
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
                             >
                               <div
                                 className="euiTableCellContent"
                               >
                                 <EuiI18n
-                                  default="Select this row"
-                                  token="euiBasicTable.selectThisRow"
+                                  default="Select all rows"
+                                  token="euiBasicTable.selectAllRows"
                                 >
                                   <EuiCheckbox
-                                    aria-label="Select this row"
+                                    aria-label="Select all rows"
                                     checked={false}
                                     compressed={false}
-                                    data-test-subj="checkboxSelectRow-0"
+                                    data-test-subj="checkboxSelectAll"
                                     disabled={false}
-                                    id="_selection_column_0-checkbox"
+                                    id="_selection_column-checkbox_random_html_id"
                                     indeterminate={false}
+                                    label={null}
                                     onChange={[Function]}
-                                    title="Select this row"
                                     type="inList"
                                   >
                                     <div
                                       className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
                                     >
                                       <input
-                                        aria-label="Select this row"
+                                        aria-label="Select all rows"
                                         checked={false}
                                         className="euiCheckbox__input"
-                                        data-test-subj="checkboxSelectRow-0"
+                                        data-test-subj="checkboxSelectAll"
                                         disabled={false}
-                                        id="_selection_column_0-checkbox"
+                                        id="_selection_column-checkbox_random_html_id"
                                         onChange={[Function]}
-                                        title="Select this row"
                                         type="checkbox"
                                       />
                                       <div
@@ -1521,558 +1115,958 @@ exports[`Services table component renders jaeger services table 1`] = `
                                   </EuiCheckbox>
                                 </EuiI18n>
                               </div>
-                            </td>
-                          </EuiTableRowCellCheckbox>
-                          <EuiTableRowCell
+                            </th>
+                          </EuiTableHeaderCellCheckbox>
+                          <EuiTableHeaderCell
                             align="left"
-                            key="_data_column_name_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Name",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
+                            data-test-subj="tableHeaderCell_name_0"
+                            isSortAscending={true}
+                            isSorted={true}
+                            key="_data_h_name_0"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="ascending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_name_0"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Name
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  className=""
-                                  data-test-subj="service-link"
-                                  key=".0"
-                                  onClick={[Function]}
+                                <CellContents
+                                  className="euiTableCellContent"
+                                  isSortAscending={true}
+                                  isSorted={true}
+                                  showSortMsg={true}
                                 >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    data-test-subj="service-link"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
+                                  <span
+                                    className="euiTableCellContent"
                                   >
-                                    database
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_average_latency_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Average duration (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Average duration (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="average_latency"
-                                  item={49.54}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Name",
+                                          }
+                                        }
                                       >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Name"
                                         >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  49.54
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_rate_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Error rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Error rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="error_rate"
-                                  item={3.77}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                          Name
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                    <EuiIcon
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortUp"
                                     >
-                                      <EuiFlexItem
-                                        grow={false}
+                                      <EuiIconSortUp
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
                                       >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
                                         >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiText
-                                                    size="s"
-                                                  >
-                                                    <div
-                                                      className="euiText euiText--small"
-                                                    >
-                                                      3.77%
-                                                    </div>
-                                                  </EuiText>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                          <path
+                                            d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                          />
+                                        </svg>
+                                      </EuiIconSortUp>
+                                    </EuiIcon>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="right"
-                            key="_data_column_throughput_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": "Request rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            data-test-subj="tableHeaderCell_average_latency_1"
+                            isSorted={false}
+                            key="_data_h_average_latency_1"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_average_latency_1"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Request rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="throughput"
-                                  item={53}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Average duration (ms)",
+                                          }
+                                        }
                                       >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Average duration (ms)"
                                         >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiI18nNumber
-                                                    value={53}
-                                                  >
-                                                    53
-                                                  </EuiI18nNumber>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                          Average duration (ms)
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="right"
-                            key="_data_column_traces_0_4"
-                            mobileOptions={
-                              Object {
-                                "header": "Traces",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            data-test-subj="tableHeaderCell_error_rate_2"
+                            isSorted={false}
+                            key="_data_h_error_rate_2"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_error_rate_2"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Traces
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  onClick={[Function]}
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
                                   >
-                                    <EuiI18nNumber
-                                      value={31}
-                                    >
-                                      31
-                                    </EuiI18nNumber>
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Error rate",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Error rate"
+                                        >
+                                          Error rate
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_throughput_3"
+                            isSorted={false}
+                            key="_data_h_throughput_3"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_throughput_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Request rate",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Request rate"
+                                        >
+                                          Request rate
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_traces_4"
+                            isSorted={false}
+                            key="_data_h_traces_4"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_traces_4"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Traces",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Traces"
+                                        >
+                                          Traces
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="center"
-                            key="_data_column_actions_0_5"
-                            mobileOptions={
-                              Object {
-                                "header": "Actions",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
+                            data-test-subj="tableHeaderCell_actions_5"
+                            key="_data_h_actions_5"
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_actions_5"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                                showSortMsg={false}
                               >
-                                Actions
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  className=""
-                                  justifyContent="center"
-                                  key=".0"
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
                                 >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Actions",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Actions"
+                                      >
+                                        Actions
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody
+                      bodyRef={[Function]}
+                    >
+                      <tbody>
+                        <EuiTableRow
+                          isSelectable={true}
+                          isSelected={false}
+                        >
+                          <tr
+                            className="euiTableRow euiTableRow-isSelectable"
+                          >
+                            <EuiTableRowCellCheckbox
+                              key="_selection_column_0"
+                            >
+                              <td
+                                className="euiTableRowCellCheckbox"
+                              >
+                                <div
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiI18n
+                                    default="Select this row"
+                                    token="euiBasicTable.selectThisRow"
                                   >
-                                    <EuiFlexItem
-                                      grow={false}
-                                      onClick={[Function]}
+                                    <EuiCheckbox
+                                      aria-label="Select this row"
+                                      checked={false}
+                                      compressed={false}
+                                      data-test-subj="checkboxSelectRow-0"
+                                      disabled={false}
+                                      id="_selection_column_0-checkbox"
+                                      indeterminate={false}
+                                      onChange={[Function]}
+                                      title="Select this row"
+                                      type="inList"
                                     >
                                       <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                      >
+                                        <input
+                                          aria-label="Select this row"
+                                          checked={false}
+                                          className="euiCheckbox__input"
+                                          data-test-subj="checkboxSelectRow-0"
+                                          disabled={false}
+                                          id="_selection_column_0-checkbox"
+                                          onChange={[Function]}
+                                          title="Select this row"
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          className="euiCheckbox__square"
+                                        />
+                                      </div>
+                                    </EuiCheckbox>
+                                  </EuiI18n>
+                                </div>
+                              </td>
+                            </EuiTableRowCellCheckbox>
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_name_0_0"
+                              mobileOptions={
+                                Object {
+                                  "header": "Name",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Name
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiLink
+                                    className=""
+                                    data-test-subj="service-link"
+                                    key=".0"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      data-test-subj="service-link"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      database
+                                    </button>
+                                  </EuiLink>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_average_latency_0_1"
+                              mobileOptions={
+                                Object {
+                                  "header": "Average duration (ms)",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Average duration (ms)
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                >
+                                  <ServiceTrendsPlots
+                                    className=""
+                                    fieldType="average_latency"
+                                    item={49.54}
+                                    key=".0"
+                                    row={
+                                      Object {
+                                        "average_latency": 49.54,
+                                        "error_rate": 3.77,
+                                        "name": "database",
+                                        "throughput": 53,
+                                        "traces": 31,
+                                      }
+                                    }
+                                  >
+                                    <EuiFlexGroup
+                                      gutterSize="s"
+                                      justifyContent="flexEnd"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiText
+                                              color="default"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <div
+                                                className="euiText euiText--medium"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <EuiTextColor
+                                                  color="default"
+                                                  component="div"
+                                                >
+                                                  <div
+                                                    className="euiTextColor euiTextColor--default"
+                                                  >
+                                                    49.54
+                                                  </div>
+                                                </EuiTextColor>
+                                              </div>
+                                            </EuiText>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </ServiceTrendsPlots>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_error_rate_0_2"
+                              mobileOptions={
+                                Object {
+                                  "header": "Error rate",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Error rate
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                >
+                                  <ServiceTrendsPlots
+                                    className=""
+                                    fieldType="error_rate"
+                                    item={3.77}
+                                    key=".0"
+                                    row={
+                                      Object {
+                                        "average_latency": 49.54,
+                                        "error_rate": 3.77,
+                                        "name": "database",
+                                        "throughput": 53,
+                                        "traces": 31,
+                                      }
+                                    }
+                                  >
+                                    <EuiFlexGroup
+                                      gutterSize="s"
+                                      justifyContent="flexEnd"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiText
+                                              color="default"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <div
+                                                className="euiText euiText--medium"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <EuiTextColor
+                                                  color="default"
+                                                  component="div"
+                                                >
+                                                  <div
+                                                    className="euiTextColor euiTextColor--default"
+                                                  >
+                                                    <EuiText
+                                                      size="s"
+                                                    >
+                                                      <div
+                                                        className="euiText euiText--small"
+                                                      >
+                                                        3.77%
+                                                      </div>
+                                                    </EuiText>
+                                                  </div>
+                                                </EuiTextColor>
+                                              </div>
+                                            </EuiText>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </ServiceTrendsPlots>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_throughput_0_3"
+                              mobileOptions={
+                                Object {
+                                  "header": "Request rate",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Request rate
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <ServiceTrendsPlots
+                                    className=""
+                                    fieldType="throughput"
+                                    item={53}
+                                    key=".0"
+                                    row={
+                                      Object {
+                                        "average_latency": 49.54,
+                                        "error_rate": 3.77,
+                                        "name": "database",
+                                        "throughput": 53,
+                                        "traces": 31,
+                                      }
+                                    }
+                                  >
+                                    <EuiFlexGroup
+                                      gutterSize="s"
+                                      justifyContent="flexEnd"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiText
+                                              color="default"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <div
+                                                className="euiText euiText--medium"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <EuiTextColor
+                                                  color="default"
+                                                  component="div"
+                                                >
+                                                  <div
+                                                    className="euiTextColor euiTextColor--default"
+                                                  >
+                                                    <EuiI18nNumber
+                                                      value={53}
+                                                    >
+                                                      53
+                                                    </EuiI18nNumber>
+                                                  </div>
+                                                </EuiTextColor>
+                                              </div>
+                                            </EuiText>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </ServiceTrendsPlots>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_traces_0_4"
+                              mobileOptions={
+                                Object {
+                                  "header": "Traces",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Traces
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiLink
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiI18nNumber
+                                        value={31}
+                                      >
+                                        31
+                                      </EuiI18nNumber>
+                                    </button>
+                                  </EuiLink>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="center"
+                              key="_data_column_actions_0_5"
+                              mobileOptions={
+                                Object {
+                                  "header": "Actions",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Actions
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiFlexGroup
+                                    className=""
+                                    justifyContent="center"
+                                    key=".0"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
                                         onClick={[Function]}
                                       >
-                                        <EuiLink
-                                          data-test-subj="service-flyout-action-btnundefined"
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          onClick={[Function]}
                                         >
-                                          <button
-                                            className="euiLink euiLink--primary"
+                                          <EuiLink
                                             data-test-subj="service-flyout-action-btnundefined"
-                                            disabled={false}
-                                            type="button"
                                           >
-                                            <EuiIcon
-                                              color="primary"
-                                              type="inspect"
+                                            <button
+                                              className="euiLink euiLink--primary"
+                                              data-test-subj="service-flyout-action-btnundefined"
+                                              disabled={false}
+                                              type="button"
                                             >
-                                              <EuiIconInspect
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--primary"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiIcon
+                                                color="primary"
+                                                type="inspect"
                                               >
-                                                <svg
+                                                <EuiIconInspect
                                                   aria-hidden={true}
                                                   className="euiIcon euiIcon--medium euiIcon--primary"
                                                   focusable="false"
-                                                  height={16}
                                                   role="img"
                                                   style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <path
-                                                    d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconInspect>
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--medium euiIcon--primary"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconInspect>
+                                              </EuiIcon>
+                                            </button>
+                                          </EuiLink>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+              <PaginationBar
+                aria-controls="random_html_id"
+                onPageChange={[Function]}
+                onPageSizeChange={[Function]}
+                pagination={
+                  Object {
+                    "hidePerPageOptions": undefined,
+                    "pageIndex": 0,
+                    "pageSize": 10,
+                    "pageSizeOptions": Array [
                       5,
                       10,
                       15,
-                    ]
+                    ],
+                    "totalItemCount": 1,
                   }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+                }
+              >
+                <div>
+                  <EuiSpacer
+                    size="m"
                   >
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiTablePagination
+                    activePage={0}
+                    aria-controls="random_html_id"
+                    itemsPerPage={10}
+                    itemsPerPageOptions={
+                      Array [
+                        5,
+                        10,
+                        15,
+                      ]
+                    }
+                    onChangeItemsPerPage={[Function]}
+                    onChangePage={[Function]}
+                    pageCount={1}
+                  >
+                    <EuiFlexGroup
+                      alignItems="center"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiPopover euiPopover--anchorUpRight"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
+                            <EuiPopover
+                              anchorPosition="upRight"
+                              button={
                                 <EuiButtonEmpty
                                   color="text"
                                   data-test-subj="tablePaginationPopoverButton"
@@ -2081,43 +2075,169 @@ exports[`Services table component renders jaeger services table 1`] = `
                                   onClick={[Function]}
                                   size="xs"
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                  <EuiI18n
+                                    default="Rows per page"
+                                    token="euiTablePagination.rowsPerPage"
+                                  />
+                                  : 
+                                  10
+                                </EuiButtonEmpty>
+                              }
+                              closePopover={[Function]}
+                              display="inlineBlock"
+                              hasArrow={true}
+                              isOpen={false}
+                              ownFocus={true}
+                              panelPaddingSize="none"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorUpRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <EuiButtonEmpty
+                                    color="text"
                                     data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
+                                    iconSide="right"
+                                    iconType="arrowDown"
                                     onClick={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                      data-test-subj="tablePaginationPopoverButton"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="right"
+                                        iconSize="s"
+                                        iconType="arrowDown"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        >
+                                          <EuiIcon
+                                            className="euiButtonContent__icon"
+                                            color="inherit"
+                                            size="s"
+                                            type="arrowDown"
+                                          >
+                                            <EuiIconArrowDown
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                  fillRule="non-zero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowDown>
+                                          </EuiIcon>
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            <EuiI18n
+                                              default="Rows per page"
+                                              token="euiTablePagination.rowsPerPage"
+                                            >
+                                              Rows per page
+                                            </EuiI18n>
+                                            : 
+                                            10
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </div>
+                            </EuiPopover>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiPagination
+                              activePage={0}
+                              aria-controls="random_html_id"
+                              onPageClick={[Function]}
+                              pageCount={1}
+                            >
+                              <nav
+                                className="euiPagination"
+                              >
+                                <EuiI18n
+                                  default="Previous page, {page}"
+                                  token="euiPagination.previousPage"
+                                  values={
+                                    Object {
+                                      "page": 0,
+                                    }
+                                  }
+                                >
+                                  <EuiI18n
+                                    default="Previous page"
+                                    token="euiPagination.disabledPreviousPage"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Previous page"
+                                      color="text"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      iconType="arrowLeft"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        aria-label="Previous page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
                                         <EuiIcon
-                                          className="euiButtonContent__icon"
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
                                           color="inherit"
-                                          size="s"
-                                          type="arrowDown"
+                                          size="m"
+                                          type="arrowLeft"
                                         >
-                                          <EuiIconArrowDown
+                                          <EuiIconArrowLeft
                                             aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                             focusable="false"
                                             role="img"
                                             style={null}
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
                                               height={16}
                                               role="img"
@@ -2127,279 +2247,183 @@ exports[`Services table component renders jaeger services table 1`] = `
                                               xmlns="http://www.w3.org/2000/svg"
                                             >
                                               <path
-                                                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                fillRule="non-zero"
+                                                d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                                fillRule="nonzero"
                                               />
                                             </svg>
-                                          </EuiIconArrowDown>
+                                          </EuiIconArrowLeft>
                                         </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
-                                        >
-                                          <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconArrowLeft
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowLeft>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
+                                <ul
+                                  className="euiPagination__list"
                                 >
-                                  <li
-                                    className="euiPagination__item"
+                                  <PaginationButton
+                                    key="0"
+                                    pageIndex={0}
                                   >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
+                                    <li
+                                      className="euiPagination__item"
                                     >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
+                                      <EuiPaginationButton
+                                        aria-controls="random_html_id"
+                                        hideOnMobile={true}
+                                        isActive={true}
+                                        onClick={[Function]}
+                                        pageIndex={0}
+                                        totalPages={1}
                                       >
                                         <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
+                                          default="Page {page} of {totalPages}"
+                                          token="euiPaginationButton.longPageString"
                                           values={
                                             Object {
                                               "page": 1,
+                                              "totalPages": 1,
                                             }
                                           }
                                         >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
+                                          <EuiI18n
+                                            default="Page {page}"
+                                            token="euiPaginationButton.shortPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                              }
+                                            }
                                           >
-                                            <button
+                                            <EuiButtonEmpty
                                               aria-controls="random_html_id"
                                               aria-current={true}
                                               aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              color="text"
                                               data-test-subj="pagination-button-0"
-                                              disabled={true}
+                                              href="#random_html_id"
+                                              isDisabled={true}
                                               onClick={[Function]}
-                                              type="button"
+                                              size="s"
                                             >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
-                                                }
+                                              <button
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                data-test-subj="pagination-button-0"
+                                                disabled={true}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="left"
+                                                  iconSize="m"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text",
+                                                    }
+                                                  }
                                                 >
                                                   <span
-                                                    className="euiButtonEmpty__text"
+                                                    className="euiButtonContent euiButtonEmpty__content"
                                                   >
-                                                    1
+                                                    <span
+                                                      className="euiButtonEmpty__text"
+                                                    >
+                                                      1
+                                                    </span>
                                                   </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </EuiI18n>
                                         </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
+                                      </EuiPaginationButton>
+                                    </li>
+                                  </PaginationButton>
+                                </ul>
                                 <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
+                                  default="Next page, {page}"
+                                  token="euiPagination.nextPage"
+                                  values={
+                                    Object {
+                                      "page": 2,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                  <EuiI18n
+                                    default="Next page"
+                                    token="euiPagination.disabledNextPage"
                                   >
-                                    <button
+                                    <EuiButtonIcon
                                       aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      color="text"
                                       data-test-subj="pagination-button-next"
                                       disabled={true}
+                                      iconType="arrowRight"
                                       onClick={[Function]}
-                                      type="button"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <button
+                                        aria-label="Next page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <EuiIconArrowRight
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="arrowRight"
                                         >
-                                          <svg
+                                          <EuiIconArrowRight
                                             aria-hidden={true}
                                             className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                             focusable="false"
-                                            height={16}
                                             role="img"
                                             style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <path
-                                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowRight>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                                fillRule="nonzero"
+                                              />
+                                            </svg>
+                                          </EuiIconArrowRight>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
-              </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
-    </div>
-  </EuiPanel>
+                              </nav>
+                            </EuiPagination>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </EuiTablePagination>
+                </div>
+              </PaginationBar>
+            </div>
+          </EuiBasicTable>
+        </EuiInMemoryTable>
+      </div>
+    </EuiPanel>
+  </div>
 </ServicesTable>
 `;
 
@@ -2430,280 +2454,177 @@ exports[`Services table component renders services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
         >
-          <EuiFlexItem
-            grow={false}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+            <EuiFlexItem
+              grow={false}
             >
-              <PanelTitle
-                title="Services"
-                totalItems={1}
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
               >
-                <EuiText
-                  size="m"
+                <PanelTitle
+                  title="Services"
+                  totalItems={1}
                 >
-                  <div
-                    className="euiText euiText--medium"
+                  <EuiText
+                    size="m"
                   >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem>
                     <div
-                      className="euiFlexItem"
+                      className="euiText euiText--medium"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <span
+                        className="panel-title"
                       >
-                        <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                        Services
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (1)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem
+              grow={false}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <EuiFlexGroup>
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  >
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiToolTip
+                          content="Select services to filter"
+                          delay="regular"
+                          position="top"
                         >
-                          <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            size="xs"
+                          <span
+                            className="euiToolTipAnchor"
+                            onKeyUp={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
+                            <EuiButtonEmpty
+                              isDisabled={true}
                               onBlur={[Function]}
                               onFocus={[Function]}
-                              type="button"
+                              size="xs"
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <button
+                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                disabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                type="button"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiButtonContent
+                                  className="euiButtonEmpty__content"
+                                  iconSide="left"
+                                  iconSize="s"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButtonEmpty__text",
+                                    }
+                                  }
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiButtonContent euiButtonEmpty__content"
                                   >
-                                    Filter services
+                                    <span
+                                      className="euiButtonEmpty__text"
+                                    >
+                                      Filter services
+                                    </span>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonEmpty>
+                          </span>
+                        </EuiToolTip>
+                      </div>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
                       >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
+                        <EuiButtonEmpty
                           onClick={[Function]}
-                          type="button"
+                          size="xs"
                         >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
+                          <button
+                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
+                            <EuiButtonContent
+                              className="euiButtonEmpty__content"
+                              iconSide="left"
+                              iconSize="s"
+                              textProps={
+                                Object {
+                                  "className": "euiButtonEmpty__text",
+                                }
+                              }
                             >
                               <span
-                                className="euiButtonEmpty__text"
+                                className="euiButtonContent euiButtonEmpty__content"
                               >
-                                Show 24 hour trends
+                                <span
+                                  className="euiButtonEmpty__text"
+                                >
+                                  Show 24 hour trends
+                                </span>
                               </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "name",
-              "name": "Name",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "average_latency",
-              "name": "Average duration (ms)",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_rate",
-              "name": "Error rate",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "throughput",
-              "name": "Request rate",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "number_of_connected_services",
-              "name": "No. of connected services",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-              "width": "80px",
-            },
-            Object {
-              "align": "left",
-              "field": "connected_services",
-              "name": "Connected services",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "traces",
-              "name": "Traces",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "center",
-              "field": "actions",
-              "name": "Actions",
-              "render": [Function],
-            },
-          ]
-        }
-        isSelectable={true}
-        itemId="itemId"
-        items={
-          Array [
-            Object {
-              "average_latency": 49.54,
-              "connected_services": Array [
-                "order",
-                "inventory",
-              ],
-              "error_rate": 3.77,
-              "name": "database",
-              "number_of_connected_services": 2,
-              "throughput": 53,
-              "traces": 31,
-            },
-          ]
-        }
-        loading={false}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        selection={
-          Object {
-            "onSelectionChange": [Function],
-          }
-        }
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "name",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonEmpty>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiSpacer
+          size="m"
+        >
+          <div
+            className="euiSpacer euiSpacer--m"
+          />
+        </EuiSpacer>
+        <EuiHorizontalRule
+          margin="none"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <EuiInMemoryTable
           columns={
             Array [
               Object {
@@ -2787,19 +2708,14 @@ exports[`Services table component renders services table 1`] = `
             ]
           }
           loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
           pagination={
             Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
+              "initialPageSize": 10,
               "pageSizeOptions": Array [
                 5,
                 10,
                 15,
               ],
-              "totalItemCount": 1,
             }
           }
           responsive={true}
@@ -2810,170 +2726,259 @@ exports[`Services table component renders services table 1`] = `
           }
           sorting={
             Object {
-              "allowNeutralSort": true,
               "sort": Object {
                 "direction": "asc",
-                "field": "Name",
+                "field": "name",
               },
             }
           }
           tableLayout="auto"
         >
-          <div
-            className="euiBasicTable"
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "name",
+                  "name": "Name",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "average_latency",
+                  "name": "Average duration (ms)",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_rate",
+                  "name": "Error rate",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "throughput",
+                  "name": "Request rate",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "number_of_connected_services",
+                  "name": "No. of connected services",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                  "width": "80px",
+                },
+                Object {
+                  "align": "left",
+                  "field": "connected_services",
+                  "name": "Connected services",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "traces",
+                  "name": "Traces",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "center",
+                  "field": "actions",
+                  "name": "Actions",
+                  "render": [Function],
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId="itemId"
+            items={
+              Array [
+                Object {
+                  "average_latency": 49.54,
+                  "connected_services": Array [
+                    "order",
+                    "inventory",
+                  ],
+                  "error_rate": 3.77,
+                  "name": "database",
+                  "number_of_connected_services": 2,
+                  "throughput": 53,
+                  "traces": 31,
+                },
+              ]
+            }
+            loading={false}
+            noItemsMessage="No items found"
+            onChange={[Function]}
+            pagination={
+              Object {
+                "hidePerPageOptions": undefined,
+                "pageIndex": 0,
+                "pageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+                "totalItemCount": 1,
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "allowNeutralSort": true,
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "Name",
+                },
+              }
+            }
+            tableLayout="auto"
           >
-            <div>
-              <EuiTableHeaderMobile>
-                <div
-                  className="euiTableHeaderMobile"
-                >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
                   >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiI18n
-                            default="Select all rows"
-                            token="euiBasicTable.selectAllRows"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <EuiCheckbox
-                              aria-label="Select all rows"
-                              checked={false}
-                              compressed={false}
-                              disabled={false}
-                              id="_selection_column-checkbox_random_html_id"
-                              indeterminate={false}
-                              label="Select all rows"
-                              onChange={[Function]}
+                            <EuiI18n
+                              default="Select all rows"
+                              token="euiBasicTable.selectAllRows"
+                            >
+                              <EuiCheckbox
+                                aria-label="Select all rows"
+                                checked={false}
+                                compressed={false}
+                                disabled={false}
+                                id="_selection_column-checkbox_random_html_id"
+                                indeterminate={false}
+                                label="Select all rows"
+                                onChange={[Function]}
+                              >
+                                <div
+                                  className="euiCheckbox"
+                                >
+                                  <input
+                                    aria-label="Select all rows"
+                                    checked={false}
+                                    className="euiCheckbox__input"
+                                    disabled={false}
+                                    id="_selection_column-checkbox_random_html_id"
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                  />
+                                  <div
+                                    className="euiCheckbox__square"
+                                  />
+                                  <label
+                                    className="euiCheckbox__label"
+                                    htmlFor="_selection_column-checkbox_random_html_id"
+                                  >
+                                    Select all rows
+                                  </label>
+                                </div>
+                              </EuiCheckbox>
+                            </EuiI18n>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": true,
+                                    "isSorted": true,
+                                    "key": "_data_s_name_0",
+                                    "name": "Name",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_average_latency_1",
+                                    "name": "Average duration (ms)",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_error_rate_2",
+                                    "name": "Error rate",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_throughput_3",
+                                    "name": "Request rate",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_number_of_connected_services_4",
+                                    "name": "No. of connected services",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_connected_services_5",
+                                    "name": "Connected services",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_traces_6",
+                                    "name": "Traces",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
                             >
                               <div
-                                className="euiCheckbox"
+                                className="euiTableSortMobile"
                               >
-                                <input
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  className="euiCheckbox__input"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  onChange={[Function]}
-                                  type="checkbox"
-                                />
-                                <div
-                                  className="euiCheckbox__square"
-                                />
-                                <label
-                                  className="euiCheckbox__label"
-                                  htmlFor="_selection_column-checkbox_random_html_id"
-                                >
-                                  Select all rows
-                                </label>
-                              </div>
-                            </EuiCheckbox>
-                          </EuiI18n>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_name_0",
-                                  "name": "Name",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_average_latency_1",
-                                  "name": "Average duration (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_rate_2",
-                                  "name": "Error rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_throughput_3",
-                                  "name": "Request rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_number_of_connected_services_4",
-                                  "name": "No. of connected services",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_connected_services_5",
-                                  "name": "Connected services",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_traces_6",
-                                  "name": "Traces",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
-                          >
-                            <div
-                              className="euiTableSortMobile"
-                            >
-                              <EuiPopover
-                                anchorPosition="downRight"
-                                button={
-                                  <EuiButtonEmpty
-                                    flush="right"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    onClick={[Function]}
-                                    size="xs"
-                                  >
-                                    <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownRight"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
                                     <EuiButtonEmpty
                                       flush="right"
                                       iconSide="right"
@@ -2981,691 +2986,171 @@ exports[`Services table component renders services table 1`] = `
                                       onClick={[Function]}
                                       size="xs"
                                     >
-                                      <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                        disabled={false}
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorDownRight"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
+                                    >
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
                                         onClick={[Function]}
-                                        type="button"
+                                        size="xs"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="right"
+                                            iconSize="s"
+                                            iconType="arrowDown"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <span
+                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                             >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiIcon
+                                                className="euiButtonContent__icon"
+                                                color="inherit"
+                                                size="s"
+                                                type="arrowDown"
                                               >
-                                                <svg
+                                                <EuiIconBeaker
                                                   aria-hidden={true}
                                                   className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                                   focusable="false"
-                                                  height={16}
                                                   role="img"
                                                   style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconBeaker>
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButtonEmpty__text"
                                               >
-                                                Sorting
-                                              </EuiI18n>
+                                                <EuiI18n
+                                                  default="Sorting"
+                                                  token="euiTableSortMobile.sorting"
+                                                >
+                                                  Sorting
+                                                </EuiI18n>
+                                              </span>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
                   id="random_html_id"
-                  tabIndex={-1}
+                  responsive={true}
+                  tableLayout="auto"
                 >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCellCheckbox
-                          key="_selection_column_h"
-                        >
-                          <th
-                            className="euiTableHeaderCellCheckbox"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <div
-                              className="euiTableCellContent"
-                            >
-                              <EuiI18n
-                                default="Select all rows"
-                                token="euiBasicTable.selectAllRows"
-                              >
-                                <EuiCheckbox
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  compressed={false}
-                                  data-test-subj="checkboxSelectAll"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  indeterminate={false}
-                                  label={null}
-                                  onChange={[Function]}
-                                  type="inList"
-                                >
-                                  <div
-                                    className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                  >
-                                    <input
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      className="euiCheckbox__input"
-                                      data-test-subj="checkboxSelectAll"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      onChange={[Function]}
-                                      type="checkbox"
-                                    />
-                                    <div
-                                      className="euiCheckbox__square"
-                                    />
-                                  </div>
-                                </EuiCheckbox>
-                              </EuiI18n>
-                            </div>
-                          </th>
-                        </EuiTableHeaderCellCheckbox>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_name_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_name_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_name_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Name",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Name"
-                                      >
-                                        Name
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
-                                  >
-                                    <EuiIconBeaker
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </EuiIconBeaker>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_average_latency_1"
-                          isSorted={false}
-                          key="_data_h_average_latency_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_average_latency_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Average duration (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Average duration (ms)"
-                                      >
-                                        Average duration (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_rate_2"
-                          isSorted={false}
-                          key="_data_h_error_rate_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_rate_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Error rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Error rate"
-                                      >
-                                        Error rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_throughput_3"
-                          isSorted={false}
-                          key="_data_h_throughput_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_throughput_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Request rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Request rate"
-                                      >
-                                        Request rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                          isSorted={false}
-                          key="_data_h_number_of_connected_services_4"
-                          onSort={[Function]}
-                          width="80px"
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": "80px",
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "No. of connected services",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="No. of connected services"
-                                      >
-                                        No. of connected services
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_connected_services_5"
-                          isSorted={false}
-                          key="_data_h_connected_services_5"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_connected_services_5"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Connected services",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Connected services"
-                                      >
-                                        Connected services
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_traces_6"
-                          isSorted={false}
-                          key="_data_h_traces_6"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_traces_6"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Traces",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Traces"
-                                      >
-                                        Traces
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="center"
-                          data-test-subj="tableHeaderCell_actions_7"
-                          key="_data_h_actions_7"
-                        >
-                          <th
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_actions_7"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <CellContents
-                              className="euiTableCellContent euiTableCellContent--alignCenter"
-                              showSortMsg={false}
-                            >
-                              <span
-                                className="euiTableCellContent euiTableCellContent--alignCenter"
-                              >
-                                <EuiInnerText>
-                                  <EuiI18n
-                                    default="{innerText}; {description}"
-                                    token="euiTableHeaderCell.titleTextWithDesc"
-                                    values={
-                                      Object {
-                                        "description": undefined,
-                                        "innerText": "Actions",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiTableCellContent__text"
-                                      title="Actions"
-                                    >
-                                      Actions
-                                    </span>
-                                  </EuiI18n>
-                                </EuiInnerText>
-                              </span>
-                            </CellContents>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
+                  <table
+                    className="euiTable euiTable--responsive euiTable--auto"
+                    id="random_html_id"
+                    tabIndex={-1}
                   >
-                    <tbody>
-                      <EuiTableRow
-                        isSelectable={true}
-                        isSelected={false}
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
                       >
-                        <tr
-                          className="euiTableRow euiTableRow-isSelectable"
-                        >
-                          <EuiTableRowCellCheckbox
-                            key="_selection_column_0"
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCellCheckbox
+                            key="_selection_column_h"
                           >
-                            <td
-                              className="euiTableRowCellCheckbox"
+                            <th
+                              className="euiTableHeaderCellCheckbox"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
                             >
                               <div
                                 className="euiTableCellContent"
                               >
                                 <EuiI18n
-                                  default="Select this row"
-                                  token="euiBasicTable.selectThisRow"
+                                  default="Select all rows"
+                                  token="euiBasicTable.selectAllRows"
                                 >
                                   <EuiCheckbox
-                                    aria-label="Select this row"
+                                    aria-label="Select all rows"
                                     checked={false}
                                     compressed={false}
-                                    data-test-subj="checkboxSelectRow-0"
+                                    data-test-subj="checkboxSelectAll"
                                     disabled={false}
-                                    id="_selection_column_0-checkbox"
+                                    id="_selection_column-checkbox_random_html_id"
                                     indeterminate={false}
+                                    label={null}
                                     onChange={[Function]}
-                                    title="Select this row"
                                     type="inList"
                                   >
                                     <div
                                       className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
                                     >
                                       <input
-                                        aria-label="Select this row"
+                                        aria-label="Select all rows"
                                         checked={false}
                                         className="euiCheckbox__input"
-                                        data-test-subj="checkboxSelectRow-0"
+                                        data-test-subj="checkboxSelectAll"
                                         disabled={false}
-                                        id="_selection_column_0-checkbox"
+                                        id="_selection_column-checkbox_random_html_id"
                                         onChange={[Function]}
-                                        title="Select this row"
                                         type="checkbox"
                                       />
                                       <div
@@ -3675,650 +3160,1167 @@ exports[`Services table component renders services table 1`] = `
                                   </EuiCheckbox>
                                 </EuiI18n>
                               </div>
-                            </td>
-                          </EuiTableRowCellCheckbox>
-                          <EuiTableRowCell
+                            </th>
+                          </EuiTableHeaderCellCheckbox>
+                          <EuiTableHeaderCell
                             align="left"
-                            key="_data_column_name_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Name",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
+                            data-test-subj="tableHeaderCell_name_0"
+                            isSortAscending={true}
+                            isSorted={true}
+                            key="_data_h_name_0"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="ascending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_name_0"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Name
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  className=""
-                                  data-test-subj="service-link"
-                                  key=".0"
-                                  onClick={[Function]}
+                                <CellContents
+                                  className="euiTableCellContent"
+                                  isSortAscending={true}
+                                  isSorted={true}
+                                  showSortMsg={true}
                                 >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    data-test-subj="service-link"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
+                                  <span
+                                    className="euiTableCellContent"
                                   >
-                                    database
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_average_latency_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Average duration (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Average duration (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="average_latency"
-                                  item={49.54}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "connected_services": Array [
-                                        "order",
-                                        "inventory",
-                                      ],
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "number_of_connected_services": 2,
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Name",
+                                          }
+                                        }
                                       >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Name"
                                         >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  49.54
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                          Name
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                    <EuiIcon
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortUp"
+                                    >
+                                      <EuiIconBeaker
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                        focusable="false"
+                                        role="img"
+                                        style={null}
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </EuiIconBeaker>
+                                    </EuiIcon>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="right"
-                            key="_data_column_error_rate_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Error rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
+                            data-test-subj="tableHeaderCell_average_latency_1"
+                            isSorted={false}
+                            key="_data_h_average_latency_1"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_average_latency_1"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Error rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="error_rate"
-                                  item={3.77}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "connected_services": Array [
-                                        "order",
-                                        "inventory",
-                                      ],
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "number_of_connected_services": 2,
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Average duration (ms)",
+                                          }
+                                        }
                                       >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Average duration (ms)"
                                         >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiText
-                                                    size="s"
-                                                  >
-                                                    <div
-                                                      className="euiText euiText--small"
-                                                    >
-                                                      3.77%
-                                                    </div>
-                                                  </EuiText>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                          Average duration (ms)
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="right"
-                            key="_data_column_throughput_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": "Request rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            data-test-subj="tableHeaderCell_error_rate_2"
+                            isSorted={false}
+                            key="_data_h_error_rate_2"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_error_rate_2"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Request rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="throughput"
-                                  item={53}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "connected_services": Array [
-                                        "order",
-                                        "inventory",
-                                      ],
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "number_of_connected_services": 2,
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Error rate",
+                                          }
+                                        }
                                       >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Error rate"
                                         >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiI18nNumber
-                                                    value={53}
-                                                  >
-                                                    53
-                                                  </EuiI18nNumber>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                          Error rate
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="right"
-                            key="_data_column_number_of_connected_services_0_4"
-                            mobileOptions={
-                              Object {
-                                "header": "No. of connected services",
-                                "render": undefined,
+                            data-test-subj="tableHeaderCell_throughput_3"
+                            isSorted={false}
+                            key="_data_h_throughput_3"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_throughput_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
                               }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Request rate",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Request rate"
+                                        >
+                                          Request rate
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                            isSorted={false}
+                            key="_data_h_number_of_connected_services_4"
+                            onSort={[Function]}
                             width="80px"
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": "80px",
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                No. of connected services
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                2
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "No. of connected services",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="No. of connected services"
+                                        >
+                                          No. of connected services
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="left"
-                            key="_data_column_connected_services_0_5"
-                            mobileOptions={
-                              Object {
-                                "header": "Connected services",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            data-test-subj="tableHeaderCell_connected_services_5"
+                            isSorted={false}
+                            key="_data_h_connected_services_5"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_connected_services_5"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Connected services
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiText
-                                  className=""
-                                  key=".0"
-                                  size="s"
+                                <CellContents
+                                  className="euiTableCellContent"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <div
-                                    className="euiText euiText--small"
+                                  <span
+                                    className="euiTableCellContent"
                                   >
-                                    order, inventory
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Connected services",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Connected services"
+                                        >
+                                          Connected services
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="right"
-                            key="_data_column_traces_0_6"
-                            mobileOptions={
-                              Object {
-                                "header": "Traces",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            data-test-subj="tableHeaderCell_traces_6"
+                            isSorted={false}
+                            key="_data_h_traces_6"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_traces_6"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Traces
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  onClick={[Function]}
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
                                   >
-                                    <EuiI18nNumber
-                                      value={31}
-                                    >
-                                      31
-                                    </EuiI18nNumber>
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Traces",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Traces"
+                                        >
+                                          Traces
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="center"
-                            key="_data_column_actions_0_7"
-                            mobileOptions={
-                              Object {
-                                "header": "Actions",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
+                            data-test-subj="tableHeaderCell_actions_7"
+                            key="_data_h_actions_7"
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_actions_7"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                                showSortMsg={false}
                               >
-                                Actions
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  className=""
-                                  justifyContent="center"
-                                  key=".0"
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
                                 >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Actions",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Actions"
+                                      >
+                                        Actions
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody
+                      bodyRef={[Function]}
+                    >
+                      <tbody>
+                        <EuiTableRow
+                          isSelectable={true}
+                          isSelected={false}
+                        >
+                          <tr
+                            className="euiTableRow euiTableRow-isSelectable"
+                          >
+                            <EuiTableRowCellCheckbox
+                              key="_selection_column_0"
+                            >
+                              <td
+                                className="euiTableRowCellCheckbox"
+                              >
+                                <div
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiI18n
+                                    default="Select this row"
+                                    token="euiBasicTable.selectThisRow"
                                   >
-                                    <EuiFlexItem
-                                      grow={false}
-                                      onClick={[Function]}
+                                    <EuiCheckbox
+                                      aria-label="Select this row"
+                                      checked={false}
+                                      compressed={false}
+                                      data-test-subj="checkboxSelectRow-0"
+                                      disabled={false}
+                                      id="_selection_column_0-checkbox"
+                                      indeterminate={false}
+                                      onChange={[Function]}
+                                      title="Select this row"
+                                      type="inList"
                                     >
                                       <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                      >
+                                        <input
+                                          aria-label="Select this row"
+                                          checked={false}
+                                          className="euiCheckbox__input"
+                                          data-test-subj="checkboxSelectRow-0"
+                                          disabled={false}
+                                          id="_selection_column_0-checkbox"
+                                          onChange={[Function]}
+                                          title="Select this row"
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          className="euiCheckbox__square"
+                                        />
+                                      </div>
+                                    </EuiCheckbox>
+                                  </EuiI18n>
+                                </div>
+                              </td>
+                            </EuiTableRowCellCheckbox>
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_name_0_0"
+                              mobileOptions={
+                                Object {
+                                  "header": "Name",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Name
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiLink
+                                    className=""
+                                    data-test-subj="service-link"
+                                    key=".0"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      data-test-subj="service-link"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      database
+                                    </button>
+                                  </EuiLink>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_average_latency_0_1"
+                              mobileOptions={
+                                Object {
+                                  "header": "Average duration (ms)",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Average duration (ms)
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                >
+                                  <ServiceTrendsPlots
+                                    className=""
+                                    fieldType="average_latency"
+                                    item={49.54}
+                                    key=".0"
+                                    row={
+                                      Object {
+                                        "average_latency": 49.54,
+                                        "connected_services": Array [
+                                          "order",
+                                          "inventory",
+                                        ],
+                                        "error_rate": 3.77,
+                                        "name": "database",
+                                        "number_of_connected_services": 2,
+                                        "throughput": 53,
+                                        "traces": 31,
+                                      }
+                                    }
+                                  >
+                                    <EuiFlexGroup
+                                      gutterSize="s"
+                                      justifyContent="flexEnd"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiText
+                                              color="default"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <div
+                                                className="euiText euiText--medium"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <EuiTextColor
+                                                  color="default"
+                                                  component="div"
+                                                >
+                                                  <div
+                                                    className="euiTextColor euiTextColor--default"
+                                                  >
+                                                    49.54
+                                                  </div>
+                                                </EuiTextColor>
+                                              </div>
+                                            </EuiText>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </ServiceTrendsPlots>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_error_rate_0_2"
+                              mobileOptions={
+                                Object {
+                                  "header": "Error rate",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Error rate
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                >
+                                  <ServiceTrendsPlots
+                                    className=""
+                                    fieldType="error_rate"
+                                    item={3.77}
+                                    key=".0"
+                                    row={
+                                      Object {
+                                        "average_latency": 49.54,
+                                        "connected_services": Array [
+                                          "order",
+                                          "inventory",
+                                        ],
+                                        "error_rate": 3.77,
+                                        "name": "database",
+                                        "number_of_connected_services": 2,
+                                        "throughput": 53,
+                                        "traces": 31,
+                                      }
+                                    }
+                                  >
+                                    <EuiFlexGroup
+                                      gutterSize="s"
+                                      justifyContent="flexEnd"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiText
+                                              color="default"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <div
+                                                className="euiText euiText--medium"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <EuiTextColor
+                                                  color="default"
+                                                  component="div"
+                                                >
+                                                  <div
+                                                    className="euiTextColor euiTextColor--default"
+                                                  >
+                                                    <EuiText
+                                                      size="s"
+                                                    >
+                                                      <div
+                                                        className="euiText euiText--small"
+                                                      >
+                                                        3.77%
+                                                      </div>
+                                                    </EuiText>
+                                                  </div>
+                                                </EuiTextColor>
+                                              </div>
+                                            </EuiText>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </ServiceTrendsPlots>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_throughput_0_3"
+                              mobileOptions={
+                                Object {
+                                  "header": "Request rate",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Request rate
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <ServiceTrendsPlots
+                                    className=""
+                                    fieldType="throughput"
+                                    item={53}
+                                    key=".0"
+                                    row={
+                                      Object {
+                                        "average_latency": 49.54,
+                                        "connected_services": Array [
+                                          "order",
+                                          "inventory",
+                                        ],
+                                        "error_rate": 3.77,
+                                        "name": "database",
+                                        "number_of_connected_services": 2,
+                                        "throughput": 53,
+                                        "traces": 31,
+                                      }
+                                    }
+                                  >
+                                    <EuiFlexGroup
+                                      gutterSize="s"
+                                      justifyContent="flexEnd"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiText
+                                              color="default"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <div
+                                                className="euiText euiText--medium"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <EuiTextColor
+                                                  color="default"
+                                                  component="div"
+                                                >
+                                                  <div
+                                                    className="euiTextColor euiTextColor--default"
+                                                  >
+                                                    <EuiI18nNumber
+                                                      value={53}
+                                                    >
+                                                      53
+                                                    </EuiI18nNumber>
+                                                  </div>
+                                                </EuiTextColor>
+                                              </div>
+                                            </EuiText>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </ServiceTrendsPlots>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_number_of_connected_services_0_4"
+                              mobileOptions={
+                                Object {
+                                  "header": "No. of connected services",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                              width="80px"
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": "80px",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  No. of connected services
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  2
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_connected_services_0_5"
+                              mobileOptions={
+                                Object {
+                                  "header": "Connected services",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Connected services
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiText
+                                    className=""
+                                    key=".0"
+                                    size="s"
+                                  >
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      order, inventory
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_traces_0_6"
+                              mobileOptions={
+                                Object {
+                                  "header": "Traces",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Traces
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiLink
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="euiLink euiLink--primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiI18nNumber
+                                        value={31}
+                                      >
+                                        31
+                                      </EuiI18nNumber>
+                                    </button>
+                                  </EuiLink>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="center"
+                              key="_data_column_actions_0_7"
+                              mobileOptions={
+                                Object {
+                                  "header": "Actions",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Actions
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiFlexGroup
+                                    className=""
+                                    justifyContent="center"
+                                    key=".0"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
                                         onClick={[Function]}
                                       >
-                                        <EuiLink
-                                          data-test-subj="service-flyout-action-btnundefined"
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          onClick={[Function]}
                                         >
-                                          <button
-                                            className="euiLink euiLink--primary"
+                                          <EuiLink
                                             data-test-subj="service-flyout-action-btnundefined"
-                                            disabled={false}
-                                            type="button"
                                           >
-                                            <EuiIcon
-                                              color="primary"
-                                              type="inspect"
+                                            <button
+                                              className="euiLink euiLink--primary"
+                                              data-test-subj="service-flyout-action-btnundefined"
+                                              disabled={false}
+                                              type="button"
                                             >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiIcon
+                                                color="primary"
+                                                type="inspect"
                                               >
-                                                <svg
+                                                <EuiIconBeaker
                                                   aria-hidden={true}
                                                   className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
                                                   focusable="false"
-                                                  height={16}
                                                   role="img"
                                                   style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconBeaker>
+                                              </EuiIcon>
+                                            </button>
+                                          </EuiLink>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+              <PaginationBar
+                aria-controls="random_html_id"
+                onPageChange={[Function]}
+                onPageSizeChange={[Function]}
+                pagination={
+                  Object {
+                    "hidePerPageOptions": undefined,
+                    "pageIndex": 0,
+                    "pageSize": 10,
+                    "pageSizeOptions": Array [
                       5,
                       10,
                       15,
-                    ]
+                    ],
+                    "totalItemCount": 1,
                   }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+                }
+              >
+                <div>
+                  <EuiSpacer
+                    size="m"
                   >
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiTablePagination
+                    activePage={0}
+                    aria-controls="random_html_id"
+                    itemsPerPage={10}
+                    itemsPerPageOptions={
+                      Array [
+                        5,
+                        10,
+                        15,
+                      ]
+                    }
+                    onChangeItemsPerPage={[Function]}
+                    onChangePage={[Function]}
+                    pageCount={1}
+                  >
+                    <EuiFlexGroup
+                      alignItems="center"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiPopover euiPopover--anchorUpRight"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
+                            <EuiPopover
+                              anchorPosition="upRight"
+                              button={
                                 <EuiButtonEmpty
                                   color="text"
                                   data-test-subj="tablePaginationPopoverButton"
@@ -4327,43 +4329,168 @@ exports[`Services table component renders services table 1`] = `
                                   onClick={[Function]}
                                   size="xs"
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                  <EuiI18n
+                                    default="Rows per page"
+                                    token="euiTablePagination.rowsPerPage"
+                                  />
+                                  : 
+                                  10
+                                </EuiButtonEmpty>
+                              }
+                              closePopover={[Function]}
+                              display="inlineBlock"
+                              hasArrow={true}
+                              isOpen={false}
+                              ownFocus={true}
+                              panelPaddingSize="none"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorUpRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <EuiButtonEmpty
+                                    color="text"
                                     data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
+                                    iconSide="right"
+                                    iconType="arrowDown"
                                     onClick={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                      data-test-subj="tablePaginationPopoverButton"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="right"
+                                        iconSize="s"
+                                        iconType="arrowDown"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        >
+                                          <EuiIcon
+                                            className="euiButtonContent__icon"
+                                            color="inherit"
+                                            size="s"
+                                            type="arrowDown"
+                                          >
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            <EuiI18n
+                                              default="Rows per page"
+                                              token="euiTablePagination.rowsPerPage"
+                                            >
+                                              Rows per page
+                                            </EuiI18n>
+                                            : 
+                                            10
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </div>
+                            </EuiPopover>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiPagination
+                              activePage={0}
+                              aria-controls="random_html_id"
+                              onPageClick={[Function]}
+                              pageCount={1}
+                            >
+                              <nav
+                                className="euiPagination"
+                              >
+                                <EuiI18n
+                                  default="Previous page, {page}"
+                                  token="euiPagination.previousPage"
+                                  values={
+                                    Object {
+                                      "page": 0,
+                                    }
+                                  }
+                                >
+                                  <EuiI18n
+                                    default="Previous page"
+                                    token="euiPagination.disabledPreviousPage"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Previous page"
+                                      color="text"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      iconType="arrowLeft"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        aria-label="Previous page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
                                         <EuiIcon
-                                          className="euiButtonContent__icon"
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
                                           color="inherit"
-                                          size="s"
-                                          type="arrowDown"
+                                          size="m"
+                                          type="arrowLeft"
                                         >
                                           <EuiIconBeaker
                                             aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                             focusable="false"
                                             role="img"
                                             style={null}
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
                                               height={16}
                                               role="img"
@@ -4378,270 +4505,175 @@ exports[`Services table component renders services table 1`] = `
                                             </svg>
                                           </EuiIconBeaker>
                                         </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
-                                        >
-                                          <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
+                                <ul
+                                  className="euiPagination__list"
                                 >
-                                  <li
-                                    className="euiPagination__item"
+                                  <PaginationButton
+                                    key="0"
+                                    pageIndex={0}
                                   >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
+                                    <li
+                                      className="euiPagination__item"
                                     >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
+                                      <EuiPaginationButton
+                                        aria-controls="random_html_id"
+                                        hideOnMobile={true}
+                                        isActive={true}
+                                        onClick={[Function]}
+                                        pageIndex={0}
+                                        totalPages={1}
                                       >
                                         <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
+                                          default="Page {page} of {totalPages}"
+                                          token="euiPaginationButton.longPageString"
                                           values={
                                             Object {
                                               "page": 1,
+                                              "totalPages": 1,
                                             }
                                           }
                                         >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
+                                          <EuiI18n
+                                            default="Page {page}"
+                                            token="euiPaginationButton.shortPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                              }
+                                            }
                                           >
-                                            <button
+                                            <EuiButtonEmpty
                                               aria-controls="random_html_id"
                                               aria-current={true}
                                               aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              color="text"
                                               data-test-subj="pagination-button-0"
-                                              disabled={true}
+                                              href="#random_html_id"
+                                              isDisabled={true}
                                               onClick={[Function]}
-                                              type="button"
+                                              size="s"
                                             >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
-                                                }
+                                              <button
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                data-test-subj="pagination-button-0"
+                                                disabled={true}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="left"
+                                                  iconSize="m"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text",
+                                                    }
+                                                  }
                                                 >
                                                   <span
-                                                    className="euiButtonEmpty__text"
+                                                    className="euiButtonContent euiButtonEmpty__content"
                                                   >
-                                                    1
+                                                    <span
+                                                      className="euiButtonEmpty__text"
+                                                    >
+                                                      1
+                                                    </span>
                                                   </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </EuiI18n>
                                         </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
+                                      </EuiPaginationButton>
+                                    </li>
+                                  </PaginationButton>
+                                </ul>
                                 <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
+                                  default="Next page, {page}"
+                                  token="euiPagination.nextPage"
+                                  values={
+                                    Object {
+                                      "page": 2,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                  <EuiI18n
+                                    default="Next page"
+                                    token="euiPagination.disabledNextPage"
                                   >
-                                    <button
+                                    <EuiButtonIcon
                                       aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      color="text"
                                       data-test-subj="pagination-button-next"
                                       disabled={true}
+                                      iconType="arrowRight"
                                       onClick={[Function]}
-                                      type="button"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <button
+                                        aria-label="Next page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="arrowRight"
                                         >
-                                          <svg
+                                          <EuiIconBeaker
                                             aria-hidden={true}
                                             className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                             focusable="false"
-                                            height={16}
                                             role="img"
                                             style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
-              </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
-    </div>
-  </EuiPanel>
+                              </nav>
+                            </EuiPagination>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </EuiTablePagination>
+                </div>
+              </PaginationBar>
+            </div>
+          </EuiBasicTable>
+        </EuiInMemoryTable>
+      </div>
+    </EuiPanel>
+  </div>
 </ServicesTable>
 `;

--- a/public/components/trace_analytics/components/services/services.tsx
+++ b/public/components/trace_analytics/components/services/services.tsx
@@ -8,7 +8,6 @@ import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { TraceAnalyticsComponentDeps } from '../../home';
-import { DataSourcePicker } from '../dashboard/mode_picker';
 import { ServicesContent } from './services_content';
 
 export interface ServicesProps extends TraceAnalyticsComponentDeps {
@@ -23,7 +22,6 @@ export interface ServicesProps extends TraceAnalyticsComponentDeps {
 export function Services(props: ServicesProps) {
   return (
     <>
-      <DataSourcePicker modes={props.modes} selectedMode={props.mode} setMode={props.setMode!} />
       <ServicesContent {...props} />
     </>
   );

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -20,8 +20,9 @@ import { SearchBar } from '../common/search_bar';
 import { ServicesTable } from './services_table';
 import { coreRefs } from '../../../../framework/core_refs';
 import { DataSourcePicker } from '../dashboard/mode_picker';
+import { ServicesProps } from './services';
 
-export function ServicesContent(props) {
+export function ServicesContent(props: ServicesProps) {
   const {
     page,
     http,

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -2,9 +2,8 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-/* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useRef, useState } from 'react';
 import { ServiceTrends } from '../../../../../common/types/trace_analytics';
@@ -14,15 +13,15 @@ import {
   handleServiceTrendsRequest,
 } from '../../requests/services_request_handler';
 import { getValidFilterFields } from '../common/filters/filter_helpers';
-import { FilterType } from '../common/filters/filters';
+import { FilterType, Filters } from '../common/filters/filters';
 import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { SearchBar } from '../common/search_bar';
-import { ServicesProps } from './services';
 import { ServicesTable } from './services_table';
 import { coreRefs } from '../../../../framework/core_refs';
+import { DataSourcePicker } from '../dashboard/mode_picker';
 
-export function ServicesContent(props: ServicesProps) {
+export function ServicesContent(props) {
   const {
     page,
     http,
@@ -47,7 +46,6 @@ export function ServicesContent(props: ServicesProps) {
     attributesFilterFields,
   } = props;
   const [tableItems, setTableItems] = useState([]);
-
   const [serviceMap, setServiceMap] = useState<ServiceObject>({});
   const [serviceMapIdSelected, setServiceMapIdSelected] = useState<
     'latency' | 'error_rate' | 'throughput'
@@ -174,23 +172,46 @@ export function ServicesContent(props: ServicesProps) {
 
   return (
     <>
-      <SearchBar
-        ref={searchBarRef}
-        query={query}
-        filters={filters}
-        appConfigs={appConfigs}
-        setFilters={setFilters}
-        setQuery={setQuery}
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
-        refresh={refresh}
+      <EuiFlexGroup
+        gutterSize="s"
+        alignItems="center"
+        justifyContent="spaceBetween"
+        style={{ padding: '0 16px' }}
+      >
+        <EuiFlexItem grow={false}>
+          <DataSourcePicker
+            modes={props.modes}
+            selectedMode={props.mode}
+            setMode={props.setMode!}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <SearchBar
+            ref={searchBarRef}
+            filters={filters}
+            setFilters={setFilters}
+            query={query}
+            setQuery={setQuery}
+            startTime={startTime}
+            setStartTime={setStartTime}
+            endTime={endTime}
+            setEndTime={setEndTime}
+            refresh={refresh}
+            page={page}
+            mode={mode}
+            attributesFilterFields={attributesFilterFields}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Filters
         page={page}
+        filters={filters}
+        setFilters={setFilters}
+        appConfigs={appConfigs}
         mode={mode}
         attributesFilterFields={attributesFilterFields}
       />
-      <EuiSpacer size="m" />
+      <EuiSpacer size="s" />
       <ServicesTable
         items={tableItems}
         selectedItems={selectedItems}
@@ -208,7 +229,7 @@ export function ServicesContent(props: ServicesProps) {
         setIsServiceTrendEnabled={setIsServiceTrendEnabled}
         serviceTrends={serviceTrends}
       />
-      <EuiSpacer size="m" />
+      <EuiSpacer size="s" />
       {mode === 'data_prepper' && dataPrepperIndicesExist ? (
         <ServiceMap
           addFilter={addFilter}

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -18,6 +18,7 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
   EuiToolTip,
+  EuiPage,
 } from '@elastic/eui';
 import truncate from 'lodash/truncate';
 import React, { useMemo } from 'react';
@@ -264,7 +265,7 @@ export function ServicesTable(props: ServicesTableProps) {
 
   return (
     <>
-      <div style={{ padding: '0 16px' }}>
+      <EuiPage paddingSize="m">
         <EuiPanel>
           {titleBar}
           <EuiSpacer size="m" />
@@ -298,7 +299,7 @@ export function ServicesTable(props: ServicesTableProps) {
             <NoMatchMessage size="xl" />
           )}
         </EuiPanel>
-      </div>
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -264,39 +264,41 @@ export function ServicesTable(props: ServicesTableProps) {
 
   return (
     <>
-      <EuiPanel>
-        {titleBar}
-        <EuiSpacer size="m" />
-        <EuiHorizontalRule margin="none" />
-        {!(
-          (mode === 'data_prepper' && dataPrepperIndicesExist) ||
-          (mode === 'jaeger' && jaegerIndicesExist)
-        ) ? (
-          <MissingConfigurationMessage mode={mode} />
-        ) : items?.length > 0 ? (
-          <EuiInMemoryTable
-            tableLayout="auto"
-            items={items}
-            columns={columns}
-            pagination={{
-              initialPageSize: 10,
-              pageSizeOptions: [5, 10, 15],
-            }}
-            sorting={{
-              sort: {
-                field: 'name',
-                direction: 'asc',
-              },
-            }}
-            loading={loading}
-            selection={selectionValue}
-            isSelectable={true}
-            itemId="itemId"
-          />
-        ) : (
-          <NoMatchMessage size="xl" />
-        )}
-      </EuiPanel>
+      <div style={{ padding: '0 16px' }}>
+        <EuiPanel>
+          {titleBar}
+          <EuiSpacer size="m" />
+          <EuiHorizontalRule margin="none" />
+          {!(
+            (mode === 'data_prepper' && dataPrepperIndicesExist) ||
+            (mode === 'jaeger' && jaegerIndicesExist)
+          ) ? (
+            <MissingConfigurationMessage mode={mode} />
+          ) : items?.length > 0 ? (
+            <EuiInMemoryTable
+              tableLayout="auto"
+              items={items}
+              columns={columns}
+              pagination={{
+                initialPageSize: 10,
+                pageSizeOptions: [5, 10, 15],
+              }}
+              sorting={{
+                sort: {
+                  field: 'name',
+                  direction: 'asc',
+                },
+              }}
+              loading={loading}
+              selection={selectionValue}
+              isSelectable={true}
+              itemId="itemId"
+            />
+          ) : (
+            <NoMatchMessage size="xl" />
+          )}
+        </EuiPanel>
+      </div>
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -1479,122 +1479,115 @@ exports[`Traces component renders empty traces page 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <div
-      style={
-        Object {
-          "padding": "0 16px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiAccordion
-            arrowDisplay="left"
-            buttonContent="Trace Groups"
-            data-test-subj="trace-groups-service-operation-accordian"
-            forceState="closed"
-            id="accordion1"
-            initialIsOpen={false}
-            isLoading={false}
-            isLoadingMessage={false}
-            onToggle={[Function]}
-            paddingSize="none"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiAccordion"
+            <EuiAccordion
+              arrowDisplay="left"
+              buttonContent="Trace Groups"
               data-test-subj="trace-groups-service-operation-accordian"
+              forceState="closed"
+              id="accordion1"
+              initialIsOpen={false}
+              isLoading={false}
+              isLoadingMessage={false}
               onToggle={[Function]}
+              paddingSize="none"
             >
               <div
-                className="euiAccordion__triggerWrapper"
+                className="euiAccordion"
+                data-test-subj="trace-groups-service-operation-accordian"
+                onToggle={[Function]}
               >
-                <button
-                  aria-controls="accordion1"
-                  aria-expanded={false}
-                  className="euiAccordion__button"
-                  id="random_html_id"
-                  onClick={[Function]}
-                  type="button"
+                <div
+                  className="euiAccordion__triggerWrapper"
                 >
-                  <span
-                    className="euiAccordion__iconWrapper"
+                  <button
+                    aria-controls="accordion1"
+                    aria-expanded={false}
+                    className="euiAccordion__button"
+                    id="random_html_id"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <EuiIcon
-                      className="euiAccordion__icon"
-                      size="m"
-                      type="arrowRight"
+                    <span
+                      className="euiAccordion__iconWrapper"
                     >
-                      <EuiIconBeaker
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
+                      <EuiIcon
+                        className="euiAccordion__icon"
+                        size="m"
+                        type="arrowRight"
                       >
-                        <svg
+                        <EuiIconBeaker
                           aria-hidden={true}
                           className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
                           focusable="false"
-                          height={16}
                           role="img"
                           style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                          />
-                        </svg>
-                      </EuiIconBeaker>
-                    </EuiIcon>
-                  </span>
-                  <span
-                    className="euiIEFlexWrapFix"
-                  >
-                    Trace Groups
-                  </span>
-                </button>
-              </div>
-              <div
-                aria-labelledby="random_html_id"
-                className="euiAccordion__childWrapper"
-                id="accordion1"
-                role="region"
-                tabIndex={-1}
-              >
-                <EuiResizeObserver
-                  onResize={[Function]}
-                >
-                  <div>
-                    <div
-                      className=""
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </EuiIconBeaker>
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
                     >
-                      <EuiSpacer
-                        size="m"
+                      Trace Groups
+                    </span>
+                  </button>
+                </div>
+                <div
+                  aria-labelledby="random_html_id"
+                  className="euiAccordion__childWrapper"
+                  id="accordion1"
+                  role="region"
+                  tabIndex={-1}
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                      </div>
                     </div>
-                  </div>
-                </EuiResizeObserver>
+                  </EuiResizeObserver>
+                </div>
               </div>
-            </div>
-          </EuiAccordion>
-        </div>
-      </EuiPanel>
-    </div>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+            </EuiAccordion>
+          </div>
+        </EuiPanel>
+      </div>
+    </EuiPage>
     <TracesTable
       dataPrepperIndicesExist={true}
       items={Array []}
@@ -1603,146 +1596,146 @@ exports[`Traces component renders empty traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
+      <EuiPage
+        paddingSize="m"
       >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiFlexGroup
-              alignItems="center"
-              gutterSize="s"
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
+        >
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
-                <EuiFlexItem
-                  grow={10}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem
+                    grow={10}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrow10"
+                    >
+                      <PanelTitle
+                        title="Traces"
+                        totalItems={0}
+                      >
+                        <EuiText
+                          size="m"
+                        >
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <span
+                              className="panel-title"
+                            >
+                              Traces
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
                 >
                   <div
-                    className="euiFlexItem euiFlexItem--flexGrow10"
-                  >
-                    <PanelTitle
-                      title="Traces"
-                      totalItems={0}
-                    >
-                      <EuiText
-                        size="m"
-                      >
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          <span
-                            className="panel-title"
-                          >
-                            Traces
-                          </span>
-                          <span
-                            className="panel-title-count"
-                          >
-                             (0)
-                          </span>
-                        </div>
-                      </EuiText>
-                    </PanelTitle>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiHorizontalRule
-              margin="none"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full"
-              />
-            </EuiHorizontalRule>
-            <NoMatchMessage
-              size="xl"
-            >
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText>
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
-                >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText>
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
                       No matches
                     </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
                   >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
+                    <EuiTitle
+                      size="m"
                     >
-                      <EuiSpacer
-                        size="m"
+                      <h2
+                        className="euiTitle euiTitle--medium"
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
                         >
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
-                          </EuiText>
-                        </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
-                </div>
-              </EuiEmptyPrompt>
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-            </NoMatchMessage>
-          </div>
-        </EuiPanel>
-      </div>
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
+        </div>
+      </EuiPage>
     </TracesTable>
   </TracesContent>
 </Traces>
@@ -3231,123 +3224,116 @@ exports[`Traces component renders jaeger traces page 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <div
-      style={
-        Object {
-          "padding": "0 16px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiAccordion
-            arrowDisplay="left"
-            buttonContent="Service and Operations"
-            data-test-subj="trace-groups-service-operation-accordian"
-            forceState="closed"
-            id="accordion1"
-            initialIsOpen={false}
-            isLoading={false}
-            isLoadingMessage={false}
-            onToggle={[Function]}
-            paddingSize="none"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiAccordion"
+            <EuiAccordion
+              arrowDisplay="left"
+              buttonContent="Service and Operations"
               data-test-subj="trace-groups-service-operation-accordian"
+              forceState="closed"
+              id="accordion1"
+              initialIsOpen={false}
+              isLoading={false}
+              isLoadingMessage={false}
               onToggle={[Function]}
+              paddingSize="none"
             >
               <div
-                className="euiAccordion__triggerWrapper"
+                className="euiAccordion"
+                data-test-subj="trace-groups-service-operation-accordian"
+                onToggle={[Function]}
               >
-                <button
-                  aria-controls="accordion1"
-                  aria-expanded={false}
-                  className="euiAccordion__button"
-                  id="random_html_id"
-                  onClick={[Function]}
-                  type="button"
+                <div
+                  className="euiAccordion__triggerWrapper"
                 >
-                  <span
-                    className="euiAccordion__iconWrapper"
+                  <button
+                    aria-controls="accordion1"
+                    aria-expanded={false}
+                    className="euiAccordion__button"
+                    id="random_html_id"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <EuiIcon
-                      className="euiAccordion__icon"
-                      size="m"
-                      type="arrowRight"
+                    <span
+                      className="euiAccordion__iconWrapper"
                     >
-                      <EuiIconArrowRight
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiAccordion__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
+                      <EuiIcon
+                        className="euiAccordion__icon"
+                        size="m"
+                        type="arrowRight"
                       >
-                        <svg
+                        <EuiIconArrowRight
                           aria-hidden={true}
                           className="euiIcon euiIcon--medium euiAccordion__icon"
                           focusable="false"
-                          height={16}
                           role="img"
                           style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                            fillRule="nonzero"
-                          />
-                        </svg>
-                      </EuiIconArrowRight>
-                    </EuiIcon>
-                  </span>
-                  <span
-                    className="euiIEFlexWrapFix"
-                  >
-                    Service and Operations
-                  </span>
-                </button>
-              </div>
-              <div
-                aria-labelledby="random_html_id"
-                className="euiAccordion__childWrapper"
-                id="accordion1"
-                role="region"
-                tabIndex={-1}
-              >
-                <EuiResizeObserver
-                  onResize={[Function]}
-                >
-                  <div>
-                    <div
-                      className=""
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiAccordion__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                              fillRule="nonzero"
+                            />
+                          </svg>
+                        </EuiIconArrowRight>
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
                     >
-                      <EuiSpacer
-                        size="m"
+                      Service and Operations
+                    </span>
+                  </button>
+                </div>
+                <div
+                  aria-labelledby="random_html_id"
+                  className="euiAccordion__childWrapper"
+                  id="accordion1"
+                  role="region"
+                  tabIndex={-1}
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                      </div>
                     </div>
-                  </div>
-                </EuiResizeObserver>
+                  </EuiResizeObserver>
+                </div>
               </div>
-            </div>
-          </EuiAccordion>
-        </div>
-      </EuiPanel>
-    </div>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+            </EuiAccordion>
+          </div>
+        </EuiPanel>
+      </div>
+    </EuiPage>
     <TracesTable
       dataPrepperIndicesExist={false}
       items={Array []}
@@ -3357,146 +3343,146 @@ exports[`Traces component renders jaeger traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
+      <EuiPage
+        paddingSize="m"
       >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiFlexGroup
-              alignItems="center"
-              gutterSize="s"
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
+        >
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
-                <EuiFlexItem
-                  grow={10}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem
+                    grow={10}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrow10"
+                    >
+                      <PanelTitle
+                        title="Traces"
+                        totalItems={0}
+                      >
+                        <EuiText
+                          size="m"
+                        >
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <span
+                              className="panel-title"
+                            >
+                              Traces
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
                 >
                   <div
-                    className="euiFlexItem euiFlexItem--flexGrow10"
-                  >
-                    <PanelTitle
-                      title="Traces"
-                      totalItems={0}
-                    >
-                      <EuiText
-                        size="m"
-                      >
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          <span
-                            className="panel-title"
-                          >
-                            Traces
-                          </span>
-                          <span
-                            className="panel-title-count"
-                          >
-                             (0)
-                          </span>
-                        </div>
-                      </EuiText>
-                    </PanelTitle>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiHorizontalRule
-              margin="none"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full"
-              />
-            </EuiHorizontalRule>
-            <NoMatchMessage
-              size="xl"
-            >
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText>
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
-                >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText>
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
                       No matches
                     </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
                   >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
+                    <EuiTitle
+                      size="m"
                     >
-                      <EuiSpacer
-                        size="m"
+                      <h2
+                        className="euiTitle euiTitle--medium"
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
                         >
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
-                          </EuiText>
-                        </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
-                </div>
-              </EuiEmptyPrompt>
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-            </NoMatchMessage>
-          </div>
-        </EuiPanel>
-      </div>
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
+        </div>
+      </EuiPage>
     </TracesTable>
   </TracesContent>
 </Traces>
@@ -4983,123 +4969,116 @@ exports[`Traces component renders traces page 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <div
-      style={
-        Object {
-          "padding": "0 16px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiAccordion
-            arrowDisplay="left"
-            buttonContent="Trace Groups"
-            data-test-subj="trace-groups-service-operation-accordian"
-            forceState="closed"
-            id="accordion1"
-            initialIsOpen={false}
-            isLoading={false}
-            isLoadingMessage={false}
-            onToggle={[Function]}
-            paddingSize="none"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiAccordion"
+            <EuiAccordion
+              arrowDisplay="left"
+              buttonContent="Trace Groups"
               data-test-subj="trace-groups-service-operation-accordian"
+              forceState="closed"
+              id="accordion1"
+              initialIsOpen={false}
+              isLoading={false}
+              isLoadingMessage={false}
               onToggle={[Function]}
+              paddingSize="none"
             >
               <div
-                className="euiAccordion__triggerWrapper"
+                className="euiAccordion"
+                data-test-subj="trace-groups-service-operation-accordian"
+                onToggle={[Function]}
               >
-                <button
-                  aria-controls="accordion1"
-                  aria-expanded={false}
-                  className="euiAccordion__button"
-                  id="random_html_id"
-                  onClick={[Function]}
-                  type="button"
+                <div
+                  className="euiAccordion__triggerWrapper"
                 >
-                  <span
-                    className="euiAccordion__iconWrapper"
+                  <button
+                    aria-controls="accordion1"
+                    aria-expanded={false}
+                    className="euiAccordion__button"
+                    id="random_html_id"
+                    onClick={[Function]}
+                    type="button"
                   >
-                    <EuiIcon
-                      className="euiAccordion__icon"
-                      size="m"
-                      type="arrowRight"
+                    <span
+                      className="euiAccordion__iconWrapper"
                     >
-                      <EuiIconArrowRight
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiAccordion__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
+                      <EuiIcon
+                        className="euiAccordion__icon"
+                        size="m"
+                        type="arrowRight"
                       >
-                        <svg
+                        <EuiIconArrowRight
                           aria-hidden={true}
                           className="euiIcon euiIcon--medium euiAccordion__icon"
                           focusable="false"
-                          height={16}
                           role="img"
                           style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                            fillRule="nonzero"
-                          />
-                        </svg>
-                      </EuiIconArrowRight>
-                    </EuiIcon>
-                  </span>
-                  <span
-                    className="euiIEFlexWrapFix"
-                  >
-                    Trace Groups
-                  </span>
-                </button>
-              </div>
-              <div
-                aria-labelledby="random_html_id"
-                className="euiAccordion__childWrapper"
-                id="accordion1"
-                role="region"
-                tabIndex={-1}
-              >
-                <EuiResizeObserver
-                  onResize={[Function]}
-                >
-                  <div>
-                    <div
-                      className=""
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiAccordion__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                              fillRule="nonzero"
+                            />
+                          </svg>
+                        </EuiIconArrowRight>
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
                     >
-                      <EuiSpacer
-                        size="m"
+                      Trace Groups
+                    </span>
+                  </button>
+                </div>
+                <div
+                  aria-labelledby="random_html_id"
+                  className="euiAccordion__childWrapper"
+                  id="accordion1"
+                  role="region"
+                  tabIndex={-1}
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                      </div>
                     </div>
-                  </div>
-                </EuiResizeObserver>
+                  </EuiResizeObserver>
+                </div>
               </div>
-            </div>
-          </EuiAccordion>
-        </div>
-      </EuiPanel>
-    </div>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+            </EuiAccordion>
+          </div>
+        </EuiPanel>
+      </div>
+    </EuiPage>
     <TracesTable
       dataPrepperIndicesExist={true}
       items={Array []}
@@ -5108,146 +5087,146 @@ exports[`Traces component renders traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <div
-        style={
-          Object {
-            "padding": "0 16px",
-          }
-        }
+      <EuiPage
+        paddingSize="m"
       >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiFlexGroup
-              alignItems="center"
-              gutterSize="s"
+        <div
+          className="euiPage euiPage--paddingMedium euiPage--grow"
+        >
+          <EuiPanel>
+            <div
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <div
-                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
-                <EuiFlexItem
-                  grow={10}
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem
+                    grow={10}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrow10"
+                    >
+                      <PanelTitle
+                        title="Traces"
+                        totalItems={0}
+                      >
+                        <EuiText
+                          size="m"
+                        >
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <span
+                              className="panel-title"
+                            >
+                              Traces
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
                 >
                   <div
-                    className="euiFlexItem euiFlexItem--flexGrow10"
-                  >
-                    <PanelTitle
-                      title="Traces"
-                      totalItems={0}
-                    >
-                      <EuiText
-                        size="m"
-                      >
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          <span
-                            className="panel-title"
-                          >
-                            Traces
-                          </span>
-                          <span
-                            className="panel-title-count"
-                          >
-                             (0)
-                          </span>
-                        </div>
-                      </EuiText>
-                    </PanelTitle>
-                  </div>
-                </EuiFlexItem>
-              </div>
-            </EuiFlexGroup>
-            <EuiSpacer
-              size="m"
-            >
-              <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiHorizontalRule
-              margin="none"
-            >
-              <hr
-                className="euiHorizontalRule euiHorizontalRule--full"
-              />
-            </EuiHorizontalRule>
-            <NoMatchMessage
-              size="xl"
-            >
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText>
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
-                >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText>
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
                       No matches
                     </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
                   >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
+                    <EuiTitle
+                      size="m"
                     >
-                      <EuiSpacer
-                        size="m"
+                      <h2
+                        className="euiTitle euiTitle--medium"
                       >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
                         >
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
-                          </EuiText>
-                        </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
-                </div>
-              </EuiEmptyPrompt>
-              <EuiSpacer
-                size="xl"
-              >
-                <div
-                  className="euiSpacer euiSpacer--xl"
-                />
-              </EuiSpacer>
-            </NoMatchMessage>
-          </div>
-        </EuiPanel>
-      </div>
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
+        </div>
+      </EuiPage>
     </TracesTable>
   </TracesContent>
 </Traces>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -238,127 +238,6 @@ exports[`Traces component renders empty traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <button
-              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-              data-test-subj="indexPattern-switch-link"
-              disabled={false}
-              onClick={[Function]}
-              title="data_prepper"
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButtonEmpty__content"
-                iconSide="right"
-                iconSize="m"
-                iconType="arrowDown"
-                textProps={
-                  Object {
-                    "className": "euiButtonEmpty__text",
-                  }
-                }
-              >
-                <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
-                    color="inherit"
-                    size="m"
-                    type="arrowDown"
-                  >
-                    <EuiIconBeaker
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                        />
-                      </svg>
-                    </EuiIconBeaker>
-                  </EuiIcon>
-                  <span
-                    className="euiButtonEmpty__text"
-                  >
-                    Data Prepper
-                  </span>
-                </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -596,16 +475,894 @@ exports[`Traces component renders empty traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <button
+                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                        data-test-subj="indexPattern-switch-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        title="data_prepper"
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="right"
+                          iconSize="m"
+                          iconType="arrowDown"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconBeaker
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
+                            </EuiIcon>
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              Data Prepper
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="traces"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <button
+                                        aria-label="Change all filters"
+                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        title="Change all filters"
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="filter"
+                                        >
+                                          <EuiIconBeaker
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconBeaker
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconBeaker
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconBeaker>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconBeaker
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -621,810 +1378,100 @@ exports[`Traces component renders empty traces page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiFieldSearch
-                compressed={false}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={false}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="m"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="m"
-                                type="search"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  element="button"
-                  iconType="refresh"
-                  isDisabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="euiButton euiButton--primary"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
-                    type="button"
-                  >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      iconType="refresh"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
-                    >
-                      <span
-                        className="euiButtonContent euiButton__content"
-                      >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="refresh"
-                        >
-                          <EuiIconBeaker
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Refresh
-                        </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <button
-                            aria-label="Change all filters"
-                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            title="Change all filters"
-                            type="button"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              color="inherit"
-                              size="m"
-                              type="filter"
-                            >
-                              <EuiIconBeaker
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                  />
-                                </svg>
-                              </EuiIconBeaker>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
       size="m"
     >
@@ -1432,107 +1479,115 @@ exports[`Traces component renders empty traces page 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Trace Groups"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
+    <div
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiAccordion"
+          <EuiAccordion
+            arrowDisplay="left"
+            buttonContent="Trace Groups"
             data-test-subj="trace-groups-service-operation-accordian"
+            forceState="closed"
+            id="accordion1"
+            initialIsOpen={false}
+            isLoading={false}
+            isLoadingMessage={false}
             onToggle={[Function]}
+            paddingSize="none"
           >
             <div
-              className="euiAccordion__triggerWrapper"
+              className="euiAccordion"
+              data-test-subj="trace-groups-service-operation-accordian"
+              onToggle={[Function]}
             >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
+              <div
+                className="euiAccordion__triggerWrapper"
               >
-                <span
-                  className="euiAccordion__iconWrapper"
+                <button
+                  aria-controls="accordion1"
+                  aria-expanded={false}
+                  className="euiAccordion__button"
+                  id="random_html_id"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
+                  <span
+                    className="euiAccordion__iconWrapper"
                   >
-                    <EuiIconBeaker
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
+                    <EuiIcon
+                      className="euiAccordion__icon"
+                      size="m"
+                      type="arrowRight"
                     >
-                      <svg
+                      <EuiIconBeaker
                         aria-hidden={true}
                         className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
                         focusable="false"
-                        height={16}
                         role="img"
                         style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                        />
-                      </svg>
-                    </EuiIconBeaker>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Trace Groups
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                          />
+                        </svg>
+                      </EuiIconBeaker>
+                    </EuiIcon>
+                  </span>
+                  <span
+                    className="euiIEFlexWrapFix"
                   >
-                    <EuiSpacer
-                      size="m"
+                    Trace Groups
+                  </span>
+                </button>
+              </div>
+              <div
+                aria-labelledby="random_html_id"
+                className="euiAccordion__childWrapper"
+                id="accordion1"
+                role="region"
+                tabIndex={-1}
+              >
+                <EuiResizeObserver
+                  onResize={[Function]}
+                >
+                  <div>
+                    <div
+                      className=""
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
+                      <EuiSpacer
+                        size="m"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                    </div>
                   </div>
-                </div>
-              </EuiResizeObserver>
+                </EuiResizeObserver>
+              </div>
             </div>
-          </div>
-        </EuiAccordion>
-      </div>
-    </EuiPanel>
+          </EuiAccordion>
+        </div>
+      </EuiPanel>
+    </div>
     <EuiSpacer
       size="m"
     >
@@ -1548,138 +1603,146 @@ exports[`Traces component renders empty traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
             >
-              <EuiFlexItem
-                grow={10}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={10}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrow10"
+                  >
+                    <PanelTitle
+                      title="Traces"
+                      totalItems={0}
+                    >
+                      <EuiText
+                        size="m"
+                      >
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <span
+                            className="panel-title"
+                          >
+                            Traces
+                          </span>
+                          <span
+                            className="panel-title-count"
+                          >
+                             (0)
+                          </span>
+                        </div>
+                      </EuiText>
+                    </PanelTitle>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiHorizontalRule
+              margin="none"
+            >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
+            <NoMatchMessage
+              size="xl"
+            >
+              <EuiSpacer
+                size="xl"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <EuiEmptyPrompt
+                body={
+                  <EuiText>
+                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                  </EuiText>
+                }
+                title={
+                  <h2>
                     No matches
                   </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                }
+              >
+                <div
+                  className="euiEmptyPrompt"
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <EuiTitle
+                    size="m"
                   >
-                    <EuiSpacer
-                      size="m"
+                    <h2
+                      className="euiTitle euiTitle--medium"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      No matches
+                    </h2>
+                  </EuiTitle>
+                  <EuiTextColor
+                    color="subdued"
+                  >
+                    <span
+                      className="euiTextColor euiTextColor--subdued"
+                    >
+                      <EuiSpacer
+                        size="m"
                       >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            </div>
+                          </EuiText>
+                        </div>
+                      </EuiText>
+                    </span>
+                  </EuiTextColor>
+                </div>
+              </EuiEmptyPrompt>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+            </NoMatchMessage>
+          </div>
+        </EuiPanel>
+      </div>
     </TracesTable>
   </TracesContent>
 </Traces>
@@ -1923,128 +1986,6 @@ exports[`Traces component renders jaeger traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="jaeger"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="jaeger"
-        >
-          Jaeger
-        </EuiButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="jaeger"
-          >
-            <button
-              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-              data-test-subj="indexPattern-switch-link"
-              disabled={false}
-              onClick={[Function]}
-              title="jaeger"
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButtonEmpty__content"
-                iconSide="right"
-                iconSize="m"
-                iconType="arrowDown"
-                textProps={
-                  Object {
-                    "className": "euiButtonEmpty__text",
-                  }
-                }
-              >
-                <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
-                    color="inherit"
-                    size="m"
-                    type="arrowDown"
-                  >
-                    <EuiIconArrowDown
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fillRule="non-zero"
-                        />
-                      </svg>
-                    </EuiIconArrowDown>
-                  </EuiIcon>
-                  <span
-                    className="euiButtonEmpty__text"
-                  >
-                    Jaeger
-                  </span>
-                </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -2282,16 +2223,898 @@ exports[`Traces component renders jaeger traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="jaeger"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="jaeger"
+                  >
+                    Jaeger
+                  </EuiButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="jaeger"
+                    >
+                      <button
+                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                        data-test-subj="indexPattern-switch-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        title="jaeger"
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="right"
+                          iconSize="m"
+                          iconType="arrowDown"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconArrowDown
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fillRule="non-zero"
+                                  />
+                                </svg>
+                              </EuiIconArrowDown>
+                            </EuiIcon>
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              Jaeger
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="jaeger"
+              page="traces"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <button
+                                        aria-label="Change all filters"
+                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        title="Change all filters"
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="filter"
+                                        >
+                                          <EuiIconFilter
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                fillRule="evenodd"
+                                              />
+                                            </svg>
+                                          </EuiIconFilter>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="jaeger"
       page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -2307,813 +3130,100 @@ exports[`Traces component renders jaeger traces page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiFieldSearch
-                compressed={false}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={false}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="m"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="m"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  element="button"
-                  iconType="refresh"
-                  isDisabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="euiButton euiButton--primary"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
-                    type="button"
-                  >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      iconType="refresh"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
-                    >
-                      <span
-                        className="euiButtonContent euiButton__content"
-                      >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="refresh"
-                        >
-                          <EuiIconRefresh
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                              />
-                            </svg>
-                          </EuiIconRefresh>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Refresh
-                        </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="jaeger"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <button
-                            aria-label="Change all filters"
-                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            title="Change all filters"
-                            type="button"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              color="inherit"
-                              size="m"
-                              type="filter"
-                            >
-                              <EuiIconFilter
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                    fillRule="evenodd"
-                                  />
-                                </svg>
-                              </EuiIconFilter>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
       size="m"
     >
@@ -3121,108 +3231,116 @@ exports[`Traces component renders jaeger traces page 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Service and Operations"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
+    <div
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiAccordion"
+          <EuiAccordion
+            arrowDisplay="left"
+            buttonContent="Service and Operations"
             data-test-subj="trace-groups-service-operation-accordian"
+            forceState="closed"
+            id="accordion1"
+            initialIsOpen={false}
+            isLoading={false}
+            isLoadingMessage={false}
             onToggle={[Function]}
+            paddingSize="none"
           >
             <div
-              className="euiAccordion__triggerWrapper"
+              className="euiAccordion"
+              data-test-subj="trace-groups-service-operation-accordian"
+              onToggle={[Function]}
             >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
+              <div
+                className="euiAccordion__triggerWrapper"
               >
-                <span
-                  className="euiAccordion__iconWrapper"
+                <button
+                  aria-controls="accordion1"
+                  aria-expanded={false}
+                  className="euiAccordion__button"
+                  id="random_html_id"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
+                  <span
+                    className="euiAccordion__iconWrapper"
                   >
-                    <EuiIconArrowRight
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
+                    <EuiIcon
+                      className="euiAccordion__icon"
+                      size="m"
+                      type="arrowRight"
                     >
-                      <svg
+                      <EuiIconArrowRight
                         aria-hidden={true}
                         className="euiIcon euiIcon--medium euiAccordion__icon"
                         focusable="false"
-                        height={16}
                         role="img"
                         style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                          fillRule="nonzero"
-                        />
-                      </svg>
-                    </EuiIconArrowRight>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Service and Operations
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiAccordion__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                            fillRule="nonzero"
+                          />
+                        </svg>
+                      </EuiIconArrowRight>
+                    </EuiIcon>
+                  </span>
+                  <span
+                    className="euiIEFlexWrapFix"
                   >
-                    <EuiSpacer
-                      size="m"
+                    Service and Operations
+                  </span>
+                </button>
+              </div>
+              <div
+                aria-labelledby="random_html_id"
+                className="euiAccordion__childWrapper"
+                id="accordion1"
+                role="region"
+                tabIndex={-1}
+              >
+                <EuiResizeObserver
+                  onResize={[Function]}
+                >
+                  <div>
+                    <div
+                      className=""
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
+                      <EuiSpacer
+                        size="m"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                    </div>
                   </div>
-                </div>
-              </EuiResizeObserver>
+                </EuiResizeObserver>
+              </div>
             </div>
-          </div>
-        </EuiAccordion>
-      </div>
-    </EuiPanel>
+          </EuiAccordion>
+        </div>
+      </EuiPanel>
+    </div>
     <EuiSpacer
       size="m"
     >
@@ -3239,138 +3357,146 @@ exports[`Traces component renders jaeger traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
             >
-              <EuiFlexItem
-                grow={10}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={10}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrow10"
+                  >
+                    <PanelTitle
+                      title="Traces"
+                      totalItems={0}
+                    >
+                      <EuiText
+                        size="m"
+                      >
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <span
+                            className="panel-title"
+                          >
+                            Traces
+                          </span>
+                          <span
+                            className="panel-title-count"
+                          >
+                             (0)
+                          </span>
+                        </div>
+                      </EuiText>
+                    </PanelTitle>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiHorizontalRule
+              margin="none"
+            >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
+            <NoMatchMessage
+              size="xl"
+            >
+              <EuiSpacer
+                size="xl"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <EuiEmptyPrompt
+                body={
+                  <EuiText>
+                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                  </EuiText>
+                }
+                title={
+                  <h2>
                     No matches
                   </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                }
+              >
+                <div
+                  className="euiEmptyPrompt"
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <EuiTitle
+                    size="m"
                   >
-                    <EuiSpacer
-                      size="m"
+                    <h2
+                      className="euiTitle euiTitle--medium"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      No matches
+                    </h2>
+                  </EuiTitle>
+                  <EuiTextColor
+                    color="subdued"
+                  >
+                    <span
+                      className="euiTextColor euiTextColor--subdued"
+                    >
+                      <EuiSpacer
+                        size="m"
                       >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            </div>
+                          </EuiText>
+                        </div>
+                      </EuiText>
+                    </span>
+                  </EuiTextColor>
+                </div>
+              </EuiEmptyPrompt>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+            </NoMatchMessage>
+          </div>
+        </EuiPanel>
+      </div>
     </TracesTable>
   </TracesContent>
 </Traces>
@@ -3613,128 +3739,6 @@ exports[`Traces component renders traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <button
-              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-              data-test-subj="indexPattern-switch-link"
-              disabled={false}
-              onClick={[Function]}
-              title="data_prepper"
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButtonEmpty__content"
-                iconSide="right"
-                iconSize="m"
-                iconType="arrowDown"
-                textProps={
-                  Object {
-                    "className": "euiButtonEmpty__text",
-                  }
-                }
-              >
-                <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
-                    color="inherit"
-                    size="m"
-                    type="arrowDown"
-                  >
-                    <EuiIconArrowDown
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fillRule="non-zero"
-                        />
-                      </svg>
-                    </EuiIconArrowDown>
-                  </EuiIcon>
-                  <span
-                    className="euiButtonEmpty__text"
-                  >
-                    Data Prepper
-                  </span>
-                </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -3971,16 +3975,898 @@ exports[`Traces component renders traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <button
+                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                        data-test-subj="indexPattern-switch-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        title="data_prepper"
+                        type="button"
+                      >
+                        <EuiButtonContent
+                          className="euiButtonEmpty__content"
+                          iconSide="right"
+                          iconSize="m"
+                          iconType="arrowDown"
+                          textProps={
+                            Object {
+                              "className": "euiButtonEmpty__text",
+                            }
+                          }
+                        >
+                          <span
+                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <EuiIcon
+                              className="euiButtonContent__icon"
+                              color="inherit"
+                              size="m"
+                              type="arrowDown"
+                            >
+                              <EuiIconArrowDown
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fillRule="non-zero"
+                                  />
+                                </svg>
+                              </EuiIconArrowDown>
+                            </EuiIcon>
+                            <span
+                              className="euiButtonEmpty__text"
+                            >
+                              Data Prepper
+                            </span>
+                          </span>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="traces"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <button
+                                        aria-label="Change all filters"
+                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        title="Change all filters"
+                                        type="button"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="filter"
+                                        >
+                                          <EuiIconFilter
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                fillRule="evenodd"
+                                              />
+                                            </svg>
+                                          </EuiIconFilter>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -3996,813 +4882,100 @@ exports[`Traces component renders traces page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiFieldSearch
-                compressed={false}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={false}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={false}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="m"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="m"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  element="button"
-                  iconType="refresh"
-                  isDisabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="euiButton euiButton--primary"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
-                    type="button"
-                  >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="left"
-                      iconType="refresh"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
-                    >
-                      <span
-                        className="euiButtonContent euiButton__content"
-                      >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="refresh"
-                        >
-                          <EuiIconRefresh
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                              />
-                            </svg>
-                          </EuiIconRefresh>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Refresh
-                        </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <button
-                            aria-label="Change all filters"
-                            className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            title="Change all filters"
-                            type="button"
-                          >
-                            <EuiIcon
-                              aria-hidden="true"
-                              className="euiButtonIcon__icon"
-                              color="inherit"
-                              size="m"
-                              type="filter"
-                            >
-                              <EuiIconFilter
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                focusable="false"
-                                role="img"
-                                style={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  height={16}
-                                  role="img"
-                                  style={null}
-                                  viewBox="0 0 16 16"
-                                  width={16}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                    fillRule="evenodd"
-                                  />
-                                </svg>
-                              </EuiIconFilter>
-                            </EuiIcon>
-                          </button>
-                        </EuiButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
       size="m"
     >
@@ -4810,108 +4983,116 @@ exports[`Traces component renders traces page 1`] = `
         className="euiSpacer euiSpacer--m"
       />
     </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Trace Groups"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
+    <div
+      style={
+        Object {
+          "padding": "0 16px",
+        }
+      }
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiAccordion"
+          <EuiAccordion
+            arrowDisplay="left"
+            buttonContent="Trace Groups"
             data-test-subj="trace-groups-service-operation-accordian"
+            forceState="closed"
+            id="accordion1"
+            initialIsOpen={false}
+            isLoading={false}
+            isLoadingMessage={false}
             onToggle={[Function]}
+            paddingSize="none"
           >
             <div
-              className="euiAccordion__triggerWrapper"
+              className="euiAccordion"
+              data-test-subj="trace-groups-service-operation-accordian"
+              onToggle={[Function]}
             >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
+              <div
+                className="euiAccordion__triggerWrapper"
               >
-                <span
-                  className="euiAccordion__iconWrapper"
+                <button
+                  aria-controls="accordion1"
+                  aria-expanded={false}
+                  className="euiAccordion__button"
+                  id="random_html_id"
+                  onClick={[Function]}
+                  type="button"
                 >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
+                  <span
+                    className="euiAccordion__iconWrapper"
                   >
-                    <EuiIconArrowRight
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
+                    <EuiIcon
+                      className="euiAccordion__icon"
+                      size="m"
+                      type="arrowRight"
                     >
-                      <svg
+                      <EuiIconArrowRight
                         aria-hidden={true}
                         className="euiIcon euiIcon--medium euiAccordion__icon"
                         focusable="false"
-                        height={16}
                         role="img"
                         style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        <path
-                          d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                          fillRule="nonzero"
-                        />
-                      </svg>
-                    </EuiIconArrowRight>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Trace Groups
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
+                        <svg
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiAccordion__icon"
+                          focusable="false"
+                          height={16}
+                          role="img"
+                          style={null}
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                            fillRule="nonzero"
+                          />
+                        </svg>
+                      </EuiIconArrowRight>
+                    </EuiIcon>
+                  </span>
+                  <span
+                    className="euiIEFlexWrapFix"
                   >
-                    <EuiSpacer
-                      size="m"
+                    Trace Groups
+                  </span>
+                </button>
+              </div>
+              <div
+                aria-labelledby="random_html_id"
+                className="euiAccordion__childWrapper"
+                id="accordion1"
+                role="region"
+                tabIndex={-1}
+              >
+                <EuiResizeObserver
+                  onResize={[Function]}
+                >
+                  <div>
+                    <div
+                      className=""
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
+                      <EuiSpacer
+                        size="m"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                    </div>
                   </div>
-                </div>
-              </EuiResizeObserver>
+                </EuiResizeObserver>
+              </div>
             </div>
-          </div>
-        </EuiAccordion>
-      </div>
-    </EuiPanel>
+          </EuiAccordion>
+        </div>
+      </EuiPanel>
+    </div>
     <EuiSpacer
       size="m"
     >
@@ -4927,138 +5108,146 @@ exports[`Traces component renders traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+      <div
+        style={
+          Object {
+            "padding": "0 16px",
+          }
+        }
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
           >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
             >
-              <EuiFlexItem
-                grow={10}
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <EuiFlexItem
+                  grow={10}
+                >
+                  <div
+                    className="euiFlexItem euiFlexItem--flexGrow10"
+                  >
+                    <PanelTitle
+                      title="Traces"
+                      totalItems={0}
+                    >
+                      <EuiText
+                        size="m"
+                      >
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <span
+                            className="panel-title"
+                          >
+                            Traces
+                          </span>
+                          <span
+                            className="panel-title-count"
+                          >
+                             (0)
+                          </span>
+                        </div>
+                      </EuiText>
+                    </PanelTitle>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <EuiSpacer
+              size="m"
+            >
+              <div
+                className="euiSpacer euiSpacer--m"
+              />
+            </EuiSpacer>
+            <EuiHorizontalRule
+              margin="none"
+            >
+              <hr
+                className="euiHorizontalRule euiHorizontalRule--full"
+              />
+            </EuiHorizontalRule>
+            <NoMatchMessage
+              size="xl"
+            >
+              <EuiSpacer
+                size="xl"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+              <EuiEmptyPrompt
+                body={
+                  <EuiText>
+                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                  </EuiText>
+                }
+                title={
+                  <h2>
                     No matches
                   </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                }
+              >
+                <div
+                  className="euiEmptyPrompt"
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <EuiTitle
+                    size="m"
                   >
-                    <EuiSpacer
-                      size="m"
+                    <h2
+                      className="euiTitle euiTitle--medium"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      No matches
+                    </h2>
+                  </EuiTitle>
+                  <EuiTextColor
+                    color="subdued"
+                  >
+                    <span
+                      className="euiTextColor euiTextColor--subdued"
+                    >
+                      <EuiSpacer
+                        size="m"
                       >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            </div>
+                          </EuiText>
+                        </div>
+                      </EuiText>
+                    </span>
+                  </EuiTextColor>
+                </div>
+              </EuiEmptyPrompt>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+            </NoMatchMessage>
+          </div>
+        </EuiPanel>
+      </div>
     </TracesTable>
   </TracesContent>
 </Traces>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -10,230 +10,230 @@ exports[`Traces table component renders empty traces table message 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <EuiFlexItem
-              grow={10}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrow10"
-              >
-                <PanelTitle
-                  title="Traces"
-                  totalItems={0}
-                >
-                  <EuiText
-                    size="m"
-                  >
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      <span
-                        className="panel-title"
-                      >
-                        Traces
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (0)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <MissingConfigurationMessage
-          mode="data_prepper"
-        >
-          <EuiEmptyPrompt
-            actions={
-              <EuiButton
-                color="primary"
-                iconSide="right"
-                iconType="popout"
-                onClick={[Function]}
-              >
-                Learn more
-              </EuiButton>
-            }
-            body={
-              <EuiText>
-                The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-              </EuiText>
-            }
-            title={
-              <h2>
-                Trace Analytics not set up
-              </h2>
-            }
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
             <div
-              className="euiEmptyPrompt"
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <EuiTitle
-                size="m"
-              >
-                <h2
-                  className="euiTitle euiTitle--medium"
-                >
-                  Trace Analytics not set up
-                </h2>
-              </EuiTitle>
-              <EuiTextColor
-                color="subdued"
-              >
-                <span
-                  className="euiTextColor euiTextColor--subdued"
-                >
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-                        </div>
-                      </EuiText>
-                    </div>
-                  </EuiText>
-                </span>
-              </EuiTextColor>
-              <EuiSpacer
-                size="l"
+              <EuiFlexItem
+                grow={10}
               >
                 <div
-                  className="euiSpacer euiSpacer--l"
-                />
-              </EuiSpacer>
-              <EuiButton
-                color="primary"
-                iconSide="right"
-                iconType="popout"
-                onClick={[Function]}
-              >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
+                  className="euiFlexItem euiFlexItem--flexGrow10"
+                >
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={0}
+                  >
+                    <EuiText
+                      size="m"
+                    >
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <span
+                          className="panel-title"
+                        >
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <MissingConfigurationMessage
+            mode="data_prepper"
+          >
+            <EuiEmptyPrompt
+              actions={
+                <EuiButton
                   color="primary"
-                  disabled={false}
-                  element="button"
                   iconSide="right"
                   iconType="popout"
-                  isDisabled={false}
                   onClick={[Function]}
-                  type="button"
                 >
-                  <button
-                    className="euiButton euiButton--primary"
+                  Learn more
+                </EuiButton>
+              }
+              body={
+                <EuiText>
+                  The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                </EuiText>
+              }
+              title={
+                <h2>
+                  Trace Analytics not set up
+                </h2>
+              }
+            >
+              <div
+                className="euiEmptyPrompt"
+              >
+                <EuiTitle
+                  size="m"
+                >
+                  <h2
+                    className="euiTitle euiTitle--medium"
+                  >
+                    Trace Analytics not set up
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+                <EuiSpacer
+                  size="l"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                </EuiSpacer>
+                <EuiButton
+                  color="primary"
+                  iconSide="right"
+                  iconType="popout"
+                  onClick={[Function]}
+                >
+                  <EuiButtonDisplay
+                    baseClassName="euiButton"
+                    color="primary"
                     disabled={false}
+                    element="button"
+                    iconSide="right"
+                    iconType="popout"
+                    isDisabled={false}
                     onClick={[Function]}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
                     type="button"
                   >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="right"
-                      iconType="popout"
-                      textProps={
+                    <button
+                      className="euiButton euiButton--primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
                         Object {
-                          "className": "euiButton__text",
+                          "minWidth": undefined,
                         }
                       }
+                      type="button"
                     >
-                      <span
-                        className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                      <EuiButtonContent
+                        className="euiButton__content"
+                        iconSide="right"
+                        iconType="popout"
+                        textProps={
+                          Object {
+                            "className": "euiButton__text",
+                          }
+                        }
                       >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="popout"
+                        <span
+                          className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                         >
-                          <EuiIconBeaker
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
+                          <EuiIcon
+                            className="euiButtonContent__icon"
+                            color="inherit"
+                            size="m"
+                            type="popout"
                           >
-                            <svg
+                            <EuiIconBeaker
                               aria-hidden={true}
                               className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                               focusable="false"
-                              height={16}
                               role="img"
                               style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
                             >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Learn more
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
+                          </EuiIcon>
+                          <span
+                            className="euiButton__text"
+                          >
+                            Learn more
+                          </span>
                         </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </div>
-          </EuiEmptyPrompt>
-        </MissingConfigurationMessage>
-      </div>
-    </EuiPanel>
-  </div>
+                      </EuiButtonContent>
+                    </button>
+                  </EuiButtonDisplay>
+                </EuiButton>
+              </div>
+            </EuiEmptyPrompt>
+          </MissingConfigurationMessage>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </TracesTable>
 `;
 
@@ -247,146 +247,146 @@ exports[`Traces table component renders empty traces table message 2`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
-            <EuiFlexItem
-              grow={10}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <EuiFlexItem
+                grow={10}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrow10"
+                >
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={0}
+                  >
+                    <EuiText
+                      size="m"
+                    >
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <span
+                          className="panel-title"
+                        >
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <NoMatchMessage
+            size="xl"
+          >
+            <EuiSpacer
+              size="xl"
             >
               <div
-                className="euiFlexItem euiFlexItem--flexGrow10"
-              >
-                <PanelTitle
-                  title="Traces"
-                  totalItems={0}
-                >
-                  <EuiText
-                    size="m"
-                  >
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      <span
-                        className="panel-title"
-                      >
-                        Traces
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (0)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <NoMatchMessage
-          size="xl"
-        >
-          <EuiSpacer
-            size="xl"
-          >
-            <div
-              className="euiSpacer euiSpacer--xl"
-            />
-          </EuiSpacer>
-          <EuiEmptyPrompt
-            body={
-              <EuiText>
-                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-              </EuiText>
-            }
-            title={
-              <h2>
-                No matches
-              </h2>
-            }
-          >
-            <div
-              className="euiEmptyPrompt"
-            >
-              <EuiTitle
-                size="m"
-              >
-                <h2
-                  className="euiTitle euiTitle--medium"
-                >
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiEmptyPrompt
+              body={
+                <EuiText>
+                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                </EuiText>
+              }
+              title={
+                <h2>
                   No matches
                 </h2>
-              </EuiTitle>
-              <EuiTextColor
-                color="subdued"
+              }
+            >
+              <div
+                className="euiEmptyPrompt"
               >
-                <span
-                  className="euiTextColor euiTextColor--subdued"
+                <EuiTitle
+                  size="m"
                 >
-                  <EuiSpacer
-                    size="m"
+                  <h2
+                    className="euiTitle euiTitle--medium"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
+                    No matches
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
                     >
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                        </div>
-                      </EuiText>
-                    </div>
-                  </EuiText>
-                </span>
-              </EuiTextColor>
-            </div>
-          </EuiEmptyPrompt>
-          <EuiSpacer
-            size="xl"
-          >
-            <div
-              className="euiSpacer euiSpacer--xl"
-            />
-          </EuiSpacer>
-        </NoMatchMessage>
-      </div>
-    </EuiPanel>
-  </div>
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+              </div>
+            </EuiEmptyPrompt>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+          </NoMatchMessage>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </TracesTable>
 `;
 
@@ -411,141 +411,71 @@ exports[`Traces table component renders jaeger traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
-            <EuiFlexItem
-              grow={10}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrow10"
+              <EuiFlexItem
+                grow={10}
               >
-                <PanelTitle
-                  title="Traces"
-                  totalItems={1}
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrow10"
                 >
-                  <EuiText
-                    size="m"
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={1}
                   >
-                    <div
-                      className="euiText euiText--medium"
+                    <EuiText
+                      size="m"
                     >
-                      <span
-                        className="panel-title"
+                      <div
+                        className="euiText euiText--medium"
                       >
-                        Traces
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (1)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <EuiInMemoryTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "trace_id",
-                "name": "Trace ID",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "latency",
-                "name": "Latency (ms)",
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_count",
-                "name": "Errors",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "left",
-                "field": "last_updated",
-                "name": "Last updated",
-                "render": [Function],
-                "sortable": true,
-              },
-            ]
-          }
-          items={
-            Array [
-              Object {
-                "actions": "#",
-                "error_count": "Yes",
-                "last_updated": "11/10/2020 09:55:45",
-                "latency": 19.91,
-                "trace_group": "HTTP GET",
-                "trace_id": "00079a615e31e61766fcb20b557051c1",
-              },
-            ]
-          }
-          loading={false}
-          onTableChange={[Function]}
-          pagination={
-            Object {
-              "initialPageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-            }
-          }
-          responsive={true}
-          sorting={
-            Object {
-              "sort": Object {
-                "direction": "asc",
-                "field": "trace_id",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <EuiBasicTable
+                        <span
+                          className="panel-title"
+                        >
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
             columns={
               Array [
                 Object {
@@ -592,128 +522,171 @@ exports[`Traces table component renders jaeger traces table 1`] = `
               ]
             }
             loading={false}
-            noItemsMessage="No items found"
-            onChange={[Function]}
+            onTableChange={[Function]}
             pagination={
               Object {
-                "hidePerPageOptions": undefined,
-                "pageIndex": 0,
-                "pageSize": 10,
+                "initialPageSize": 10,
                 "pageSizeOptions": Array [
                   5,
                   10,
                   15,
                 ],
-                "totalItemCount": 1,
               }
             }
             responsive={true}
             sorting={
               Object {
-                "allowNeutralSort": true,
                 "sort": Object {
                   "direction": "asc",
-                  "field": "Trace ID",
+                  "field": "trace_id",
                 },
               }
             }
             tableLayout="auto"
           >
-            <div
-              className="euiBasicTable"
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "trace_id",
+                    "name": "Trace ID",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "latency",
+                    "name": "Latency (ms)",
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_count",
+                    "name": "Errors",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "last_updated",
+                    "name": "Last updated",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                ]
+              }
+              items={
+                Array [
+                  Object {
+                    "actions": "#",
+                    "error_count": "Yes",
+                    "last_updated": "11/10/2020 09:55:45",
+                    "latency": 19.91,
+                    "trace_group": "HTTP GET",
+                    "trace_id": "00079a615e31e61766fcb20b557051c1",
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Trace ID",
+                  },
+                }
+              }
+              tableLayout="auto"
             >
-              <div>
-                <EuiTableHeaderMobile>
-                  <div
-                    className="euiTableHeaderMobile"
-                  >
-                    <EuiFlexGroup
-                      alignItems="baseline"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
                     >
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          />
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiTableSortMobile
-                              items={
-                                Array [
-                                  Object {
-                                    "isSortAscending": true,
-                                    "isSorted": true,
-                                    "key": "_data_s_trace_id_0",
-                                    "name": "Trace ID",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_latency_1",
-                                    "name": "Latency (ms)",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_error_count_2",
-                                    "name": "Errors",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_last_updated_3",
-                                    "name": "Last updated",
-                                    "onSort": [Function],
-                                  },
-                                ]
-                              }
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiTableSortMobile"
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_trace_id_0",
+                                      "name": "Trace ID",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_latency_1",
+                                      "name": "Latency (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_count_2",
+                                      "name": "Errors",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_last_updated_3",
+                                      "name": "Last updated",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
                               >
-                                <EuiPopover
-                                  anchorPosition="downRight"
-                                  button={
-                                    <EuiButtonEmpty
-                                      flush="right"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      onClick={[Function]}
-                                      size="xs"
-                                    >
-                                      <EuiI18n
-                                        default="Sorting"
-                                        token="euiTableSortMobile.sorting"
-                                      />
-                                    </EuiButtonEmpty>
-                                  }
-                                  closePopover={[Function]}
-                                  display="inlineBlock"
-                                  hasArrow={true}
-                                  isOpen={false}
-                                  ownFocus={true}
-                                  panelPaddingSize="none"
+                                <div
+                                  className="euiTableSortMobile"
                                 >
-                                  <div
-                                    className="euiPopover euiPopover--anchorDownRight"
-                                  >
-                                    <div
-                                      className="euiPopover__anchor"
-                                    >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
                                       <EuiButtonEmpty
                                         flush="right"
                                         iconSide="right"
@@ -721,727 +694,724 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                         onClick={[Function]}
                                         size="xs"
                                       >
-                                        <button
-                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                          disabled={false}
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
                                           onClick={[Function]}
-                                          type="button"
+                                          size="xs"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButtonEmpty__content"
-                                            iconSide="right"
-                                            iconSize="s"
-                                            iconType="arrowDown"
-                                            textProps={
-                                              Object {
-                                                "className": "euiButtonEmpty__text",
-                                              }
-                                            }
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
                                             >
-                                              <EuiIcon
-                                                className="euiButtonContent__icon"
-                                                color="inherit"
-                                                size="s"
-                                                type="arrowDown"
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                               >
-                                                <EuiIconArrowDown
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
                                                 >
-                                                  <svg
+                                                  <EuiIconArrowDown
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                      fillRule="non-zero"
-                                                    />
-                                                  </svg>
-                                                </EuiIconArrowDown>
-                                              </EuiIcon>
-                                              <span
-                                                className="euiButtonEmpty__text"
-                                              >
-                                                <EuiI18n
-                                                  default="Sorting"
-                                                  token="euiTableSortMobile.sorting"
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                        fillRule="non-zero"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconArrowDown>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
                                                 >
-                                                  Sorting
-                                                </EuiI18n>
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonEmpty>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
                                     </div>
-                                  </div>
-                                </EuiPopover>
-                              </div>
-                            </EuiTableSortMobile>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiTableHeaderMobile>
-                <EuiTable
-                  id="random_html_id"
-                  responsive={true}
-                  tableLayout="auto"
-                >
-                  <table
-                    className="euiTable euiTable--responsive euiTable--auto"
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
                     id="random_html_id"
-                    tabIndex={-1}
+                    responsive={true}
+                    tableLayout="auto"
                   >
-                    <EuiScreenReaderOnly>
-                      <caption
-                        className="euiScreenReaderOnly euiTableCaption"
-                      >
-                        <EuiDelayRender
-                          delay={500}
-                        />
-                      </caption>
-                    </EuiScreenReaderOnly>
-                    <EuiTableHeader>
-                      <thead>
-                        <tr>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_trace_id_0"
-                            isSortAscending={true}
-                            isSorted={true}
-                            key="_data_h_trace_id_0"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="ascending"
-                              className="euiTableHeaderCell"
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
+                    >
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        >
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCell
+                              align="left"
                               data-test-subj="tableHeaderCell_trace_id_0"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_trace_id_0"
+                              onSort={[Function]}
                             >
-                              <button
-                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_trace_id_0"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSortAscending={true}
-                                  isSorted={true}
-                                  showSortMsg={true}
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <span
+                                  <CellContents
                                     className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
                                   >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Trace ID",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Trace ID"
-                                        >
-                                          Trace ID
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                    <EuiIcon
-                                      className="euiTableSortIcon"
-                                      size="m"
-                                      type="sortUp"
+                                    <span
+                                      className="euiTableCellContent"
                                     >
-                                      <EuiIconSortUp
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiTableSortIcon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Trace ID",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Trace ID"
+                                          >
+                                            Trace ID
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
                                       >
-                                        <svg
+                                        <EuiIconSortUp
                                           aria-hidden={true}
                                           className="euiIcon euiIcon--medium euiTableSortIcon"
                                           focusable="false"
-                                          height={16}
                                           role="img"
                                           style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
                                         >
-                                          <path
-                                            d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                          />
-                                        </svg>
-                                      </EuiIconSortUp>
-                                    </EuiIcon>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_latency_1"
-                            isSorted={false}
-                            key="_data_h_latency_1"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSortUp>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
                               data-test-subj="tableHeaderCell_latency_1"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
+                              isSorted={false}
+                              key="_data_h_latency_1"
+                              onSort={[Function]}
                             >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Latency (ms)",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Latency (ms)"
-                                        >
-                                          Latency (ms)
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_error_count_2"
-                            isSorted={false}
-                            key="_data_h_error_count_2"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_error_count_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Errors",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Errors"
-                                        >
-                                          Errors
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_last_updated_3"
-                            isSorted={false}
-                            key="_data_h_last_updated_3"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_last_updated_3"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Last updated",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Last updated"
-                                        >
-                                          Last updated
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                        </tr>
-                      </thead>
-                    </EuiTableHeader>
-                    <EuiTableBody
-                      bodyRef={[Function]}
-                    >
-                      <tbody>
-                        <EuiTableRow
-                          isSelected={false}
-                        >
-                          <tr
-                            className="euiTableRow"
-                          >
-                            <EuiTableRowCell
-                              align="left"
-                              key="_data_column_trace_id_0_0"
-                              mobileOptions={
-                                Object {
-                                  "header": "Trace ID",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
-                            >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_latency_1"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Trace ID
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiFlexGroup
-                                    alignItems="center"
-                                    className=""
-                                    gutterSize="s"
-                                    key=".0"
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
                                     >
-                                      <EuiFlexItem
-                                        grow={10}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrow10"
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Latency (ms)",
+                                            }
+                                          }
                                         >
-                                          <EuiLink
-                                            onClick={[Function]}
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Latency (ms)"
                                           >
-                                            <button
-                                              className="euiLink euiLink--primary"
-                                              disabled={false}
+                                            Latency (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_error_count_2"
+                              isSorted={false}
+                              key="_data_h_error_count_2"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_count_2"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Errors",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Errors"
+                                          >
+                                            Errors
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_last_updated_3"
+                              isSorted={false}
+                              key="_data_h_last_updated_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_last_updated_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Last updated",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Last updated"
+                                          >
+                                            Last updated
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow"
+                            >
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_trace_id_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Trace ID",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Trace ID
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      alignItems="center"
+                                      className=""
+                                      gutterSize="s"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={10}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow10"
+                                          >
+                                            <EuiLink
                                               onClick={[Function]}
-                                              type="button"
                                             >
-                                              <div
-                                                title="00079a615e31e61766fcb20b557051c1"
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                00079a615e31e61766fcb...
-                                              </div>
-                                            </button>
-                                          </EuiLink>
-                                        </div>
-                                      </EuiFlexItem>
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiCopy
-                                            afterMessage="Copied"
-                                            textToCopy="00079a615e31e61766fcb20b557051c1"
-                                          >
-                                            <EuiToolTip
-                                              delay="regular"
-                                              onMouseOut={[Function]}
-                                              position="top"
-                                            >
-                                              <span
-                                                className="euiToolTipAnchor"
-                                                onKeyUp={[Function]}
-                                                onMouseOut={[Function]}
-                                                onMouseOver={[Function]}
-                                              >
-                                                <EuiButtonIcon
-                                                  aria-label="Copy trace id"
-                                                  iconType="copyClipboard"
-                                                  onBlur={[Function]}
-                                                  onClick={[Function]}
-                                                  onFocus={[Function]}
+                                                <div
+                                                  title="00079a615e31e61766fcb20b557051c1"
                                                 >
-                                                  <button
+                                                  00079a615e31e61766fcb...
+                                                </div>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiCopy
+                                              afterMessage="Copied"
+                                              textToCopy="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              <EuiToolTip
+                                                delay="regular"
+                                                onMouseOut={[Function]}
+                                                position="top"
+                                              >
+                                                <span
+                                                  className="euiToolTipAnchor"
+                                                  onKeyUp={[Function]}
+                                                  onMouseOut={[Function]}
+                                                  onMouseOver={[Function]}
+                                                >
+                                                  <EuiButtonIcon
                                                     aria-label="Copy trace id"
-                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                                                    disabled={false}
+                                                    iconType="copyClipboard"
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
                                                     onFocus={[Function]}
-                                                    type="button"
                                                   >
-                                                    <EuiIcon
-                                                      aria-hidden="true"
-                                                      className="euiButtonIcon__icon"
-                                                      color="inherit"
-                                                      size="m"
-                                                      type="copyClipboard"
+                                                    <button
+                                                      aria-label="Copy trace id"
+                                                      className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                                      disabled={false}
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onFocus={[Function]}
+                                                      type="button"
                                                     >
-                                                      <EuiIconCopyClipboard
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
+                                                      <EuiIcon
+                                                        aria-hidden="true"
+                                                        className="euiButtonIcon__icon"
+                                                        color="inherit"
+                                                        size="m"
+                                                        type="copyClipboard"
                                                       >
-                                                        <svg
+                                                        <EuiIconCopyClipboard
                                                           aria-hidden={true}
                                                           className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                                           focusable="false"
-                                                          height={16}
                                                           role="img"
                                                           style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
                                                         >
-                                                          <path
-                                                            d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
-                                                          />
-                                                          <path
-                                                            d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconCopyClipboard>
-                                                    </EuiIcon>
-                                                  </button>
-                                                </EuiButtonIcon>
-                                              </span>
-                                            </EuiToolTip>
-                                          </EuiCopy>
-                                        </div>
-                                      </EuiFlexItem>
-                                      <EuiFlexItem
-                                        grow={3}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrow3"
-                                        />
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_latency_0_1"
-                              mobileOptions={
-                                Object {
-                                  "header": "Latency (ms)",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={true}
-                              truncateText={true}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
+                                                            />
+                                                            <path
+                                                              d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCopyClipboard>
+                                                      </EuiIcon>
+                                                    </button>
+                                                  </EuiButtonIcon>
+                                                </span>
+                                              </EuiToolTip>
+                                            </EuiCopy>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={3}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow3"
+                                          />
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_latency_0_1"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Latency (ms)",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={true}
+                                truncateText={true}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Latency (ms)
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                                >
-                                  <span
-                                    className="euiTableCellContent__text"
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                                   >
-                                    19.91
-                                  </span>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_error_count_0_2"
-                              mobileOptions={
-                                Object {
-                                  "header": "Errors",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                    Latency (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                                  >
+                                    <span
+                                      className="euiTableCellContent__text"
+                                    >
+                                      19.91
+                                    </span>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_count_0_2"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Errors",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={false}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Errors
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  No
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="left"
-                              key="_data_column_last_updated_0_3"
-                              mobileOptions={
-                                Object {
-                                  "header": "Last updated",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Errors
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    No
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_last_updated_0_3"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Last updated",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={false}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Last updated
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                >
-                                  11/10/2020 09:55:45
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                          </tr>
-                        </EuiTableRow>
-                      </tbody>
-                    </EuiTableBody>
-                  </table>
-                </EuiTable>
-              </div>
-              <PaginationBar
-                aria-controls="random_html_id"
-                onPageChange={[Function]}
-                onPageSizeChange={[Function]}
-                pagination={
-                  Object {
-                    "hidePerPageOptions": undefined,
-                    "pageIndex": 0,
-                    "pageSize": 10,
-                    "pageSizeOptions": Array [
-                      5,
-                      10,
-                      15,
-                    ],
-                    "totalItemCount": 1,
-                  }
-                }
-              >
-                <div>
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiTablePagination
-                    activePage={0}
-                    aria-controls="random_html_id"
-                    itemsPerPage={10}
-                    itemsPerPageOptions={
-                      Array [
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Last updated
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    11/10/2020 09:55:45
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
                         5,
                         10,
                         15,
-                      ]
+                      ],
+                      "totalItemCount": 1,
                     }
-                    onChangeItemsPerPage={[Function]}
-                    onChangePage={[Function]}
-                    pageCount={1}
-                  >
-                    <EuiFlexGroup
-                      alignItems="center"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiPopover
-                              anchorPosition="upRight"
-                              button={
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
-                                >
-                                  <EuiI18n
-                                    default="Rows per page"
-                                    token="euiTablePagination.rowsPerPage"
-                                  />
-                                  : 
-                                  10
-                                </EuiButtonEmpty>
-                              }
-                              closePopover={[Function]}
-                              display="inlineBlock"
-                              hasArrow={true}
-                              isOpen={false}
-                              ownFocus={true}
-                              panelPaddingSize="none"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiPopover euiPopover--anchorUpRight"
-                              >
-                                <div
-                                  className="euiPopover__anchor"
-                                >
+                              <EuiPopover
+                                anchorPosition="upRight"
+                                button={
                                   <EuiButtonEmpty
                                     color="text"
                                     data-test-subj="tablePaginationPopoverButton"
@@ -1450,43 +1420,169 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                     onClick={[Function]}
                                     size="xs"
                                   >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    <EuiI18n
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
+                                    />
+                                    : 
+                                    10
+                                  </EuiButtonEmpty>
+                                }
+                                closePopover={[Function]}
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorUpRight"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonEmpty
+                                      color="text"
                                       data-test-subj="tablePaginationPopoverButton"
-                                      disabled={false}
+                                      iconSide="right"
+                                      iconType="arrowDown"
                                       onClick={[Function]}
-                                      type="button"
+                                      size="xs"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="right"
-                                        iconSize="s"
-                                        iconType="arrowDown"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
+                                      <button
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        <EuiButtonContent
+                                          className="euiButtonEmpty__content"
+                                          iconSide="right"
+                                          iconSize="s"
+                                          iconType="arrowDown"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          >
+                                            <EuiIcon
+                                              className="euiButtonContent__icon"
+                                              color="inherit"
+                                              size="s"
+                                              type="arrowDown"
+                                            >
+                                              <EuiIconArrowDown
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                focusable="false"
+                                                role="img"
+                                                style={null}
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                  focusable="false"
+                                                  height={16}
+                                                  role="img"
+                                                  style={null}
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                    fillRule="non-zero"
+                                                  />
+                                                </svg>
+                                              </EuiIconArrowDown>
+                                            </EuiIcon>
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              <EuiI18n
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
+                                              >
+                                                Rows per page
+                                              </EuiI18n>
+                                              : 
+                                              10
+                                            </span>
+                                          </span>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonEmpty>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
+                              >
+                                <nav
+                                  className="euiPagination"
+                                >
+                                  <EuiI18n
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
+                                    values={
+                                      Object {
+                                        "page": 0,
+                                      }
+                                    }
+                                  >
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
                                           <EuiIcon
-                                            className="euiButtonContent__icon"
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
                                             color="inherit"
-                                            size="s"
-                                            type="arrowDown"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
-                                            <EuiIconArrowDown
+                                            <EuiIconArrowLeft
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
                                               role="img"
                                               style={null}
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                                 focusable="false"
                                                 height={16}
                                                 role="img"
@@ -1496,280 +1592,184 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                                 xmlns="http://www.w3.org/2000/svg"
                                               >
                                                 <path
-                                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                  fillRule="non-zero"
+                                                  d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                                  fillRule="nonzero"
                                                 />
                                               </svg>
-                                            </EuiIconArrowDown>
+                                            </EuiIconArrowLeft>
                                           </EuiIcon>
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            <EuiI18n
-                                              default="Rows per page"
-                                              token="euiTablePagination.rowsPerPage"
-                                            >
-                                              Rows per page
-                                            </EuiI18n>
-                                            : 
-                                            10
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </div>
-                              </div>
-                            </EuiPopover>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiPagination
-                              activePage={0}
-                              aria-controls="random_html_id"
-                              onPageClick={[Function]}
-                              pageCount={1}
-                            >
-                              <nav
-                                className="euiPagination"
-                              >
-                                <EuiI18n
-                                  default="Previous page, {page}"
-                                  token="euiPagination.previousPage"
-                                  values={
-                                    Object {
-                                      "page": 0,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Previous page"
-                                    token="euiPagination.disabledPreviousPage"
-                                  >
-                                    <EuiButtonIcon
-                                      aria-label="Previous page"
-                                      color="text"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      iconType="arrowLeft"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        aria-label="Previous page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowLeft"
-                                        >
-                                          <EuiIconArrowLeft
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              height={16}
-                                              role="img"
-                                              style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                                fillRule="nonzero"
-                                              />
-                                            </svg>
-                                          </EuiIconArrowLeft>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                                <ul
-                                  className="euiPagination__list"
-                                >
-                                  <PaginationButton
-                                    key="0"
-                                    pageIndex={0}
+                                  <ul
+                                    className="euiPagination__list"
                                   >
-                                    <li
-                                      className="euiPagination__item"
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
                                     >
-                                      <EuiPaginationButton
-                                        aria-controls="random_html_id"
-                                        hideOnMobile={true}
-                                        isActive={true}
-                                        onClick={[Function]}
-                                        pageIndex={0}
-                                        totalPages={1}
+                                      <li
+                                        className="euiPagination__item"
                                       >
-                                        <EuiI18n
-                                          default="Page {page} of {totalPages}"
-                                          token="euiPaginationButton.longPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
-                                              "totalPages": 1,
-                                            }
-                                          }
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Page {page}"
-                                            token="euiPaginationButton.shortPageString"
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
                                             values={
                                               Object {
                                                 "page": 1,
+                                                "totalPages": 1,
                                               }
                                             }
                                           >
-                                            <EuiButtonEmpty
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              color="text"
-                                              data-test-subj="pagination-button-0"
-                                              href="#random_html_id"
-                                              isDisabled={true}
-                                              onClick={[Function]}
-                                              size="s"
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
+                                                }
+                                              }
                                             >
-                                              <button
+                                              <EuiButtonEmpty
                                                 aria-controls="random_html_id"
                                                 aria-current={true}
                                                 aria-label="Page 1 of 1"
-                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
                                                 data-test-subj="pagination-button-0"
-                                                disabled={true}
+                                                href="#random_html_id"
+                                                isDisabled={true}
                                                 onClick={[Function]}
-                                                type="button"
+                                                size="s"
                                               >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="left"
-                                                  iconSize="m"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text",
-                                                    }
-                                                  }
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonContent euiButtonEmpty__content"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
                                                     <span
-                                                      className="euiButtonEmpty__text"
+                                                      className="euiButtonContent euiButtonEmpty__content"
                                                     >
-                                                      1
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
                                                     </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
                                           </EuiI18n>
-                                        </EuiI18n>
-                                      </EuiPaginationButton>
-                                    </li>
-                                  </PaginationButton>
-                                </ul>
-                                <EuiI18n
-                                  default="Next page, {page}"
-                                  token="euiPagination.nextPage"
-                                  values={
-                                    Object {
-                                      "page": 2,
-                                    }
-                                  }
-                                >
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
                                   <EuiI18n
-                                    default="Next page"
-                                    token="euiPagination.disabledNextPage"
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <EuiButtonIcon
-                                      aria-label="Next page"
-                                      color="text"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      iconType="arrowRight"
-                                      onClick={[Function]}
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <button
+                                      <EuiButtonIcon
                                         aria-label="Next page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        color="text"
                                         data-test-subj="pagination-button-next"
                                         disabled={true}
+                                        iconType="arrowRight"
                                         onClick={[Function]}
-                                        type="button"
                                       >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowRight"
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <EuiIconArrowRight
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <svg
+                                            <EuiIconArrowRight
                                               aria-hidden={true}
                                               className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                                fillRule="nonzero"
-                                              />
-                                            </svg>
-                                          </EuiIconArrowRight>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                                  fillRule="nonzero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowRight>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                              </nav>
-                            </EuiPagination>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </EuiTablePagination>
-                </div>
-              </PaginationBar>
-            </div>
-          </EuiBasicTable>
-        </EuiInMemoryTable>
-      </div>
-    </EuiPanel>
-  </div>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
+              </div>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </TracesTable>
 `;
 
@@ -1795,161 +1795,71 @@ exports[`Traces table component renders traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <div
-    style={
-      Object {
-        "padding": "0 16px",
-      }
-    }
+  <EuiPage
+    paddingSize="m"
   >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
+    <div
+      className="euiPage euiPage--paddingMedium euiPage--grow"
+    >
+      <EuiPanel>
+        <div
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
-            <EuiFlexItem
-              grow={10}
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrow10"
+              <EuiFlexItem
+                grow={10}
               >
-                <PanelTitle
-                  title="Traces"
-                  totalItems={1}
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrow10"
                 >
-                  <EuiText
-                    size="m"
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={1}
                   >
-                    <div
-                      className="euiText euiText--medium"
+                    <EuiText
+                      size="m"
                     >
-                      <span
-                        className="panel-title"
+                      <div
+                        className="euiText euiText--medium"
                       >
-                        Traces
-                      </span>
-                      <span
-                        className="panel-title-count"
-                      >
-                         (1)
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiHorizontalRule
-          margin="none"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full"
-          />
-        </EuiHorizontalRule>
-        <EuiInMemoryTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "trace_id",
-                "name": "Trace ID",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "left",
-                "field": "trace_group",
-                "name": "Trace group",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "latency",
-                "name": "Duration (ms)",
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "percentile_in_trace_group",
-                "name": <React.Fragment>
-                  <div>
-                    Percentile in trace group
-                  </div>
-                </React.Fragment>,
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_count",
-                "name": "Errors",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "left",
-                "field": "last_updated",
-                "name": "Last updated",
-                "render": [Function],
-                "sortable": true,
-              },
-            ]
-          }
-          items={
-            Array [
-              Object {
-                "actions": "#",
-                "error_count": "Yes",
-                "last_updated": "11/10/2020 09:55:45",
-                "latency": 19.91,
-                "percentile_in_trace_group": 30,
-                "trace_group": "HTTP GET",
-                "trace_id": "00079a615e31e61766fcb20b557051c1",
-              },
-            ]
-          }
-          loading={false}
-          onTableChange={[Function]}
-          pagination={
-            Object {
-              "initialPageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-            }
-          }
-          responsive={true}
-          sorting={
-            Object {
-              "sort": Object {
-                "direction": "asc",
-                "field": "trace_id",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <EuiBasicTable
+                        <span
+                          className="panel-title"
+                        >
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
             columns={
               Array [
                 Object {
@@ -2016,146 +1926,209 @@ exports[`Traces table component renders traces table 1`] = `
               ]
             }
             loading={false}
-            noItemsMessage="No items found"
-            onChange={[Function]}
+            onTableChange={[Function]}
             pagination={
               Object {
-                "hidePerPageOptions": undefined,
-                "pageIndex": 0,
-                "pageSize": 10,
+                "initialPageSize": 10,
                 "pageSizeOptions": Array [
                   5,
                   10,
                   15,
                 ],
-                "totalItemCount": 1,
               }
             }
             responsive={true}
             sorting={
               Object {
-                "allowNeutralSort": true,
                 "sort": Object {
                   "direction": "asc",
-                  "field": "Trace ID",
+                  "field": "trace_id",
                 },
               }
             }
             tableLayout="auto"
           >
-            <div
-              className="euiBasicTable"
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "trace_id",
+                    "name": "Trace ID",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "trace_group",
+                    "name": "Trace group",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "latency",
+                    "name": "Duration (ms)",
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "percentile_in_trace_group",
+                    "name": <React.Fragment>
+                      <div>
+                        Percentile in trace group
+                      </div>
+                    </React.Fragment>,
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_count",
+                    "name": "Errors",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "last_updated",
+                    "name": "Last updated",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                ]
+              }
+              items={
+                Array [
+                  Object {
+                    "actions": "#",
+                    "error_count": "Yes",
+                    "last_updated": "11/10/2020 09:55:45",
+                    "latency": 19.91,
+                    "percentile_in_trace_group": 30,
+                    "trace_group": "HTTP GET",
+                    "trace_id": "00079a615e31e61766fcb20b557051c1",
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Trace ID",
+                  },
+                }
+              }
+              tableLayout="auto"
             >
-              <div>
-                <EuiTableHeaderMobile>
-                  <div
-                    className="euiTableHeaderMobile"
-                  >
-                    <EuiFlexGroup
-                      alignItems="baseline"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
                     >
-                      <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          />
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiTableSortMobile
-                              items={
-                                Array [
-                                  Object {
-                                    "isSortAscending": true,
-                                    "isSorted": true,
-                                    "key": "_data_s_trace_id_0",
-                                    "name": "Trace ID",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_trace_group_1",
-                                    "name": "Trace group",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_latency_2",
-                                    "name": "Duration (ms)",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_percentile_in_trace_group_3",
-                                    "name": <React.Fragment>
-                                      <div>
-                                        Percentile in trace group
-                                      </div>
-                                    </React.Fragment>,
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_error_count_4",
-                                    "name": "Errors",
-                                    "onSort": [Function],
-                                  },
-                                  Object {
-                                    "isSortAscending": undefined,
-                                    "isSorted": false,
-                                    "key": "_data_s_last_updated_5",
-                                    "name": "Last updated",
-                                    "onSort": [Function],
-                                  },
-                                ]
-                              }
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiTableSortMobile"
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_trace_id_0",
+                                      "name": "Trace ID",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_trace_group_1",
+                                      "name": "Trace group",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_latency_2",
+                                      "name": "Duration (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_percentile_in_trace_group_3",
+                                      "name": <React.Fragment>
+                                        <div>
+                                          Percentile in trace group
+                                        </div>
+                                      </React.Fragment>,
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_count_4",
+                                      "name": "Errors",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_last_updated_5",
+                                      "name": "Last updated",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
                               >
-                                <EuiPopover
-                                  anchorPosition="downRight"
-                                  button={
-                                    <EuiButtonEmpty
-                                      flush="right"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      onClick={[Function]}
-                                      size="xs"
-                                    >
-                                      <EuiI18n
-                                        default="Sorting"
-                                        token="euiTableSortMobile.sorting"
-                                      />
-                                    </EuiButtonEmpty>
-                                  }
-                                  closePopover={[Function]}
-                                  display="inlineBlock"
-                                  hasArrow={true}
-                                  isOpen={false}
-                                  ownFocus={true}
-                                  panelPaddingSize="none"
+                                <div
+                                  className="euiTableSortMobile"
                                 >
-                                  <div
-                                    className="euiPopover euiPopover--anchorDownRight"
-                                  >
-                                    <div
-                                      className="euiPopover__anchor"
-                                    >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
                                       <EuiButtonEmpty
                                         flush="right"
                                         iconSide="right"
@@ -2163,934 +2136,931 @@ exports[`Traces table component renders traces table 1`] = `
                                         onClick={[Function]}
                                         size="xs"
                                       >
-                                        <button
-                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                          disabled={false}
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
                                           onClick={[Function]}
-                                          type="button"
+                                          size="xs"
                                         >
-                                          <EuiButtonContent
-                                            className="euiButtonEmpty__content"
-                                            iconSide="right"
-                                            iconSize="s"
-                                            iconType="arrowDown"
-                                            textProps={
-                                              Object {
-                                                "className": "euiButtonEmpty__text",
-                                              }
-                                            }
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
                                           >
-                                            <span
-                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
                                             >
-                                              <EuiIcon
-                                                className="euiButtonContent__icon"
-                                                color="inherit"
-                                                size="s"
-                                                type="arrowDown"
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                               >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
                                                 >
-                                                  <svg
+                                                  <EuiIconBeaker
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                                     focusable="false"
-                                                    height={16}
                                                     role="img"
                                                     style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
                                                   >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                              <span
-                                                className="euiButtonEmpty__text"
-                                              >
-                                                <EuiI18n
-                                                  default="Sorting"
-                                                  token="euiTableSortMobile.sorting"
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
                                                 >
-                                                  Sorting
-                                                </EuiI18n>
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
                                               </span>
-                                            </span>
-                                          </EuiButtonContent>
-                                        </button>
-                                      </EuiButtonEmpty>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
                                     </div>
-                                  </div>
-                                </EuiPopover>
-                              </div>
-                            </EuiTableSortMobile>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </div>
-                </EuiTableHeaderMobile>
-                <EuiTable
-                  id="random_html_id"
-                  responsive={true}
-                  tableLayout="auto"
-                >
-                  <table
-                    className="euiTable euiTable--responsive euiTable--auto"
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
                     id="random_html_id"
-                    tabIndex={-1}
+                    responsive={true}
+                    tableLayout="auto"
                   >
-                    <EuiScreenReaderOnly>
-                      <caption
-                        className="euiScreenReaderOnly euiTableCaption"
-                      >
-                        <EuiDelayRender
-                          delay={500}
-                        />
-                      </caption>
-                    </EuiScreenReaderOnly>
-                    <EuiTableHeader>
-                      <thead>
-                        <tr>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_trace_id_0"
-                            isSortAscending={true}
-                            isSorted={true}
-                            key="_data_h_trace_id_0"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="ascending"
-                              className="euiTableHeaderCell"
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
+                    >
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        >
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCell
+                              align="left"
                               data-test-subj="tableHeaderCell_trace_id_0"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_trace_id_0"
+                              onSort={[Function]}
                             >
-                              <button
-                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_trace_id_0"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSortAscending={true}
-                                  isSorted={true}
-                                  showSortMsg={true}
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <span
+                                  <CellContents
                                     className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
                                   >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Trace ID",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Trace ID"
-                                        >
-                                          Trace ID
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                    <EuiIcon
-                                      className="euiTableSortIcon"
-                                      size="m"
-                                      type="sortUp"
+                                    <span
+                                      className="euiTableCellContent"
                                     >
-                                      <EuiIconBeaker
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Trace ID",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Trace ID"
+                                          >
+                                            Trace ID
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
                                       >
-                                        <svg
+                                        <EuiIconBeaker
                                           aria-hidden={true}
                                           className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
                                           focusable="false"
-                                          height={16}
                                           role="img"
                                           style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
                                         >
-                                          <path
-                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                          />
-                                        </svg>
-                                      </EuiIconBeaker>
-                                    </EuiIcon>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_trace_group_1"
-                            isSorted={false}
-                            key="_data_h_trace_group_1"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_trace_group_1"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Trace group",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Trace group"
-                                        >
-                                          Trace group
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_latency_2"
-                            isSorted={false}
-                            key="_data_h_latency_2"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_latency_2"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Duration (ms)",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Duration (ms)"
-                                        >
-                                          Duration (ms)
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                            isSorted={false}
-                            key="_data_h_percentile_in_trace_group_3"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Percentile in trace group",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Percentile in trace group"
-                                        >
-                                          <div>
-                                            Percentile in trace group
-                                          </div>
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="right"
-                            data-test-subj="tableHeaderCell_error_count_4"
-                            isSorted={false}
-                            key="_data_h_error_count_4"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_error_count_4"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Errors",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Errors"
-                                        >
-                                          Errors
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                          <EuiTableHeaderCell
-                            align="left"
-                            data-test-subj="tableHeaderCell_last_updated_5"
-                            isSorted={false}
-                            key="_data_h_last_updated_5"
-                            onSort={[Function]}
-                          >
-                            <th
-                              aria-live="polite"
-                              aria-sort="none"
-                              className="euiTableHeaderCell"
-                              data-test-subj="tableHeaderCell_last_updated_5"
-                              role="columnheader"
-                              scope="col"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <button
-                                className="euiTableHeaderButton"
-                                data-test-subj="tableHeaderSortButton"
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  isSorted={false}
-                                  showSortMsg={true}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Last updated",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Last updated"
-                                        >
-                                          Last updated
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </button>
-                            </th>
-                          </EuiTableHeaderCell>
-                        </tr>
-                      </thead>
-                    </EuiTableHeader>
-                    <EuiTableBody
-                      bodyRef={[Function]}
-                    >
-                      <tbody>
-                        <EuiTableRow
-                          isSelected={false}
-                        >
-                          <tr
-                            className="euiTableRow"
-                          >
-                            <EuiTableRowCell
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
                               align="left"
-                              key="_data_column_trace_id_0_0"
-                              mobileOptions={
-                                Object {
-                                  "header": "Trace ID",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
+                              data-test-subj="tableHeaderCell_trace_group_1"
+                              isSorted={false}
+                              key="_data_h_trace_group_1"
+                              onSort={[Function]}
                             >
-                              <td
-                                className="euiTableRowCell"
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_trace_group_1"
+                                role="columnheader"
+                                scope="col"
                                 style={
                                   Object {
                                     "width": undefined,
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  Trace ID
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiFlexGroup
-                                    alignItems="center"
-                                    className=""
-                                    gutterSize="s"
-                                    key=".0"
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
                                   >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    <span
+                                      className="euiTableCellContent"
                                     >
-                                      <EuiFlexItem
-                                        grow={10}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrow10"
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Trace group",
+                                            }
+                                          }
                                         >
-                                          <EuiLink
-                                            data-test-subj="trace-link"
-                                            onClick={[Function]}
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Trace group"
                                           >
-                                            <button
-                                              className="euiLink euiLink--primary"
+                                            Trace group
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_latency_2"
+                              isSorted={false}
+                              key="_data_h_latency_2"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_latency_2"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Duration (ms)",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Duration (ms)"
+                                          >
+                                            Duration (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                              isSorted={false}
+                              key="_data_h_percentile_in_trace_group_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Percentile in trace group",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Percentile in trace group"
+                                          >
+                                            <div>
+                                              Percentile in trace group
+                                            </div>
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_error_count_4"
+                              isSorted={false}
+                              key="_data_h_error_count_4"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_count_4"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Errors",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Errors"
+                                          >
+                                            Errors
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_last_updated_5"
+                              isSorted={false}
+                              key="_data_h_last_updated_5"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_last_updated_5"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Last updated",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Last updated"
+                                          >
+                                            Last updated
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow"
+                            >
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_trace_id_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Trace ID",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Trace ID
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      alignItems="center"
+                                      className=""
+                                      gutterSize="s"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={10}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow10"
+                                          >
+                                            <EuiLink
                                               data-test-subj="trace-link"
-                                              disabled={false}
                                               onClick={[Function]}
-                                              type="button"
                                             >
-                                              <div
-                                                title="00079a615e31e61766fcb20b557051c1"
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                data-test-subj="trace-link"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                00079a615e31e61766fcb...
-                                              </div>
-                                            </button>
-                                          </EuiLink>
-                                        </div>
-                                      </EuiFlexItem>
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiCopy
-                                            afterMessage="Copied"
-                                            textToCopy="00079a615e31e61766fcb20b557051c1"
-                                          >
-                                            <EuiToolTip
-                                              delay="regular"
-                                              onMouseOut={[Function]}
-                                              position="top"
-                                            >
-                                              <span
-                                                className="euiToolTipAnchor"
-                                                onKeyUp={[Function]}
-                                                onMouseOut={[Function]}
-                                                onMouseOver={[Function]}
-                                              >
-                                                <EuiButtonIcon
-                                                  aria-label="Copy trace id"
-                                                  iconType="copyClipboard"
-                                                  onBlur={[Function]}
-                                                  onClick={[Function]}
-                                                  onFocus={[Function]}
+                                                <div
+                                                  title="00079a615e31e61766fcb20b557051c1"
                                                 >
-                                                  <button
+                                                  00079a615e31e61766fcb...
+                                                </div>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiCopy
+                                              afterMessage="Copied"
+                                              textToCopy="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              <EuiToolTip
+                                                delay="regular"
+                                                onMouseOut={[Function]}
+                                                position="top"
+                                              >
+                                                <span
+                                                  className="euiToolTipAnchor"
+                                                  onKeyUp={[Function]}
+                                                  onMouseOut={[Function]}
+                                                  onMouseOver={[Function]}
+                                                >
+                                                  <EuiButtonIcon
                                                     aria-label="Copy trace id"
-                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                                                    disabled={false}
+                                                    iconType="copyClipboard"
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
                                                     onFocus={[Function]}
-                                                    type="button"
                                                   >
-                                                    <EuiIcon
-                                                      aria-hidden="true"
-                                                      className="euiButtonIcon__icon"
-                                                      color="inherit"
-                                                      size="m"
-                                                      type="copyClipboard"
+                                                    <button
+                                                      aria-label="Copy trace id"
+                                                      className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                                      disabled={false}
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onFocus={[Function]}
+                                                      type="button"
                                                     >
-                                                      <EuiIconBeaker
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
+                                                      <EuiIcon
+                                                        aria-hidden="true"
+                                                        className="euiButtonIcon__icon"
+                                                        color="inherit"
+                                                        size="m"
+                                                        type="copyClipboard"
                                                       >
-                                                        <svg
+                                                        <EuiIconBeaker
                                                           aria-hidden={true}
                                                           className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                           focusable="false"
-                                                          height={16}
                                                           role="img"
                                                           style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
                                                         >
-                                                          <path
-                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconBeaker>
-                                                    </EuiIcon>
-                                                  </button>
-                                                </EuiButtonIcon>
-                                              </span>
-                                            </EuiToolTip>
-                                          </EuiCopy>
-                                        </div>
-                                      </EuiFlexItem>
-                                      <EuiFlexItem
-                                        grow={3}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrow3"
-                                        />
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="left"
-                              key="_data_column_trace_group_0_1"
-                              mobileOptions={
-                                Object {
-                                  "header": "Trace group",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                              truncateText={true}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconBeaker>
+                                                      </EuiIcon>
+                                                    </button>
+                                                  </EuiButtonIcon>
+                                                </span>
+                                              </EuiToolTip>
+                                            </EuiCopy>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={3}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow3"
+                                          />
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_trace_group_0_1"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Trace group",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Trace group
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiText
-                                    className=""
-                                    key=".0"
-                                    size="s"
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                                   >
-                                    <div
-                                      className="euiText euiText--small"
+                                    Trace group
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiText
+                                      className=""
+                                      key=".0"
+                                      size="s"
                                     >
-                                      HTTP GET
-                                    </div>
-                                  </EuiText>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_latency_0_2"
-                              mobileOptions={
-                                Object {
-                                  "header": "Duration (ms)",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={true}
-                              truncateText={true}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                      <div
+                                        className="euiText euiText--small"
+                                      >
+                                        HTTP GET
+                                      </div>
+                                    </EuiText>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_latency_0_2"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Duration (ms)",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={true}
+                                truncateText={true}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Duration (ms)
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                                >
-                                  <span
-                                    className="euiTableCellContent__text"
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                                   >
-                                    19.91
-                                  </span>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_percentile_in_trace_group_0_3"
-                              mobileOptions={
-                                Object {
-                                  "header": <React.Fragment>
+                                    Duration (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                                  >
+                                    <span
+                                      className="euiTableCellContent__text"
+                                    >
+                                      19.91
+                                    </span>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_percentile_in_trace_group_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": <React.Fragment>
+                                      <div>
+                                        Percentile in trace group
+                                      </div>
+                                    </React.Fragment>,
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
                                     <div>
                                       Percentile in trace group
                                     </div>
-                                  </React.Fragment>,
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                >
-                                  <div>
-                                    Percentile in trace group
                                   </div>
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  <EuiText
-                                    className=""
-                                    key=".0"
-                                    size="s"
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
                                   >
-                                    <div
-                                      className="euiText euiText--small"
+                                    <EuiText
+                                      className=""
+                                      key=".0"
+                                      size="s"
                                     >
-                                      30th
-                                    </div>
-                                  </EuiText>
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="right"
-                              key="_data_column_error_count_0_4"
-                              mobileOptions={
-                                Object {
-                                  "header": "Errors",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                      <div
+                                        className="euiText euiText--small"
+                                      >
+                                        30th
+                                      </div>
+                                    </EuiText>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_count_0_4"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Errors",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={false}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Errors
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                >
-                                  No
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                            <EuiTableRowCell
-                              align="left"
-                              key="_data_column_last_updated_0_5"
-                              mobileOptions={
-                                Object {
-                                  "header": "Last updated",
-                                  "render": undefined,
-                                }
-                              }
-                              setScopeRow={false}
-                              textOnly={false}
-                            >
-                              <td
-                                className="euiTableRowCell"
-                                style={
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Errors
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    No
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_last_updated_0_5"
+                                mobileOptions={
                                   Object {
-                                    "width": undefined,
+                                    "header": "Last updated",
+                                    "render": undefined,
                                   }
                                 }
+                                setScopeRow={false}
+                                textOnly={false}
                               >
-                                <div
-                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
                                 >
-                                  Last updated
-                                </div>
-                                <div
-                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                >
-                                  11/10/2020 09:55:45
-                                </div>
-                              </td>
-                            </EuiTableRowCell>
-                          </tr>
-                        </EuiTableRow>
-                      </tbody>
-                    </EuiTableBody>
-                  </table>
-                </EuiTable>
-              </div>
-              <PaginationBar
-                aria-controls="random_html_id"
-                onPageChange={[Function]}
-                onPageSizeChange={[Function]}
-                pagination={
-                  Object {
-                    "hidePerPageOptions": undefined,
-                    "pageIndex": 0,
-                    "pageSize": 10,
-                    "pageSizeOptions": Array [
-                      5,
-                      10,
-                      15,
-                    ],
-                    "totalItemCount": 1,
-                  }
-                }
-              >
-                <div>
-                  <EuiSpacer
-                    size="m"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--m"
-                    />
-                  </EuiSpacer>
-                  <EuiTablePagination
-                    activePage={0}
-                    aria-controls="random_html_id"
-                    itemsPerPage={10}
-                    itemsPerPageOptions={
-                      Array [
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Last updated
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    11/10/2020 09:55:45
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
                         5,
                         10,
                         15,
-                      ]
+                      ],
+                      "totalItemCount": 1,
                     }
-                    onChangeItemsPerPage={[Function]}
-                    onChangePage={[Function]}
-                    pageCount={1}
-                  >
-                    <EuiFlexGroup
-                      alignItems="center"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
-                        <EuiFlexItem
-                          grow={false}
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <EuiPopover
-                              anchorPosition="upRight"
-                              button={
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
-                                >
-                                  <EuiI18n
-                                    default="Rows per page"
-                                    token="euiTablePagination.rowsPerPage"
-                                  />
-                                  : 
-                                  10
-                                </EuiButtonEmpty>
-                              }
-                              closePopover={[Function]}
-                              display="inlineBlock"
-                              hasArrow={true}
-                              isOpen={false}
-                              ownFocus={true}
-                              panelPaddingSize="none"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiPopover euiPopover--anchorUpRight"
-                              >
-                                <div
-                                  className="euiPopover__anchor"
-                                >
+                              <EuiPopover
+                                anchorPosition="upRight"
+                                button={
                                   <EuiButtonEmpty
                                     color="text"
                                     data-test-subj="tablePaginationPopoverButton"
@@ -3099,43 +3069,168 @@ exports[`Traces table component renders traces table 1`] = `
                                     onClick={[Function]}
                                     size="xs"
                                   >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    <EuiI18n
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
+                                    />
+                                    : 
+                                    10
+                                  </EuiButtonEmpty>
+                                }
+                                closePopover={[Function]}
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorUpRight"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiButtonEmpty
+                                      color="text"
                                       data-test-subj="tablePaginationPopoverButton"
-                                      disabled={false}
+                                      iconSide="right"
+                                      iconType="arrowDown"
                                       onClick={[Function]}
-                                      type="button"
+                                      size="xs"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="right"
-                                        iconSize="s"
-                                        iconType="arrowDown"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
+                                      <button
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        <EuiButtonContent
+                                          className="euiButtonEmpty__content"
+                                          iconSide="right"
+                                          iconSize="s"
+                                          iconType="arrowDown"
+                                          textProps={
+                                            Object {
+                                              "className": "euiButtonEmpty__text",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          >
+                                            <EuiIcon
+                                              className="euiButtonContent__icon"
+                                              color="inherit"
+                                              size="s"
+                                              type="arrowDown"
+                                            >
+                                              <EuiIconBeaker
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                focusable="false"
+                                                role="img"
+                                                style={null}
+                                              >
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                  focusable="false"
+                                                  height={16}
+                                                  role="img"
+                                                  style={null}
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
+                                              </EuiIconBeaker>
+                                            </EuiIcon>
+                                            <span
+                                              className="euiButtonEmpty__text"
+                                            >
+                                              <EuiI18n
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
+                                              >
+                                                Rows per page
+                                              </EuiI18n>
+                                              : 
+                                              10
+                                            </span>
+                                          </span>
+                                        </EuiButtonContent>
+                                      </button>
+                                    </EuiButtonEmpty>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
+                              >
+                                <nav
+                                  className="euiPagination"
+                                >
+                                  <EuiI18n
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
+                                    values={
+                                      Object {
+                                        "page": 0,
+                                      }
+                                    }
+                                  >
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
+                                        onClick={[Function]}
+                                      >
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
                                           <EuiIcon
-                                            className="euiButtonContent__icon"
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
                                             color="inherit"
-                                            size="s"
-                                            type="arrowDown"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
                                             <EuiIconBeaker
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
                                               role="img"
                                               style={null}
                                             >
                                               <svg
                                                 aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                 focusable="false"
                                                 height={16}
                                                 role="img"
@@ -3150,271 +3245,176 @@ exports[`Traces table component renders traces table 1`] = `
                                               </svg>
                                             </EuiIconBeaker>
                                           </EuiIcon>
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            <EuiI18n
-                                              default="Rows per page"
-                                              token="euiTablePagination.rowsPerPage"
-                                            >
-                                              Rows per page
-                                            </EuiI18n>
-                                            : 
-                                            10
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </div>
-                              </div>
-                            </EuiPopover>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiPagination
-                              activePage={0}
-                              aria-controls="random_html_id"
-                              onPageClick={[Function]}
-                              pageCount={1}
-                            >
-                              <nav
-                                className="euiPagination"
-                              >
-                                <EuiI18n
-                                  default="Previous page, {page}"
-                                  token="euiPagination.previousPage"
-                                  values={
-                                    Object {
-                                      "page": 0,
-                                    }
-                                  }
-                                >
-                                  <EuiI18n
-                                    default="Previous page"
-                                    token="euiPagination.disabledPreviousPage"
-                                  >
-                                    <EuiButtonIcon
-                                      aria-label="Previous page"
-                                      color="text"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      iconType="arrowLeft"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        aria-label="Previous page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowLeft"
-                                        >
-                                          <EuiIconBeaker
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              height={16}
-                                              role="img"
-                                              style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                              />
-                                            </svg>
-                                          </EuiIconBeaker>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                                <ul
-                                  className="euiPagination__list"
-                                >
-                                  <PaginationButton
-                                    key="0"
-                                    pageIndex={0}
+                                  <ul
+                                    className="euiPagination__list"
                                   >
-                                    <li
-                                      className="euiPagination__item"
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
                                     >
-                                      <EuiPaginationButton
-                                        aria-controls="random_html_id"
-                                        hideOnMobile={true}
-                                        isActive={true}
-                                        onClick={[Function]}
-                                        pageIndex={0}
-                                        totalPages={1}
+                                      <li
+                                        className="euiPagination__item"
                                       >
-                                        <EuiI18n
-                                          default="Page {page} of {totalPages}"
-                                          token="euiPaginationButton.longPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
-                                              "totalPages": 1,
-                                            }
-                                          }
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Page {page}"
-                                            token="euiPaginationButton.shortPageString"
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
                                             values={
                                               Object {
                                                 "page": 1,
+                                                "totalPages": 1,
                                               }
                                             }
                                           >
-                                            <EuiButtonEmpty
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              color="text"
-                                              data-test-subj="pagination-button-0"
-                                              href="#random_html_id"
-                                              isDisabled={true}
-                                              onClick={[Function]}
-                                              size="s"
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
+                                                }
+                                              }
                                             >
-                                              <button
+                                              <EuiButtonEmpty
                                                 aria-controls="random_html_id"
                                                 aria-current={true}
                                                 aria-label="Page 1 of 1"
-                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
                                                 data-test-subj="pagination-button-0"
-                                                disabled={true}
+                                                href="#random_html_id"
+                                                isDisabled={true}
                                                 onClick={[Function]}
-                                                type="button"
+                                                size="s"
                                               >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="left"
-                                                  iconSize="m"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text",
-                                                    }
-                                                  }
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonContent euiButtonEmpty__content"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
                                                     <span
-                                                      className="euiButtonEmpty__text"
+                                                      className="euiButtonContent euiButtonEmpty__content"
                                                     >
-                                                      1
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
                                                     </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
                                           </EuiI18n>
-                                        </EuiI18n>
-                                      </EuiPaginationButton>
-                                    </li>
-                                  </PaginationButton>
-                                </ul>
-                                <EuiI18n
-                                  default="Next page, {page}"
-                                  token="euiPagination.nextPage"
-                                  values={
-                                    Object {
-                                      "page": 2,
-                                    }
-                                  }
-                                >
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
                                   <EuiI18n
-                                    default="Next page"
-                                    token="euiPagination.disabledNextPage"
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <EuiButtonIcon
-                                      aria-label="Next page"
-                                      color="text"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      iconType="arrowRight"
-                                      onClick={[Function]}
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <button
+                                      <EuiButtonIcon
                                         aria-label="Next page"
-                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        color="text"
                                         data-test-subj="pagination-button-next"
                                         disabled={true}
+                                        iconType="arrowRight"
                                         onClick={[Function]}
-                                        type="button"
                                       >
-                                        <EuiIcon
-                                          aria-hidden="true"
-                                          className="euiButtonIcon__icon"
-                                          color="inherit"
-                                          size="m"
-                                          type="arrowRight"
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <EuiIconBeaker
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <svg
+                                            <EuiIconBeaker
                                               aria-hidden={true}
                                               className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                              />
-                                            </svg>
-                                          </EuiIconBeaker>
-                                        </EuiIcon>
-                                      </button>
-                                    </EuiButtonIcon>
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
                                   </EuiI18n>
-                                </EuiI18n>
-                              </nav>
-                            </EuiPagination>
-                          </div>
-                        </EuiFlexItem>
-                      </div>
-                    </EuiFlexGroup>
-                  </EuiTablePagination>
-                </div>
-              </PaginationBar>
-            </div>
-          </EuiBasicTable>
-        </EuiInMemoryTable>
-      </div>
-    </EuiPanel>
-  </div>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
+              </div>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
+    </div>
+  </EuiPage>
 </TracesTable>
 `;

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -10,222 +10,230 @@ exports[`Traces table component renders empty traces table message 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem
-            grow={10}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
-            >
-              <PanelTitle
-                title="Traces"
-                totalItems={0}
-              >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <MissingConfigurationMessage
-        mode="data_prepper"
-      >
-        <EuiEmptyPrompt
-          actions={
-            <EuiButton
-              color="primary"
-              iconSide="right"
-              iconType="popout"
-              onClick={[Function]}
-            >
-              Learn more
-            </EuiButton>
-          }
-          body={
-            <EuiText>
-              The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-            </EuiText>
-          }
-          title={
-            <h2>
-              Trace Analytics not set up
-            </h2>
-          }
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
         >
           <div
-            className="euiEmptyPrompt"
+            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
-                Trace Analytics not set up
-              </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
-            >
-              <span
-                className="euiTextColor euiTextColor--subdued"
-              >
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-                      </div>
-                    </EuiText>
-                  </div>
-                </EuiText>
-              </span>
-            </EuiTextColor>
-            <EuiSpacer
-              size="l"
+            <EuiFlexItem
+              grow={10}
             >
               <div
-                className="euiSpacer euiSpacer--l"
-              />
-            </EuiSpacer>
-            <EuiButton
-              color="primary"
-              iconSide="right"
-              iconType="popout"
-              onClick={[Function]}
-            >
-              <EuiButtonDisplay
-                baseClassName="euiButton"
+                className="euiFlexItem euiFlexItem--flexGrow10"
+              >
+                <PanelTitle
+                  title="Traces"
+                  totalItems={0}
+                >
+                  <EuiText
+                    size="m"
+                  >
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <span
+                        className="panel-title"
+                      >
+                        Traces
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (0)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiSpacer
+          size="m"
+        >
+          <div
+            className="euiSpacer euiSpacer--m"
+          />
+        </EuiSpacer>
+        <EuiHorizontalRule
+          margin="none"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <MissingConfigurationMessage
+          mode="data_prepper"
+        >
+          <EuiEmptyPrompt
+            actions={
+              <EuiButton
                 color="primary"
-                disabled={false}
-                element="button"
                 iconSide="right"
                 iconType="popout"
-                isDisabled={false}
                 onClick={[Function]}
-                type="button"
               >
-                <button
-                  className="euiButton euiButton--primary"
+                Learn more
+              </EuiButton>
+            }
+            body={
+              <EuiText>
+                The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+              </EuiText>
+            }
+            title={
+              <h2>
+                Trace Analytics not set up
+              </h2>
+            }
+          >
+            <div
+              className="euiEmptyPrompt"
+            >
+              <EuiTitle
+                size="m"
+              >
+                <h2
+                  className="euiTitle euiTitle--medium"
+                >
+                  Trace Analytics not set up
+                </h2>
+              </EuiTitle>
+              <EuiTextColor
+                color="subdued"
+              >
+                <span
+                  className="euiTextColor euiTextColor--subdued"
+                >
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiText>
+                </span>
+              </EuiTextColor>
+              <EuiSpacer
+                size="l"
+              >
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <EuiButton
+                color="primary"
+                iconSide="right"
+                iconType="popout"
+                onClick={[Function]}
+              >
+                <EuiButtonDisplay
+                  baseClassName="euiButton"
+                  color="primary"
                   disabled={false}
+                  element="button"
+                  iconSide="right"
+                  iconType="popout"
+                  isDisabled={false}
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "minWidth": undefined,
-                    }
-                  }
                   type="button"
                 >
-                  <EuiButtonContent
-                    className="euiButton__content"
-                    iconSide="right"
-                    iconType="popout"
-                    textProps={
+                  <button
+                    className="euiButton euiButton--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    style={
                       Object {
-                        "className": "euiButton__text",
+                        "minWidth": undefined,
                       }
                     }
+                    type="button"
                   >
-                    <span
-                      className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                    <EuiButtonContent
+                      className="euiButton__content"
+                      iconSide="right"
+                      iconType="popout"
+                      textProps={
+                        Object {
+                          "className": "euiButton__text",
+                        }
+                      }
                     >
-                      <EuiIcon
-                        className="euiButtonContent__icon"
-                        color="inherit"
-                        size="m"
-                        type="popout"
+                      <span
+                        className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                       >
-                        <EuiIconBeaker
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
+                        <EuiIcon
+                          className="euiButtonContent__icon"
+                          color="inherit"
+                          size="m"
+                          type="popout"
                         >
-                          <svg
+                          <EuiIconBeaker
                             aria-hidden={true}
                             className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                             focusable="false"
-                            height={16}
                             role="img"
                             style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <path
-                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                            />
-                          </svg>
-                        </EuiIconBeaker>
-                      </EuiIcon>
-                      <span
-                        className="euiButton__text"
-                      >
-                        Learn more
+                            <svg
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                          </EuiIconBeaker>
+                        </EuiIcon>
+                        <span
+                          className="euiButton__text"
+                        >
+                          Learn more
+                        </span>
                       </span>
-                    </span>
-                  </EuiButtonContent>
-                </button>
-              </EuiButtonDisplay>
-            </EuiButton>
-          </div>
-        </EuiEmptyPrompt>
-      </MissingConfigurationMessage>
-    </div>
-  </EuiPanel>
+                    </EuiButtonContent>
+                  </button>
+                </EuiButtonDisplay>
+              </EuiButton>
+            </div>
+          </EuiEmptyPrompt>
+        </MissingConfigurationMessage>
+      </div>
+    </EuiPanel>
+  </div>
 </TracesTable>
 `;
 
@@ -239,138 +247,146 @@ exports[`Traces table component renders empty traces table message 2`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
         >
-          <EuiFlexItem
-            grow={10}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <EuiFlexItem
+              grow={10}
+            >
+              <div
+                className="euiFlexItem euiFlexItem--flexGrow10"
+              >
+                <PanelTitle
+                  title="Traces"
+                  totalItems={0}
+                >
+                  <EuiText
+                    size="m"
+                  >
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <span
+                        className="panel-title"
+                      >
+                        Traces
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (0)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiSpacer
+          size="m"
+        >
+          <div
+            className="euiSpacer euiSpacer--m"
+          />
+        </EuiSpacer>
+        <EuiHorizontalRule
+          margin="none"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <NoMatchMessage
+          size="xl"
+        >
+          <EuiSpacer
+            size="xl"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
-            >
-              <PanelTitle
-                title="Traces"
-                totalItems={0}
-              >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <NoMatchMessage
-        size="xl"
-      >
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-        <EuiEmptyPrompt
-          body={
-            <EuiText>
-              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-            </EuiText>
-          }
-          title={
-            <h2>
-              No matches
-            </h2>
-          }
-        >
-          <div
-            className="euiEmptyPrompt"
-          >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+          <EuiEmptyPrompt
+            body={
+              <EuiText>
+                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+              </EuiText>
+            }
+            title={
+              <h2>
                 No matches
               </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
+            }
+          >
+            <div
+              className="euiEmptyPrompt"
             >
-              <span
-                className="euiTextColor euiTextColor--subdued"
+              <EuiTitle
+                size="m"
               >
-                <EuiSpacer
-                  size="m"
+                <h2
+                  className="euiTitle euiTitle--medium"
                 >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  No matches
+                </h2>
+              </EuiTitle>
+              <EuiTextColor
+                color="subdued"
+              >
+                <span
+                  className="euiTextColor euiTextColor--subdued"
+                >
+                  <EuiSpacer
+                    size="m"
                   >
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </div>
-                    </EuiText>
-                  </div>
-                </EuiText>
-              </span>
-            </EuiTextColor>
-          </div>
-        </EuiEmptyPrompt>
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </NoMatchMessage>
-    </div>
-  </EuiPanel>
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiText>
+                </span>
+              </EuiTextColor>
+            </div>
+          </EuiEmptyPrompt>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
+        </NoMatchMessage>
+      </div>
+    </EuiPanel>
+  </div>
 </TracesTable>
 `;
 
@@ -395,134 +411,72 @@ exports[`Traces table component renders jaeger traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
         >
-          <EuiFlexItem
-            grow={10}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
+            <EuiFlexItem
+              grow={10}
             >
-              <PanelTitle
-                title="Traces"
-                totalItems={1}
+              <div
+                className="euiFlexItem euiFlexItem--flexGrow10"
               >
-                <EuiText
-                  size="m"
+                <PanelTitle
+                  title="Traces"
+                  totalItems={1}
                 >
-                  <div
-                    className="euiText euiText--medium"
+                  <EuiText
+                    size="m"
                   >
-                    <span
-                      className="panel-title"
+                    <div
+                      className="euiText euiText--medium"
                     >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "trace_id",
-              "name": "Trace ID",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "latency",
-              "name": "Latency (ms)",
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_count",
-              "name": "Errors",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "left",
-              "field": "last_updated",
-              "name": "Last updated",
-              "render": [Function],
-              "sortable": true,
-            },
-          ]
-        }
-        items={
-          Array [
-            Object {
-              "actions": "#",
-              "error_count": "Yes",
-              "last_updated": "11/10/2020 09:55:45",
-              "latency": 19.91,
-              "trace_group": "HTTP GET",
-              "trace_id": "00079a615e31e61766fcb20b557051c1",
-            },
-          ]
-        }
-        loading={false}
-        onTableChange={[Function]}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "trace_id",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
+                      <span
+                        className="panel-title"
+                      >
+                        Traces
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (1)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiSpacer
+          size="m"
+        >
+          <div
+            className="euiSpacer euiSpacer--m"
+          />
+        </EuiSpacer>
+        <EuiHorizontalRule
+          margin="none"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <EuiInMemoryTable
           columns={
             Array [
               Object {
@@ -569,128 +523,171 @@ exports[`Traces table component renders jaeger traces table 1`] = `
             ]
           }
           loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
+          onTableChange={[Function]}
           pagination={
             Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
+              "initialPageSize": 10,
               "pageSizeOptions": Array [
                 5,
                 10,
                 15,
               ],
-              "totalItemCount": 1,
             }
           }
           responsive={true}
           sorting={
             Object {
-              "allowNeutralSort": true,
               "sort": Object {
                 "direction": "asc",
-                "field": "Trace ID",
+                "field": "trace_id",
               },
             }
           }
           tableLayout="auto"
         >
-          <div
-            className="euiBasicTable"
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "trace_id",
+                  "name": "Trace ID",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "latency",
+                  "name": "Latency (ms)",
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_count",
+                  "name": "Errors",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "left",
+                  "field": "last_updated",
+                  "name": "Last updated",
+                  "render": [Function],
+                  "sortable": true,
+                },
+              ]
+            }
+            items={
+              Array [
+                Object {
+                  "actions": "#",
+                  "error_count": "Yes",
+                  "last_updated": "11/10/2020 09:55:45",
+                  "latency": 19.91,
+                  "trace_group": "HTTP GET",
+                  "trace_id": "00079a615e31e61766fcb20b557051c1",
+                },
+              ]
+            }
+            loading={false}
+            noItemsMessage="No items found"
+            onChange={[Function]}
+            pagination={
+              Object {
+                "hidePerPageOptions": undefined,
+                "pageIndex": 0,
+                "pageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+                "totalItemCount": 1,
+              }
+            }
+            responsive={true}
+            sorting={
+              Object {
+                "allowNeutralSort": true,
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "Trace ID",
+                },
+              }
+            }
+            tableLayout="auto"
           >
-            <div>
-              <EuiTableHeaderMobile>
-                <div
-                  className="euiTableHeaderMobile"
-                >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
                   >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        />
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_trace_id_0",
-                                  "name": "Trace ID",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_latency_1",
-                                  "name": "Latency (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_count_2",
-                                  "name": "Errors",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_last_updated_3",
-                                  "name": "Last updated",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiTableSortMobile"
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": true,
+                                    "isSorted": true,
+                                    "key": "_data_s_trace_id_0",
+                                    "name": "Trace ID",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_latency_1",
+                                    "name": "Latency (ms)",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_error_count_2",
+                                    "name": "Errors",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_last_updated_3",
+                                    "name": "Last updated",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
                             >
-                              <EuiPopover
-                                anchorPosition="downRight"
-                                button={
-                                  <EuiButtonEmpty
-                                    flush="right"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    onClick={[Function]}
-                                    size="xs"
-                                  >
-                                    <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
+                              <div
+                                className="euiTableSortMobile"
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownRight"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
                                     <EuiButtonEmpty
                                       flush="right"
                                       iconSide="right"
@@ -698,727 +695,724 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                       onClick={[Function]}
                                       size="xs"
                                     >
-                                      <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                        disabled={false}
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorDownRight"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
+                                    >
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
                                         onClick={[Function]}
-                                        type="button"
+                                        size="xs"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="right"
+                                            iconSize="s"
+                                            iconType="arrowDown"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <span
+                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                             >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiIcon
+                                                className="euiButtonContent__icon"
+                                                color="inherit"
+                                                size="s"
+                                                type="arrowDown"
                                               >
-                                                <svg
+                                                <EuiIconArrowDown
                                                   aria-hidden={true}
                                                   className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
                                                   focusable="false"
-                                                  height={16}
                                                   role="img"
                                                   style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                      fillRule="non-zero"
+                                                    />
+                                                  </svg>
+                                                </EuiIconArrowDown>
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButtonEmpty__text"
                                               >
-                                                Sorting
-                                              </EuiI18n>
+                                                <EuiI18n
+                                                  default="Sorting"
+                                                  token="euiTableSortMobile.sorting"
+                                                >
+                                                  Sorting
+                                                </EuiI18n>
+                                              </span>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
                   id="random_html_id"
-                  tabIndex={-1}
+                  responsive={true}
+                  tableLayout="auto"
                 >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_trace_id_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_trace_id_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
+                  <table
+                    className="euiTable euiTable--responsive euiTable--auto"
+                    id="random_html_id"
+                    tabIndex={-1}
+                  >
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCell
+                            align="left"
                             data-test-subj="tableHeaderCell_trace_id_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
+                            isSortAscending={true}
+                            isSorted={true}
+                            key="_data_h_trace_id_0"
+                            onSort={[Function]}
                           >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
+                            <th
+                              aria-live="polite"
+                              aria-sort="ascending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_trace_id_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
                             >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                <span
+                                <CellContents
                                   className="euiTableCellContent"
+                                  isSortAscending={true}
+                                  isSorted={true}
+                                  showSortMsg={true}
                                 >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Trace ID",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Trace ID"
-                                      >
-                                        Trace ID
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
+                                  <span
+                                    className="euiTableCellContent"
                                   >
-                                    <EuiIconSortUp
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Trace ID",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Trace ID"
+                                        >
+                                          Trace ID
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                    <EuiIcon
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortUp"
                                     >
-                                      <svg
+                                      <EuiIconSortUp
                                         aria-hidden={true}
                                         className="euiIcon euiIcon--medium euiTableSortIcon"
                                         focusable="false"
-                                        height={16}
                                         role="img"
                                         style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSortUp>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_latency_1"
-                          isSorted={false}
-                          key="_data_h_latency_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                          />
+                                        </svg>
+                                      </EuiIconSortUp>
+                                    </EuiIcon>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
                             data-test-subj="tableHeaderCell_latency_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
+                            isSorted={false}
+                            key="_data_h_latency_1"
+                            onSort={[Function]}
                           >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Latency (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Latency (ms)"
-                                      >
-                                        Latency (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_count_2"
-                          isSorted={false}
-                          key="_data_h_error_count_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_count_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Errors",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Errors"
-                                      >
-                                        Errors
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_last_updated_3"
-                          isSorted={false}
-                          key="_data_h_last_updated_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_last_updated_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Last updated",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Last updated"
-                                      >
-                                        Last updated
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
-                  >
-                    <tbody>
-                      <EuiTableRow
-                        isSelected={false}
-                      >
-                        <tr
-                          className="euiTableRow"
-                        >
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_trace_id_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Trace ID",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_latency_1"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Trace ID
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  alignItems="center"
-                                  className=""
-                                  gutterSize="s"
-                                  key=".0"
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
                                   >
-                                    <EuiFlexItem
-                                      grow={10}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow10"
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Latency (ms)",
+                                          }
+                                        }
                                       >
-                                        <EuiLink
-                                          onClick={[Function]}
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Latency (ms)"
                                         >
-                                          <button
-                                            className="euiLink euiLink--primary"
-                                            disabled={false}
+                                          Latency (ms)
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_error_count_2"
+                            isSorted={false}
+                            key="_data_h_error_count_2"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_error_count_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Errors",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Errors"
+                                        >
+                                          Errors
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_last_updated_3"
+                            isSorted={false}
+                            key="_data_h_last_updated_3"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_last_updated_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Last updated",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Last updated"
+                                        >
+                                          Last updated
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody
+                      bodyRef={[Function]}
+                    >
+                      <tbody>
+                        <EuiTableRow
+                          isSelected={false}
+                        >
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_trace_id_0_0"
+                              mobileOptions={
+                                Object {
+                                  "header": "Trace ID",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Trace ID
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiFlexGroup
+                                    alignItems="center"
+                                    className=""
+                                    gutterSize="s"
+                                    key=".0"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={10}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrow10"
+                                        >
+                                          <EuiLink
                                             onClick={[Function]}
-                                            type="button"
                                           >
-                                            <div
-                                              title="00079a615e31e61766fcb20b557051c1"
+                                            <button
+                                              className="euiLink euiLink--primary"
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              type="button"
                                             >
-                                              00079a615e31e61766fcb...
-                                            </div>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={false}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
-                                      >
-                                        <EuiCopy
-                                          afterMessage="Copied"
-                                          textToCopy="00079a615e31e61766fcb20b557051c1"
-                                        >
-                                          <EuiToolTip
-                                            delay="regular"
-                                            onMouseOut={[Function]}
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            >
-                                              <EuiButtonIcon
-                                                aria-label="Copy trace id"
-                                                iconType="copyClipboard"
-                                                onBlur={[Function]}
-                                                onClick={[Function]}
-                                                onFocus={[Function]}
+                                              <div
+                                                title="00079a615e31e61766fcb20b557051c1"
                                               >
-                                                <button
+                                                00079a615e31e61766fcb...
+                                              </div>
+                                            </button>
+                                          </EuiLink>
+                                        </div>
+                                      </EuiFlexItem>
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiCopy
+                                            afterMessage="Copied"
+                                            textToCopy="00079a615e31e61766fcb20b557051c1"
+                                          >
+                                            <EuiToolTip
+                                              delay="regular"
+                                              onMouseOut={[Function]}
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Copy trace id"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                                                  disabled={false}
+                                                  iconType="copyClipboard"
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
                                                   onFocus={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="copyClipboard"
+                                                  <button
+                                                    aria-label="Copy trace id"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                                    disabled={false}
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onFocus={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconCopyClipboard
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="copyClipboard"
                                                     >
-                                                      <svg
+                                                      <EuiIconCopyClipboard
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
                                                       >
-                                                        <path
-                                                          d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
-                                                        />
-                                                        <path
-                                                          d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
-                                                        />
-                                                      </svg>
-                                                    </EuiIconCopyClipboard>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                        </EuiCopy>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={3}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow3"
-                                      />
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_latency_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Latency (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={true}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
+                                                          />
+                                                          <path
+                                                            d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconCopyClipboard>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </EuiCopy>
+                                        </div>
+                                      </EuiFlexItem>
+                                      <EuiFlexItem
+                                        grow={3}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrow3"
+                                        />
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_latency_0_1"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Latency (ms)",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={true}
+                              truncateText={true}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Latency (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                              >
-                                <span
-                                  className="euiTableCellContent__text"
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                                 >
-                                  19.91
-                                </span>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_count_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Errors",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                  Latency (ms)
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                  >
+                                    19.91
+                                  </span>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_error_count_0_2"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Errors",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={false}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Errors
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                No
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_last_updated_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": "Last updated",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Errors
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                >
+                                  No
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_last_updated_0_3"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Last updated",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={false}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Last updated
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                11/10/2020 09:55:45
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Last updated
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                >
+                                  11/10/2020 09:55:45
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+              <PaginationBar
+                aria-controls="random_html_id"
+                onPageChange={[Function]}
+                onPageSizeChange={[Function]}
+                pagination={
+                  Object {
+                    "hidePerPageOptions": undefined,
+                    "pageIndex": 0,
+                    "pageSize": 10,
+                    "pageSizeOptions": Array [
                       5,
                       10,
                       15,
-                    ]
+                    ],
+                    "totalItemCount": 1,
                   }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+                }
+              >
+                <div>
+                  <EuiSpacer
+                    size="m"
                   >
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiTablePagination
+                    activePage={0}
+                    aria-controls="random_html_id"
+                    itemsPerPage={10}
+                    itemsPerPageOptions={
+                      Array [
+                        5,
+                        10,
+                        15,
+                      ]
+                    }
+                    onChangeItemsPerPage={[Function]}
+                    onChangePage={[Function]}
+                    pageCount={1}
+                  >
+                    <EuiFlexGroup
+                      alignItems="center"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiPopover euiPopover--anchorUpRight"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
+                            <EuiPopover
+                              anchorPosition="upRight"
+                              button={
                                 <EuiButtonEmpty
                                   color="text"
                                   data-test-subj="tablePaginationPopoverButton"
@@ -1427,43 +1421,169 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                   onClick={[Function]}
                                   size="xs"
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                  <EuiI18n
+                                    default="Rows per page"
+                                    token="euiTablePagination.rowsPerPage"
+                                  />
+                                  : 
+                                  10
+                                </EuiButtonEmpty>
+                              }
+                              closePopover={[Function]}
+                              display="inlineBlock"
+                              hasArrow={true}
+                              isOpen={false}
+                              ownFocus={true}
+                              panelPaddingSize="none"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorUpRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <EuiButtonEmpty
+                                    color="text"
                                     data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
+                                    iconSide="right"
+                                    iconType="arrowDown"
                                     onClick={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                      data-test-subj="tablePaginationPopoverButton"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="right"
+                                        iconSize="s"
+                                        iconType="arrowDown"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        >
+                                          <EuiIcon
+                                            className="euiButtonContent__icon"
+                                            color="inherit"
+                                            size="s"
+                                            type="arrowDown"
+                                          >
+                                            <EuiIconArrowDown
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                  fillRule="non-zero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowDown>
+                                          </EuiIcon>
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            <EuiI18n
+                                              default="Rows per page"
+                                              token="euiTablePagination.rowsPerPage"
+                                            >
+                                              Rows per page
+                                            </EuiI18n>
+                                            : 
+                                            10
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </div>
+                            </EuiPopover>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiPagination
+                              activePage={0}
+                              aria-controls="random_html_id"
+                              onPageClick={[Function]}
+                              pageCount={1}
+                            >
+                              <nav
+                                className="euiPagination"
+                              >
+                                <EuiI18n
+                                  default="Previous page, {page}"
+                                  token="euiPagination.previousPage"
+                                  values={
+                                    Object {
+                                      "page": 0,
+                                    }
+                                  }
+                                >
+                                  <EuiI18n
+                                    default="Previous page"
+                                    token="euiPagination.disabledPreviousPage"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Previous page"
+                                      color="text"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      iconType="arrowLeft"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        aria-label="Previous page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
                                         <EuiIcon
-                                          className="euiButtonContent__icon"
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
                                           color="inherit"
-                                          size="s"
-                                          type="arrowDown"
+                                          size="m"
+                                          type="arrowLeft"
                                         >
-                                          <EuiIconArrowDown
+                                          <EuiIconArrowLeft
                                             aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                             focusable="false"
                                             role="img"
                                             style={null}
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
                                               height={16}
                                               role="img"
@@ -1473,279 +1593,183 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                               xmlns="http://www.w3.org/2000/svg"
                                             >
                                               <path
-                                                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                fillRule="non-zero"
+                                                d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                                fillRule="nonzero"
                                               />
                                             </svg>
-                                          </EuiIconArrowDown>
+                                          </EuiIconArrowLeft>
                                         </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
-                                        >
-                                          <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconArrowLeft
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowLeft>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
+                                <ul
+                                  className="euiPagination__list"
                                 >
-                                  <li
-                                    className="euiPagination__item"
+                                  <PaginationButton
+                                    key="0"
+                                    pageIndex={0}
                                   >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
+                                    <li
+                                      className="euiPagination__item"
                                     >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
+                                      <EuiPaginationButton
+                                        aria-controls="random_html_id"
+                                        hideOnMobile={true}
+                                        isActive={true}
+                                        onClick={[Function]}
+                                        pageIndex={0}
+                                        totalPages={1}
                                       >
                                         <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
+                                          default="Page {page} of {totalPages}"
+                                          token="euiPaginationButton.longPageString"
                                           values={
                                             Object {
                                               "page": 1,
+                                              "totalPages": 1,
                                             }
                                           }
                                         >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
+                                          <EuiI18n
+                                            default="Page {page}"
+                                            token="euiPaginationButton.shortPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                              }
+                                            }
                                           >
-                                            <button
+                                            <EuiButtonEmpty
                                               aria-controls="random_html_id"
                                               aria-current={true}
                                               aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              color="text"
                                               data-test-subj="pagination-button-0"
-                                              disabled={true}
+                                              href="#random_html_id"
+                                              isDisabled={true}
                                               onClick={[Function]}
-                                              type="button"
+                                              size="s"
                                             >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
-                                                }
+                                              <button
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                data-test-subj="pagination-button-0"
+                                                disabled={true}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="left"
+                                                  iconSize="m"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text",
+                                                    }
+                                                  }
                                                 >
                                                   <span
-                                                    className="euiButtonEmpty__text"
+                                                    className="euiButtonContent euiButtonEmpty__content"
                                                   >
-                                                    1
+                                                    <span
+                                                      className="euiButtonEmpty__text"
+                                                    >
+                                                      1
+                                                    </span>
                                                   </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </EuiI18n>
                                         </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
+                                      </EuiPaginationButton>
+                                    </li>
+                                  </PaginationButton>
+                                </ul>
                                 <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
+                                  default="Next page, {page}"
+                                  token="euiPagination.nextPage"
+                                  values={
+                                    Object {
+                                      "page": 2,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                  <EuiI18n
+                                    default="Next page"
+                                    token="euiPagination.disabledNextPage"
                                   >
-                                    <button
+                                    <EuiButtonIcon
                                       aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      color="text"
                                       data-test-subj="pagination-button-next"
                                       disabled={true}
+                                      iconType="arrowRight"
                                       onClick={[Function]}
-                                      type="button"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <button
+                                        aria-label="Next page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <EuiIconArrowRight
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="arrowRight"
                                         >
-                                          <svg
+                                          <EuiIconArrowRight
                                             aria-hidden={true}
                                             className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                             focusable="false"
-                                            height={16}
                                             role="img"
                                             style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <path
-                                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowRight>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                                fillRule="nonzero"
+                                              />
+                                            </svg>
+                                          </EuiIconArrowRight>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
-              </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
-    </div>
-  </EuiPanel>
+                              </nav>
+                            </EuiPagination>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </EuiTablePagination>
+                </div>
+              </PaginationBar>
+            </div>
+          </EuiBasicTable>
+        </EuiInMemoryTable>
+      </div>
+    </EuiPanel>
+  </div>
 </TracesTable>
 `;
 
@@ -1771,154 +1795,72 @@ exports[`Traces table component renders traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
-    <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
+  <div
+    style={
+      Object {
+        "padding": "0 16px",
+      }
+    }
+  >
+    <EuiPanel>
+      <div
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
         >
-          <EuiFlexItem
-            grow={10}
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
+            <EuiFlexItem
+              grow={10}
             >
-              <PanelTitle
-                title="Traces"
-                totalItems={1}
+              <div
+                className="euiFlexItem euiFlexItem--flexGrow10"
               >
-                <EuiText
-                  size="m"
+                <PanelTitle
+                  title="Traces"
+                  totalItems={1}
                 >
-                  <div
-                    className="euiText euiText--medium"
+                  <EuiText
+                    size="m"
                   >
-                    <span
-                      className="panel-title"
+                    <div
+                      className="euiText euiText--medium"
                     >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "trace_id",
-              "name": "Trace ID",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "left",
-              "field": "trace_group",
-              "name": "Trace group",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "latency",
-              "name": "Duration (ms)",
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "percentile_in_trace_group",
-              "name": <React.Fragment>
-                <div>
-                  Percentile in trace group
-                </div>
-              </React.Fragment>,
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_count",
-              "name": "Errors",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "left",
-              "field": "last_updated",
-              "name": "Last updated",
-              "render": [Function],
-              "sortable": true,
-            },
-          ]
-        }
-        items={
-          Array [
-            Object {
-              "actions": "#",
-              "error_count": "Yes",
-              "last_updated": "11/10/2020 09:55:45",
-              "latency": 19.91,
-              "percentile_in_trace_group": 30,
-              "trace_group": "HTTP GET",
-              "trace_id": "00079a615e31e61766fcb20b557051c1",
-            },
-          ]
-        }
-        loading={false}
-        onTableChange={[Function]}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "trace_id",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
+                      <span
+                        className="panel-title"
+                      >
+                        Traces
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (1)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
+              </div>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
+        <EuiSpacer
+          size="m"
+        >
+          <div
+            className="euiSpacer euiSpacer--m"
+          />
+        </EuiSpacer>
+        <EuiHorizontalRule
+          margin="none"
+        >
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
+          />
+        </EuiHorizontalRule>
+        <EuiInMemoryTable
           columns={
             Array [
               Object {
@@ -1985,146 +1927,209 @@ exports[`Traces table component renders traces table 1`] = `
             ]
           }
           loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
+          onTableChange={[Function]}
           pagination={
             Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
+              "initialPageSize": 10,
               "pageSizeOptions": Array [
                 5,
                 10,
                 15,
               ],
-              "totalItemCount": 1,
             }
           }
           responsive={true}
           sorting={
             Object {
-              "allowNeutralSort": true,
               "sort": Object {
                 "direction": "asc",
-                "field": "Trace ID",
+                "field": "trace_id",
               },
             }
           }
           tableLayout="auto"
         >
-          <div
-            className="euiBasicTable"
+          <EuiBasicTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "trace_id",
+                  "name": "Trace ID",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "left",
+                  "field": "trace_group",
+                  "name": "Trace group",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "latency",
+                  "name": "Duration (ms)",
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "percentile_in_trace_group",
+                  "name": <React.Fragment>
+                    <div>
+                      Percentile in trace group
+                    </div>
+                  </React.Fragment>,
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_count",
+                  "name": "Errors",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "left",
+                  "field": "last_updated",
+                  "name": "Last updated",
+                  "render": [Function],
+                  "sortable": true,
+                },
+              ]
+            }
+            items={
+              Array [
+                Object {
+                  "actions": "#",
+                  "error_count": "Yes",
+                  "last_updated": "11/10/2020 09:55:45",
+                  "latency": 19.91,
+                  "percentile_in_trace_group": 30,
+                  "trace_group": "HTTP GET",
+                  "trace_id": "00079a615e31e61766fcb20b557051c1",
+                },
+              ]
+            }
+            loading={false}
+            noItemsMessage="No items found"
+            onChange={[Function]}
+            pagination={
+              Object {
+                "hidePerPageOptions": undefined,
+                "pageIndex": 0,
+                "pageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+                "totalItemCount": 1,
+              }
+            }
+            responsive={true}
+            sorting={
+              Object {
+                "allowNeutralSort": true,
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "Trace ID",
+                },
+              }
+            }
+            tableLayout="auto"
           >
-            <div>
-              <EuiTableHeaderMobile>
-                <div
-                  className="euiTableHeaderMobile"
-                >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+            <div
+              className="euiBasicTable"
+            >
+              <div>
+                <EuiTableHeaderMobile>
+                  <div
+                    className="euiTableHeaderMobile"
                   >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    <EuiFlexGroup
+                      alignItems="baseline"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        />
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_trace_id_0",
-                                  "name": "Trace ID",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_trace_group_1",
-                                  "name": "Trace group",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_latency_2",
-                                  "name": "Duration (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_percentile_in_trace_group_3",
-                                  "name": <React.Fragment>
-                                    <div>
-                                      Percentile in trace group
-                                    </div>
-                                  </React.Fragment>,
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_count_4",
-                                  "name": "Errors",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_last_updated_5",
-                                  "name": "Last updated",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiTableSortMobile"
+                            <EuiTableSortMobile
+                              items={
+                                Array [
+                                  Object {
+                                    "isSortAscending": true,
+                                    "isSorted": true,
+                                    "key": "_data_s_trace_id_0",
+                                    "name": "Trace ID",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_trace_group_1",
+                                    "name": "Trace group",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_latency_2",
+                                    "name": "Duration (ms)",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_percentile_in_trace_group_3",
+                                    "name": <React.Fragment>
+                                      <div>
+                                        Percentile in trace group
+                                      </div>
+                                    </React.Fragment>,
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_error_count_4",
+                                    "name": "Errors",
+                                    "onSort": [Function],
+                                  },
+                                  Object {
+                                    "isSortAscending": undefined,
+                                    "isSorted": false,
+                                    "key": "_data_s_last_updated_5",
+                                    "name": "Last updated",
+                                    "onSort": [Function],
+                                  },
+                                ]
+                              }
                             >
-                              <EuiPopover
-                                anchorPosition="downRight"
-                                button={
-                                  <EuiButtonEmpty
-                                    flush="right"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    onClick={[Function]}
-                                    size="xs"
-                                  >
-                                    <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
+                              <div
+                                className="euiTableSortMobile"
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownRight"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
+                                <EuiPopover
+                                  anchorPosition="downRight"
+                                  button={
                                     <EuiButtonEmpty
                                       flush="right"
                                       iconSide="right"
@@ -2132,934 +2137,931 @@ exports[`Traces table component renders traces table 1`] = `
                                       onClick={[Function]}
                                       size="xs"
                                     >
-                                      <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                        disabled={false}
+                                      <EuiI18n
+                                        default="Sorting"
+                                        token="euiTableSortMobile.sorting"
+                                      />
+                                    </EuiButtonEmpty>
+                                  }
+                                  closePopover={[Function]}
+                                  display="inlineBlock"
+                                  hasArrow={true}
+                                  isOpen={false}
+                                  ownFocus={true}
+                                  panelPaddingSize="none"
+                                >
+                                  <div
+                                    className="euiPopover euiPopover--anchorDownRight"
+                                  >
+                                    <div
+                                      className="euiPopover__anchor"
+                                    >
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
                                         onClick={[Function]}
-                                        type="button"
+                                        size="xs"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text",
-                                            }
-                                          }
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="right"
+                                            iconSize="s"
+                                            iconType="arrowDown"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <span
+                                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                             >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiIcon
+                                                className="euiButtonContent__icon"
+                                                color="inherit"
+                                                size="s"
+                                                type="arrowDown"
                                               >
-                                                <svg
+                                                <EuiIconBeaker
                                                   aria-hidden={true}
                                                   className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                                   focusable="false"
-                                                  height={16}
                                                   role="img"
                                                   style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
                                                 >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text"
-                                            >
-                                              <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconBeaker>
+                                              </EuiIcon>
+                                              <span
+                                                className="euiButtonEmpty__text"
                                               >
-                                                Sorting
-                                              </EuiI18n>
+                                                <EuiI18n
+                                                  default="Sorting"
+                                                  token="euiTableSortMobile.sorting"
+                                                >
+                                                  Sorting
+                                                </EuiI18n>
+                                              </span>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
+                                </EuiPopover>
+                              </div>
+                            </EuiTableSortMobile>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </div>
+                </EuiTableHeaderMobile>
+                <EuiTable
                   id="random_html_id"
-                  tabIndex={-1}
+                  responsive={true}
+                  tableLayout="auto"
                 >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_trace_id_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_trace_id_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
+                  <table
+                    className="euiTable euiTable--responsive euiTable--auto"
+                    id="random_html_id"
+                    tabIndex={-1}
+                  >
+                    <EuiScreenReaderOnly>
+                      <caption
+                        className="euiScreenReaderOnly euiTableCaption"
+                      >
+                        <EuiDelayRender
+                          delay={500}
+                        />
+                      </caption>
+                    </EuiScreenReaderOnly>
+                    <EuiTableHeader>
+                      <thead>
+                        <tr>
+                          <EuiTableHeaderCell
+                            align="left"
                             data-test-subj="tableHeaderCell_trace_id_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
+                            isSortAscending={true}
+                            isSorted={true}
+                            key="_data_h_trace_id_0"
+                            onSort={[Function]}
                           >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
+                            <th
+                              aria-live="polite"
+                              aria-sort="ascending"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_trace_id_0"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
                             >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
+                              <button
+                                className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                <span
+                                <CellContents
                                   className="euiTableCellContent"
+                                  isSortAscending={true}
+                                  isSorted={true}
+                                  showSortMsg={true}
                                 >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Trace ID",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Trace ID"
-                                      >
-                                        Trace ID
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
+                                  <span
+                                    className="euiTableCellContent"
                                   >
-                                    <EuiIconBeaker
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Trace ID",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Trace ID"
+                                        >
+                                          Trace ID
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                    <EuiIcon
+                                      className="euiTableSortIcon"
+                                      size="m"
+                                      type="sortUp"
                                     >
-                                      <svg
+                                      <EuiIconBeaker
                                         aria-hidden={true}
                                         className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
                                         focusable="false"
-                                        height={16}
                                         role="img"
                                         style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </EuiIconBeaker>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_trace_group_1"
-                          isSorted={false}
-                          key="_data_h_trace_group_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_trace_group_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Trace group",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Trace group"
-                                      >
-                                        Trace group
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_latency_2"
-                          isSorted={false}
-                          key="_data_h_latency_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_latency_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Duration (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Duration (ms)"
-                                      >
-                                        Duration (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                          isSorted={false}
-                          key="_data_h_percentile_in_trace_group_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Percentile in trace group",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Percentile in trace group"
-                                      >
-                                        <div>
-                                          Percentile in trace group
-                                        </div>
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_count_4"
-                          isSorted={false}
-                          key="_data_h_error_count_4"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_count_4"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Errors",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Errors"
-                                      >
-                                        Errors
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_last_updated_5"
-                          isSorted={false}
-                          key="_data_h_last_updated_5"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_last_updated_5"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Last updated",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Last updated"
-                                      >
-                                        Last updated
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
-                  >
-                    <tbody>
-                      <EuiTableRow
-                        isSelected={false}
-                      >
-                        <tr
-                          className="euiTableRow"
-                        >
-                          <EuiTableRowCell
+                                        <svg
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          height={16}
+                                          role="img"
+                                          style={null}
+                                          viewBox="0 0 16 16"
+                                          width={16}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </EuiIconBeaker>
+                                    </EuiIcon>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
                             align="left"
-                            key="_data_column_trace_id_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Trace ID",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
+                            data-test-subj="tableHeaderCell_trace_group_1"
+                            isSorted={false}
+                            key="_data_h_trace_group_1"
+                            onSort={[Function]}
                           >
-                            <td
-                              className="euiTableRowCell"
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_trace_group_1"
+                              role="columnheader"
+                              scope="col"
                               style={
                                 Object {
                                   "width": undefined,
                                 }
                               }
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
                               >
-                                Trace ID
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  alignItems="center"
-                                  className=""
-                                  gutterSize="s"
-                                  key=".0"
+                                <CellContents
+                                  className="euiTableCellContent"
+                                  isSorted={false}
+                                  showSortMsg={true}
                                 >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  <span
+                                    className="euiTableCellContent"
                                   >
-                                    <EuiFlexItem
-                                      grow={10}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow10"
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Trace group",
+                                          }
+                                        }
                                       >
-                                        <EuiLink
-                                          data-test-subj="trace-link"
-                                          onClick={[Function]}
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Trace group"
                                         >
-                                          <button
-                                            className="euiLink euiLink--primary"
+                                          Trace group
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_latency_2"
+                            isSorted={false}
+                            key="_data_h_latency_2"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_latency_2"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Duration (ms)",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Duration (ms)"
+                                        >
+                                          Duration (ms)
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                            isSorted={false}
+                            key="_data_h_percentile_in_trace_group_3"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Percentile in trace group",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Percentile in trace group"
+                                        >
+                                          <div>
+                                            Percentile in trace group
+                                          </div>
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="right"
+                            data-test-subj="tableHeaderCell_error_count_4"
+                            isSorted={false}
+                            key="_data_h_error_count_4"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_error_count_4"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Errors",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Errors"
+                                        >
+                                          Errors
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                          <EuiTableHeaderCell
+                            align="left"
+                            data-test-subj="tableHeaderCell_last_updated_5"
+                            isSorted={false}
+                            key="_data_h_last_updated_5"
+                            onSort={[Function]}
+                          >
+                            <th
+                              aria-live="polite"
+                              aria-sort="none"
+                              className="euiTableHeaderCell"
+                              data-test-subj="tableHeaderCell_last_updated_5"
+                              role="columnheader"
+                              scope="col"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <button
+                                className="euiTableHeaderButton"
+                                data-test-subj="tableHeaderSortButton"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <CellContents
+                                  className="euiTableCellContent"
+                                  isSorted={false}
+                                  showSortMsg={true}
+                                >
+                                  <span
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Last updated",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Last updated"
+                                        >
+                                          Last updated
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </button>
+                            </th>
+                          </EuiTableHeaderCell>
+                        </tr>
+                      </thead>
+                    </EuiTableHeader>
+                    <EuiTableBody
+                      bodyRef={[Function]}
+                    >
+                      <tbody>
+                        <EuiTableRow
+                          isSelected={false}
+                        >
+                          <tr
+                            className="euiTableRow"
+                          >
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_trace_id_0_0"
+                              mobileOptions={
+                                Object {
+                                  "header": "Trace ID",
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Trace ID
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiFlexGroup
+                                    alignItems="center"
+                                    className=""
+                                    gutterSize="s"
+                                    key=".0"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={10}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrow10"
+                                        >
+                                          <EuiLink
                                             data-test-subj="trace-link"
-                                            disabled={false}
                                             onClick={[Function]}
-                                            type="button"
                                           >
-                                            <div
-                                              title="00079a615e31e61766fcb20b557051c1"
+                                            <button
+                                              className="euiLink euiLink--primary"
+                                              data-test-subj="trace-link"
+                                              disabled={false}
+                                              onClick={[Function]}
+                                              type="button"
                                             >
-                                              00079a615e31e61766fcb...
-                                            </div>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={false}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
-                                      >
-                                        <EuiCopy
-                                          afterMessage="Copied"
-                                          textToCopy="00079a615e31e61766fcb20b557051c1"
-                                        >
-                                          <EuiToolTip
-                                            delay="regular"
-                                            onMouseOut={[Function]}
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            >
-                                              <EuiButtonIcon
-                                                aria-label="Copy trace id"
-                                                iconType="copyClipboard"
-                                                onBlur={[Function]}
-                                                onClick={[Function]}
-                                                onFocus={[Function]}
+                                              <div
+                                                title="00079a615e31e61766fcb20b557051c1"
                                               >
-                                                <button
+                                                00079a615e31e61766fcb...
+                                              </div>
+                                            </button>
+                                          </EuiLink>
+                                        </div>
+                                      </EuiFlexItem>
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiCopy
+                                            afterMessage="Copied"
+                                            textToCopy="00079a615e31e61766fcb20b557051c1"
+                                          >
+                                            <EuiToolTip
+                                              delay="regular"
+                                              onMouseOut={[Function]}
+                                              position="top"
+                                            >
+                                              <span
+                                                className="euiToolTipAnchor"
+                                                onKeyUp={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                              >
+                                                <EuiButtonIcon
                                                   aria-label="Copy trace id"
-                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
-                                                  disabled={false}
+                                                  iconType="copyClipboard"
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
                                                   onFocus={[Function]}
-                                                  type="button"
                                                 >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiButtonIcon__icon"
-                                                    color="inherit"
-                                                    size="m"
-                                                    type="copyClipboard"
+                                                  <button
+                                                    aria-label="Copy trace id"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                                                    disabled={false}
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onFocus={[Function]}
+                                                    type="button"
                                                   >
-                                                    <EuiIconBeaker
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="copyClipboard"
                                                     >
-                                                      <svg
+                                                      <EuiIconBeaker
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                         focusable="false"
-                                                        height={16}
                                                         role="img"
                                                         style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
                                                       >
-                                                        <path
-                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                        />
-                                                      </svg>
-                                                    </EuiIconBeaker>
-                                                  </EuiIcon>
-                                                </button>
-                                              </EuiButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                        </EuiCopy>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={3}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow3"
-                                      />
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_trace_group_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Trace group",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </span>
+                                            </EuiToolTip>
+                                          </EuiCopy>
+                                        </div>
+                                      </EuiFlexItem>
+                                      <EuiFlexItem
+                                        grow={3}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrow3"
+                                        />
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_trace_group_0_1"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Trace group",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={false}
+                              truncateText={true}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Trace group
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiText
-                                  className=""
-                                  key=".0"
-                                  size="s"
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                                 >
-                                  <div
-                                    className="euiText euiText--small"
+                                  Trace group
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                >
+                                  <EuiText
+                                    className=""
+                                    key=".0"
+                                    size="s"
                                   >
-                                    HTTP GET
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_latency_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Duration (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={true}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      HTTP GET
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_latency_0_2"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Duration (ms)",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={true}
+                              truncateText={true}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Duration (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                              >
-                                <span
-                                  className="euiTableCellContent__text"
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                                 >
-                                  19.91
-                                </span>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_percentile_in_trace_group_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": <React.Fragment>
+                                  Duration (ms)
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                                >
+                                  <span
+                                    className="euiTableCellContent__text"
+                                  >
+                                    19.91
+                                  </span>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_percentile_in_trace_group_0_3"
+                              mobileOptions={
+                                Object {
+                                  "header": <React.Fragment>
+                                    <div>
+                                      Percentile in trace group
+                                    </div>
+                                  </React.Fragment>,
+                                  "render": undefined,
+                                }
+                              }
+                              setScopeRow={false}
+                              textOnly={false}
+                            >
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
                                   <div>
                                     Percentile in trace group
                                   </div>
-                                </React.Fragment>,
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                <div>
-                                  Percentile in trace group
                                 </div>
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <EuiText
-                                  className=""
-                                  key=".0"
-                                  size="s"
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
                                 >
-                                  <div
-                                    className="euiText euiText--small"
+                                  <EuiText
+                                    className=""
+                                    key=".0"
+                                    size="s"
                                   >
-                                    30th
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_count_0_4"
-                            mobileOptions={
-                              Object {
-                                "header": "Errors",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      30th
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="right"
+                              key="_data_column_error_count_0_4"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Errors",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={false}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Errors
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                No
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_last_updated_0_5"
-                            mobileOptions={
-                              Object {
-                                "header": "Last updated",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Errors
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                >
+                                  No
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                            <EuiTableRowCell
+                              align="left"
+                              key="_data_column_last_updated_0_5"
+                              mobileOptions={
                                 Object {
-                                  "width": undefined,
+                                  "header": "Last updated",
+                                  "render": undefined,
                                 }
                               }
+                              setScopeRow={false}
+                              textOnly={false}
                             >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              <td
+                                className="euiTableRowCell"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
                               >
-                                Last updated
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                11/10/2020 09:55:45
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
+                                <div
+                                  className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                >
+                                  Last updated
+                                </div>
+                                <div
+                                  className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                >
+                                  11/10/2020 09:55:45
+                                </div>
+                              </td>
+                            </EuiTableRowCell>
+                          </tr>
+                        </EuiTableRow>
+                      </tbody>
+                    </EuiTableBody>
+                  </table>
+                </EuiTable>
+              </div>
+              <PaginationBar
+                aria-controls="random_html_id"
+                onPageChange={[Function]}
+                onPageSizeChange={[Function]}
+                pagination={
+                  Object {
+                    "hidePerPageOptions": undefined,
+                    "pageIndex": 0,
+                    "pageSize": 10,
+                    "pageSizeOptions": Array [
                       5,
                       10,
                       15,
-                    ]
+                    ],
+                    "totalItemCount": 1,
                   }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+                }
+              >
+                <div>
+                  <EuiSpacer
+                    size="m"
                   >
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiTablePagination
+                    activePage={0}
+                    aria-controls="random_html_id"
+                    itemsPerPage={10}
+                    itemsPerPageOptions={
+                      Array [
+                        5,
+                        10,
+                        15,
+                      ]
+                    }
+                    onChangeItemsPerPage={[Function]}
+                    onChangePage={[Function]}
+                    pageCount={1}
+                  >
+                    <EuiFlexGroup
+                      alignItems="center"
+                      justifyContent="spaceBetween"
+                      responsive={false}
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <EuiFlexItem
+                          grow={false}
                         >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
                           >
-                            <div
-                              className="euiPopover euiPopover--anchorUpRight"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
+                            <EuiPopover
+                              anchorPosition="upRight"
+                              button={
                                 <EuiButtonEmpty
                                   color="text"
                                   data-test-subj="tablePaginationPopoverButton"
@@ -3068,43 +3070,168 @@ exports[`Traces table component renders traces table 1`] = `
                                   onClick={[Function]}
                                   size="xs"
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                  <EuiI18n
+                                    default="Rows per page"
+                                    token="euiTablePagination.rowsPerPage"
+                                  />
+                                  : 
+                                  10
+                                </EuiButtonEmpty>
+                              }
+                              closePopover={[Function]}
+                              display="inlineBlock"
+                              hasArrow={true}
+                              isOpen={false}
+                              ownFocus={true}
+                              panelPaddingSize="none"
+                            >
+                              <div
+                                className="euiPopover euiPopover--anchorUpRight"
+                              >
+                                <div
+                                  className="euiPopover__anchor"
+                                >
+                                  <EuiButtonEmpty
+                                    color="text"
                                     data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
+                                    iconSide="right"
+                                    iconType="arrowDown"
                                     onClick={[Function]}
-                                    type="button"
+                                    size="xs"
                                   >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                      data-test-subj="tablePaginationPopoverButton"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="right"
+                                        iconSize="s"
+                                        iconType="arrowDown"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                        >
+                                          <EuiIcon
+                                            className="euiButtonContent__icon"
+                                            color="inherit"
+                                            size="s"
+                                            type="arrowDown"
+                                          >
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            <EuiI18n
+                                              default="Rows per page"
+                                              token="euiTablePagination.rowsPerPage"
+                                            >
+                                              Rows per page
+                                            </EuiI18n>
+                                            : 
+                                            10
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </div>
+                            </EuiPopover>
+                          </div>
+                        </EuiFlexItem>
+                        <EuiFlexItem
+                          grow={false}
+                        >
+                          <div
+                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <EuiPagination
+                              activePage={0}
+                              aria-controls="random_html_id"
+                              onPageClick={[Function]}
+                              pageCount={1}
+                            >
+                              <nav
+                                className="euiPagination"
+                              >
+                                <EuiI18n
+                                  default="Previous page, {page}"
+                                  token="euiPagination.previousPage"
+                                  values={
+                                    Object {
+                                      "page": 0,
+                                    }
+                                  }
+                                >
+                                  <EuiI18n
+                                    default="Previous page"
+                                    token="euiPagination.disabledPreviousPage"
+                                  >
+                                    <EuiButtonIcon
+                                      aria-label="Previous page"
+                                      color="text"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      iconType="arrowLeft"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        aria-label="Previous page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
                                         <EuiIcon
-                                          className="euiButtonContent__icon"
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
                                           color="inherit"
-                                          size="s"
-                                          type="arrowDown"
+                                          size="m"
+                                          type="arrowLeft"
                                         >
                                           <EuiIconBeaker
                                             aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                             focusable="false"
                                             role="img"
                                             style={null}
                                           >
                                             <svg
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
                                               height={16}
                                               role="img"
@@ -3119,270 +3246,175 @@ exports[`Traces table component renders traces table 1`] = `
                                             </svg>
                                           </EuiIconBeaker>
                                         </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
-                                        >
-                                          <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
+                                <ul
+                                  className="euiPagination__list"
                                 >
-                                  <li
-                                    className="euiPagination__item"
+                                  <PaginationButton
+                                    key="0"
+                                    pageIndex={0}
                                   >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
+                                    <li
+                                      className="euiPagination__item"
                                     >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
+                                      <EuiPaginationButton
+                                        aria-controls="random_html_id"
+                                        hideOnMobile={true}
+                                        isActive={true}
+                                        onClick={[Function]}
+                                        pageIndex={0}
+                                        totalPages={1}
                                       >
                                         <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
+                                          default="Page {page} of {totalPages}"
+                                          token="euiPaginationButton.longPageString"
                                           values={
                                             Object {
                                               "page": 1,
+                                              "totalPages": 1,
                                             }
                                           }
                                         >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
+                                          <EuiI18n
+                                            default="Page {page}"
+                                            token="euiPaginationButton.shortPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                              }
+                                            }
                                           >
-                                            <button
+                                            <EuiButtonEmpty
                                               aria-controls="random_html_id"
                                               aria-current={true}
                                               aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              color="text"
                                               data-test-subj="pagination-button-0"
-                                              disabled={true}
+                                              href="#random_html_id"
+                                              isDisabled={true}
                                               onClick={[Function]}
-                                              type="button"
+                                              size="s"
                                             >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
-                                                }
+                                              <button
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                data-test-subj="pagination-button-0"
+                                                disabled={true}
+                                                onClick={[Function]}
+                                                type="button"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="left"
+                                                  iconSize="m"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text",
+                                                    }
+                                                  }
                                                 >
                                                   <span
-                                                    className="euiButtonEmpty__text"
+                                                    className="euiButtonContent euiButtonEmpty__content"
                                                   >
-                                                    1
+                                                    <span
+                                                      className="euiButtonEmpty__text"
+                                                    >
+                                                      1
+                                                    </span>
                                                   </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </EuiI18n>
                                         </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
+                                      </EuiPaginationButton>
+                                    </li>
+                                  </PaginationButton>
+                                </ul>
                                 <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
+                                  default="Next page, {page}"
+                                  token="euiPagination.nextPage"
+                                  values={
+                                    Object {
+                                      "page": 2,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                  <EuiI18n
+                                    default="Next page"
+                                    token="euiPagination.disabledNextPage"
                                   >
-                                    <button
+                                    <EuiButtonIcon
                                       aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      color="text"
                                       data-test-subj="pagination-button-next"
                                       disabled={true}
+                                      iconType="arrowRight"
                                       onClick={[Function]}
-                                      type="button"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <button
+                                        aria-label="Next page"
+                                        className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        onClick={[Function]}
+                                        type="button"
                                       >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="arrowRight"
                                         >
-                                          <svg
+                                          <EuiIconBeaker
                                             aria-hidden={true}
                                             className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                             focusable="false"
-                                            height={16}
                                             role="img"
                                             style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiI18n>
                                 </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
-              </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
-    </div>
-  </EuiPanel>
+                              </nav>
+                            </EuiPagination>
+                          </div>
+                        </EuiFlexItem>
+                      </div>
+                    </EuiFlexGroup>
+                  </EuiTablePagination>
+                </div>
+              </PaginationBar>
+            </div>
+          </EuiBasicTable>
+        </EuiInMemoryTable>
+      </div>
+    </EuiPanel>
+  </div>
 </TracesTable>
 `;

--- a/public/components/trace_analytics/components/traces/traces.tsx
+++ b/public/components/trace_analytics/components/traces/traces.tsx
@@ -8,7 +8,6 @@ import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { TraceAnalyticsComponentDeps } from '../../home';
-import { DataSourcePicker } from '../dashboard/mode_picker';
 import { TracesContent } from './traces_content';
 
 export interface TracesProps extends TraceAnalyticsComponentDeps {
@@ -22,7 +21,6 @@ export interface TracesProps extends TraceAnalyticsComponentDeps {
 export function Traces(props: TracesProps) {
   return (
     <>
-      <DataSourcePicker modes={props.modes} selectedMode={props.mode} setMode={props.setMode!} />
       <TracesContent {...props} />
     </>
   );

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -4,7 +4,14 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiAccordion, EuiPanel, EuiSpacer, PropertySort } from '@elastic/eui';
+import {
+  EuiAccordion,
+  EuiPanel,
+  EuiSpacer,
+  PropertySort,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../framework/core_refs';
 import { handleTracesRequest } from '../../requests/traces_request_handler';
@@ -12,8 +19,10 @@ import { getValidFilterFields } from '../common/filters/filter_helpers';
 import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { SearchBar } from '../common/search_bar';
 import { DashboardContent } from '../dashboard/dashboard_content';
-import { TracesProps } from './traces';
 import { TracesTable } from './traces_table';
+import { TracesProps } from './traces';
+import { DataSourcePicker } from '../dashboard/mode_picker';
+import { Filters } from '../common/filters/filters';
 
 export function TracesContent(props: TracesProps) {
   const {
@@ -109,34 +118,60 @@ export function TracesContent(props: TracesProps) {
 
   return (
     <>
-      <SearchBar
-        query={query}
-        filters={filters}
-        appConfigs={appConfigs}
-        setFilters={setFilters}
-        setQuery={setQuery}
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
-        refresh={refresh}
+      <EuiFlexGroup
+        gutterSize="s"
+        alignItems="center"
+        justifyContent="spaceBetween"
+        style={{ padding: '0 16px' }}
+      >
+        <EuiFlexItem grow={false}>
+          <DataSourcePicker
+            modes={props.modes}
+            selectedMode={props.mode}
+            setMode={props.setMode!}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <SearchBar
+            query={query}
+            filters={filters}
+            appConfigs={appConfigs}
+            setFilters={setFilters}
+            setQuery={setQuery}
+            startTime={startTime}
+            setStartTime={setStartTime}
+            endTime={endTime}
+            setEndTime={setEndTime}
+            refresh={refresh}
+            page={page}
+            mode={mode}
+            attributesFilterFields={attributesFilterFields}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Filters
         page={page}
+        filters={filters}
+        setFilters={setFilters}
+        appConfigs={appConfigs}
         mode={mode}
         attributesFilterFields={attributesFilterFields}
       />
       <EuiSpacer size="m" />
-      <EuiPanel>
-        <EuiAccordion
-          id="accordion1"
-          buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
-          forceState={trigger}
-          onToggle={onToggle}
-          data-test-subj="trace-groups-service-operation-accordian"
-        >
-          <EuiSpacer size="m" />
-          {trigger === 'open' && dashboardContent()}
-        </EuiAccordion>
-      </EuiPanel>
+      <div style={{ padding: '0 16px' }}>
+        <EuiPanel>
+          <EuiAccordion
+            id="accordion1"
+            buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
+            forceState={trigger}
+            onToggle={onToggle}
+            data-test-subj="trace-groups-service-operation-accordian"
+          >
+            <EuiSpacer size="m" />
+            {trigger === 'open' && dashboardContent()}
+          </EuiAccordion>
+        </EuiPanel>
+      </div>
       <EuiSpacer size="m" />
       <TracesTable
         items={tableItems}

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -11,6 +11,7 @@ import {
   PropertySort,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPage,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../framework/core_refs';
@@ -158,7 +159,7 @@ export function TracesContent(props: TracesProps) {
         attributesFilterFields={attributesFilterFields}
       />
       <EuiSpacer size="m" />
-      <div style={{ padding: '0 16px' }}>
+      <EuiPage paddingSize="m">
         <EuiPanel>
           <EuiAccordion
             id="accordion1"
@@ -171,8 +172,7 @@ export function TracesContent(props: TracesProps) {
             {trigger === 'open' && dashboardContent()}
           </EuiAccordion>
         </EuiPanel>
-      </div>
-      <EuiSpacer size="m" />
+      </EuiPage>
       <TracesTable
         items={tableItems}
         refresh={refresh}

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -51,11 +51,9 @@ export function TracesTable(props: TracesTableProps) {
     );
   };
 
-  const columns = useMemo(
-    () => {
-      if (mode === 'data_prepper') {
-        return(
-      [
+  const columns = useMemo(() => {
+    if (mode === 'data_prepper') {
+      return [
         {
           field: 'trace_id',
           name: 'Trace ID',
@@ -65,7 +63,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) => (
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
-                <EuiLink data-test-subj='trace-link' onClick={() => traceIdColumnAction(item)}>
+                <EuiLink data-test-subj="trace-link" onClick={() => traceIdColumnAction(item)}>
                   {item.length < 24 ? (
                     item
                   ) : (
@@ -99,11 +97,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) =>
             item ? (
               <EuiText size="s">
-                {item.length < 36 ? (
-                  item
-                ) : (
-                  <div title={item}>{truncate(item, { length: 36 })}</div>
-                )}
+                {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
               </EuiText>
             ) : (
               '-'
@@ -152,79 +146,76 @@ export function TracesTable(props: TracesTableProps) {
           sortable: true,
           render: (item) => (item === 0 || item ? item : '-'),
         },
-      ] as Array<EuiTableFieldDataColumnType<any>>)
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     } else {
-      return (
-        [
-          {
-            field: 'trace_id',
-            name: 'Trace ID',
-            align: 'left',
-            sortable: true,
-            truncateText: true,
-            render: (item) => (
-              <EuiFlexGroup gutterSize="s" alignItems="center">
-                <EuiFlexItem grow={10}>
-                  <EuiLink onClick={() => traceIdColumnAction(item)}>
-                    {item.length < 24 ? (
-                      item
-                    ) : (
-                      <div title={item}>{truncate(item, { length: 24 })}</div>
-                    )}
-                  </EuiLink>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiCopy textToCopy={item}>
-                    {(copy) => (
-                      <EuiButtonIcon
-                        aria-label="Copy trace id"
-                        iconType="copyClipboard"
-                        onClick={copy}
-                      >
-                        Click to copy
-                      </EuiButtonIcon>
-                    )}
-                  </EuiCopy>
-                </EuiFlexItem>
-                <EuiFlexItem grow={3} />
-              </EuiFlexGroup>
+      return [
+        {
+          field: 'trace_id',
+          name: 'Trace ID',
+          align: 'left',
+          sortable: true,
+          truncateText: true,
+          render: (item) => (
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={10}>
+                <EuiLink onClick={() => traceIdColumnAction(item)}>
+                  {item.length < 24 ? (
+                    item
+                  ) : (
+                    <div title={item}>{truncate(item, { length: 24 })}</div>
+                  )}
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCopy textToCopy={item}>
+                  {(copy) => (
+                    <EuiButtonIcon
+                      aria-label="Copy trace id"
+                      iconType="copyClipboard"
+                      onClick={copy}
+                    >
+                      Click to copy
+                    </EuiButtonIcon>
+                  )}
+                </EuiCopy>
+              </EuiFlexItem>
+              <EuiFlexItem grow={3} />
+            </EuiFlexGroup>
+          ),
+        },
+        {
+          field: 'latency',
+          name: 'Latency (ms)',
+          align: 'right',
+          sortable: true,
+          truncateText: true,
+        },
+        {
+          field: 'error_count',
+          name: 'Errors',
+          align: 'right',
+          sortable: true,
+          render: (item) =>
+            item == null ? (
+              '-'
+            ) : item > 0 ? (
+              <EuiText color="danger" size="s">
+                Yes
+              </EuiText>
+            ) : (
+              'No'
             ),
-          },
-          {
-            field: 'latency',
-            name: 'Latency (ms)',
-            align: 'right',
-            sortable: true,
-            truncateText: true,
-          },
-          {
-            field: 'error_count',
-            name: 'Errors',
-            align: 'right',
-            sortable: true,
-            render: (item) =>
-              item == null ? (
-                '-'
-              ) : item > 0 ? (
-                <EuiText color="danger" size="s">
-                  Yes
-                </EuiText>
-              ) : (
-                'No'
-              ),
-          },
-          {
-            field: 'last_updated',
-            name: 'Last updated',
-            align: 'left',
-            sortable: true,
-            render: (item) => (item === 0 || item ? item : '-'),
-          },
-        ] as Array<EuiTableFieldDataColumnType<any>>)
+        },
+        {
+          field: 'last_updated',
+          name: 'Last updated',
+          align: 'left',
+          sortable: true,
+          render: (item) => (item === 0 || item ? item : '-'),
+        },
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     }
-    },
-    [items]
-  );
+  }, [items]);
 
   const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
 
@@ -235,7 +226,7 @@ export function TracesTable(props: TracesTableProps) {
     },
   });
 
-  const onTableChange = async ({ currPage, sort }: { currPage: any; sort: any }) => {
+  const onTableChange = async ({ _currPage, sort }: { currPage: any; sort: any }) => {
     if (typeof sort?.field !== 'string') return;
 
     // maps table column key to DSL aggregation name
@@ -266,29 +257,34 @@ export function TracesTable(props: TracesTableProps) {
 
   return (
     <>
-      <EuiPanel>
-        {titleBar}
-        <EuiSpacer size="m" />
-        <EuiHorizontalRule margin="none" />
-        {!((mode === 'data_prepper' && props.dataPrepperIndicesExist) || (mode === 'jaeger' && props.jaegerIndicesExist)) ? (
-          <MissingConfigurationMessage mode={mode}/>
-        ) : items?.length > 0 ? (
-          <EuiInMemoryTable
-            tableLayout="auto"
-            items={items}
-            columns={columns}
-            pagination={{
-              initialPageSize: 10,
-              pageSizeOptions: [5, 10, 15],
-            }}
-            sorting={sorting}
-            onTableChange={onTableChange}
-            loading={loading}
-          />
-        ) : (
-          <NoMatchMessage size="xl" />
-        )}
-      </EuiPanel>
+      <div style={{ padding: '0 16px' }}>
+        <EuiPanel>
+          {titleBar}
+          <EuiSpacer size="m" />
+          <EuiHorizontalRule margin="none" />
+          {!(
+            (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
+            (mode === 'jaeger' && props.jaegerIndicesExist)
+          ) ? (
+            <MissingConfigurationMessage mode={mode} />
+          ) : items?.length > 0 ? (
+            <EuiInMemoryTable
+              tableLayout="auto"
+              items={items}
+              columns={columns}
+              pagination={{
+                initialPageSize: 10,
+                pageSizeOptions: [5, 10, 15],
+              }}
+              sorting={sorting}
+              onTableChange={onTableChange}
+              loading={loading}
+            />
+          ) : (
+            <NoMatchMessage size="xl" />
+          )}
+        </EuiPanel>
+      </div>
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -17,6 +17,7 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
   PropertySort,
+  EuiPage,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import truncate from 'lodash/truncate';
@@ -257,7 +258,7 @@ export function TracesTable(props: TracesTableProps) {
 
   return (
     <>
-      <div style={{ padding: '0 16px' }}>
+      <EuiPage paddingSize="m">
         <EuiPanel>
           {titleBar}
           <EuiSpacer size="m" />
@@ -284,7 +285,7 @@ export function TracesTable(props: TracesTableProps) {
             <NoMatchMessage size="xl" />
           )}
         </EuiPanel>
-      </div>
+      </EuiPage>
     </>
   );
 }


### PR DESCRIPTION
### Description
1. Updates Traces UI to conform with the header changes.
2. Updates Services UI to conform with the header changes.
3. Fixes a bug with the global filter icon where it would get stuck open if double clicked.

Traces before: 
<img width="1279" alt="Screenshot 2024-08-16 at 4 22 55 PM" src="https://github.com/user-attachments/assets/c696b8cb-15ab-4851-ac6d-2298912f9f72">
After:
<img width="1137" alt="Screenshot 2024-08-16 at 4 15 26 PM" src="https://github.com/user-attachments/assets/c81bf810-0b07-4aba-841a-9c0ae9c1895f">

Services before: 
<img width="1273" alt="Screenshot 2024-08-16 at 4 23 41 PM" src="https://github.com/user-attachments/assets/5e432fa0-564c-433f-835f-88ccb15cf551">
After:
<img width="1140" alt="Screenshot 2024-08-16 at 4 15 42 PM" src="https://github.com/user-attachments/assets/50fa44d1-f94e-46f7-843d-1d807a6a2194">

Fix to filter button - now closes when re-clicked or an option is selected.
<img width="229" alt="Screenshot 2024-08-16 at 4 16 30 PM" src="https://github.com/user-attachments/assets/e45147f9-5202-45e0-b910-6614553848e0">

These changes to UI required the filter to be broken apart.
Video showing it still works while separated:

https://github.com/user-attachments/assets/4cd95047-0c99-479e-9595-ffa16ea40747



### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
