### PR TITLE
[Look&Feel] Traces Density and Consistency Improvements

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -728,7 +728,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -1051,7 +1051,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -1985,7 +1985,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -2308,7 +2308,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -3181,7 +3181,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -3538,7 +3538,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -4352,7 +4352,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -4709,7 +4709,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -5616,7 +5616,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -5939,7 +5939,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -6787,7 +6787,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -7110,7 +7110,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -7978,7 +7978,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -8299,7 +8299,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -9110,7 +9110,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -9431,7 +9431,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -10304,7 +10304,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -10627,7 +10627,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -11441,7 +11441,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -11764,7 +11764,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -12669,7 +12669,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -12992,7 +12992,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -13840,7 +13840,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -14163,7 +14163,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -15036,7 +15036,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -15393,7 +15393,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -16207,7 +16207,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -16564,7 +16564,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>
@@ -17441,7 +17441,7 @@ Object {
                                   class="euiText euiText--medium"
                                 >
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiText euiText--small"
                                   >
                                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                   </div>
@@ -17764,7 +17764,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -18698,7 +18698,7 @@ Object {
                                 class="euiText euiText--medium"
                               >
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -19021,7 +19021,7 @@ Object {
                               class="euiText euiText--medium"
                             >
                               <div
-                                class="euiText euiText--medium"
+                                class="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -1124,7 +1124,9 @@ exports[`Service Config component renders empty service config 1`] = `
                           </EuiSpacer>
                           <EuiEmptyPrompt
                             body={
-                              <EuiText>
+                              <EuiText
+                                size="s"
+                              >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </EuiText>
                             }
@@ -1163,9 +1165,11 @@ exports[`Service Config component renders empty service config 1`] = `
                                     <div
                                       className="euiText euiText--medium"
                                     >
-                                      <EuiText>
+                                      <EuiText
+                                        size="s"
+                                      >
                                         <div
-                                          className="euiText euiText--medium"
+                                          className="euiText euiText--small"
                                         >
                                           No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                         </div>
@@ -2345,7 +2349,9 @@ exports[`Service Config component renders with one service selected 1`] = `
                           </EuiSpacer>
                           <EuiEmptyPrompt
                             body={
-                              <EuiText>
+                              <EuiText
+                                size="s"
+                              >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </EuiText>
                             }
@@ -2384,9 +2390,11 @@ exports[`Service Config component renders with one service selected 1`] = `
                                     <div
                                       className="euiText euiText--medium"
                                     >
-                                      <EuiText>
+                                      <EuiText
+                                        size="s"
+                                      >
                                         <div
-                                          className="euiText euiText--medium"
+                                          className="euiText euiText--small"
                                         >
                                           No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                         </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
@@ -845,7 +845,9 @@ exports[`Trace Config component renders empty trace config 1`] = `
                         </EuiSpacer>
                         <EuiEmptyPrompt
                           body={
-                            <EuiText>
+                            <EuiText
+                              size="s"
+                            >
                               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                             </EuiText>
                           }
@@ -884,9 +886,11 @@ exports[`Trace Config component renders empty trace config 1`] = `
                                   <div
                                     className="euiText euiText--medium"
                                   >
-                                    <EuiText>
+                                    <EuiText
+                                      size="s"
+                                    >
                                       <div
-                                        className="euiText euiText--medium"
+                                        className="euiText euiText--small"
                                       >
                                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                       </div>
@@ -1779,7 +1783,9 @@ exports[`Trace Config component renders with one trace selected 1`] = `
                         </EuiSpacer>
                         <EuiEmptyPrompt
                           body={
-                            <EuiText>
+                            <EuiText
+                              size="s"
+                            >
                               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                             </EuiText>
                           }
@@ -1818,9 +1824,11 @@ exports[`Trace Config component renders with one trace selected 1`] = `
                                   <div
                                     className="euiText euiText--medium"
                                   >
-                                    <EuiText>
+                                    <EuiText
+                                      size="s"
+                                    >
                                       <div
-                                        className="euiText euiText--medium"
+                                        className="euiText euiText--small"
                                       >
                                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                       </div>

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1
           hasArrow={true}
           isOpen={false}
           ownFocus={true}
-          panelPaddingSize="m"
+          panelPaddingSize="s"
         >
           <div
             className="euiPopover euiPopover--anchorDownCenter"

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
@@ -934,7 +934,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                             hasArrow={true}
                             isOpen={false}
                             ownFocus={true}
-                            panelPaddingSize="m"
+                            panelPaddingSize="s"
                           >
                             <div
                               className="euiPopover euiPopover--anchorDownCenter"

--- a/public/components/metrics/top_menu/metrics_export.tsx
+++ b/public/components/metrics/top_menu/metrics_export.tsx
@@ -391,6 +391,7 @@ const MetricsExportPopOver = () => {
         button={<Savebutton setIsPanelOpen={setIsPanelOpen} />}
         isOpen={isPanelOpen}
         closePopover={() => setIsPanelOpen(false)}
+        panelPaddingSize="s"
       >
         <MetricsExportPanel
           availableDashboards={availableDashboards ?? []}

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
@@ -73,7 +73,9 @@ exports[`Helper functions renders no match and missing configuration messages 1`
   />
   <EuiEmptyPrompt
     body={
-      <EuiText>
+      <EuiText
+        size="s"
+      >
         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
       </EuiText>
     }
@@ -93,17 +95,19 @@ exports[`Helper functions renders no match and missing configuration messages 2`
 <Fragment>
   <EuiEmptyPrompt
     actions={
-      <EuiSmallButton
+      <EuiSmallButtonEmpty
         color="primary"
         iconSide="right"
         iconType="popout"
         onClick={[Function]}
       >
         Learn more
-      </EuiSmallButton>
+      </EuiSmallButtonEmpty>
     }
     body={
-      <EuiText>
+      <EuiText
+        size="s"
+      >
         The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
       </EuiText>
     }

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -210,7 +210,7 @@ export function Filters(props: FiltersOwnProps) {
         withTitle
         data-test-subj="global-filter-button"
       >
-        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} />
+        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} size="s" />
       </EuiPopover>
     );
   };

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -5,7 +5,7 @@
 /* eslint-disable radix */
 
 import dateMath from '@elastic/datemath';
-import { EuiSmallButton, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButtonEmpty, EuiEmptyPrompt, EuiSpacer, EuiText } from '@elastic/eui';
 import { SpacerSize } from '@elastic/eui/src/components/spacer/spacer';
 import { isEmpty, round } from 'lodash';
 import React from 'react';
@@ -45,7 +45,7 @@ export function NoMatchMessage(props: { size: SpacerSize }) {
       <EuiEmptyPrompt
         title={<h2>No matches</h2>}
         body={
-          <EuiText>
+          <EuiText size="s">
             No data matches the selected filter. Clear the filter and/or increase the time range to
             see more results.
           </EuiText>
@@ -65,16 +65,16 @@ export function MissingConfigurationMessage(props: { mode: TraceAnalyticsMode })
     <>
       <EuiEmptyPrompt
         title={<h2>Trace Analytics not set up</h2>}
-        body={<EuiText>{missingConfigurationBody}</EuiText>}
+        body={<EuiText size="s">{missingConfigurationBody}</EuiText>}
         actions={
-          <EuiSmallButton
+          <EuiSmallButtonEmpty
             color="primary"
             iconSide="right"
             iconType="popout"
             onClick={() => window.open(TRACE_ANALYTICS_DOCUMENTATION_LINK, '_blank')}
           >
             Learn more
-          </EuiSmallButton>
+          </EuiSmallButtonEmpty>
         }
       />
     </>

--- a/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map_node_details.tsx
@@ -46,9 +46,9 @@ export const ServiceMapNodeDetails = ({
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="l" />
-      <EuiText>{selectedNodeDetails?.average_latency}</EuiText>
-      <EuiText>{selectedNodeDetails?.error_rate}</EuiText>
-      <EuiText>{selectedNodeDetails?.throughput}</EuiText>
+      <EuiText size="s">{selectedNodeDetails?.average_latency}</EuiText>
+      <EuiText size="s">{selectedNodeDetails?.error_rate}</EuiText>
+      <EuiText size="s">{selectedNodeDetails?.throughput}</EuiText>
       <EuiSpacer size="l" />
       <EuiFlexGroup direction="column" gutterSize="s">
         <EuiFlexItem>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -791,7 +791,9 @@ exports[`Dashboard component renders dashboard 1`] = `
               </EuiSpacer>
               <EuiEmptyPrompt
                 body={
-                  <EuiText>
+                  <EuiText
+                    size="s"
+                  >
                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                   </EuiText>
                 }
@@ -830,9 +832,11 @@ exports[`Dashboard component renders dashboard 1`] = `
                         <div
                           className="euiText euiText--medium"
                         >
-                          <EuiText>
+                          <EuiText
+                            size="s"
+                          >
                             <div
-                              className="euiText euiText--medium"
+                              className="euiText euiText--small"
                             >
                               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                             </div>
@@ -982,7 +986,9 @@ exports[`Dashboard component renders dashboard 1`] = `
                                 </EuiSpacer>
                                 <EuiEmptyPrompt
                                   body={
-                                    <EuiText>
+                                    <EuiText
+                                      size="s"
+                                    >
                                       No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                     </EuiText>
                                   }
@@ -1021,9 +1027,11 @@ exports[`Dashboard component renders dashboard 1`] = `
                                           <div
                                             className="euiText euiText--medium"
                                           >
-                                            <EuiText>
+                                            <EuiText
+                                              size="s"
+                                            >
                                               <div
-                                                className="euiText euiText--medium"
+                                                className="euiText euiText--small"
                                               >
                                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                               </div>
@@ -1156,7 +1164,9 @@ exports[`Dashboard component renders dashboard 1`] = `
                                 </EuiSpacer>
                                 <EuiEmptyPrompt
                                   body={
-                                    <EuiText>
+                                    <EuiText
+                                      size="s"
+                                    >
                                       No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                     </EuiText>
                                   }
@@ -1195,9 +1205,11 @@ exports[`Dashboard component renders dashboard 1`] = `
                                           <div
                                             className="euiText euiText--medium"
                                           >
-                                            <EuiText>
+                                            <EuiText
+                                              size="s"
+                                            >
                                               <div
-                                                className="euiText euiText--medium"
+                                                className="euiText euiText--small"
                                               >
                                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                               </div>
@@ -2023,7 +2035,9 @@ exports[`Dashboard component renders empty dashboard 1`] = `
               </EuiSpacer>
               <EuiEmptyPrompt
                 body={
-                  <EuiText>
+                  <EuiText
+                    size="s"
+                  >
                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                   </EuiText>
                 }
@@ -2062,9 +2076,11 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                         <div
                           className="euiText euiText--medium"
                         >
-                          <EuiText>
+                          <EuiText
+                            size="s"
+                          >
                             <div
-                              className="euiText euiText--medium"
+                              className="euiText euiText--small"
                             >
                               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                             </div>
@@ -2214,7 +2230,9 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                                 </EuiSpacer>
                                 <EuiEmptyPrompt
                                   body={
-                                    <EuiText>
+                                    <EuiText
+                                      size="s"
+                                    >
                                       No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                     </EuiText>
                                   }
@@ -2253,9 +2271,11 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                                           <div
                                             className="euiText euiText--medium"
                                           >
-                                            <EuiText>
+                                            <EuiText
+                                              size="s"
+                                            >
                                               <div
-                                                className="euiText euiText--medium"
+                                                className="euiText euiText--small"
                                               >
                                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                               </div>
@@ -2388,7 +2408,9 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                                 </EuiSpacer>
                                 <EuiEmptyPrompt
                                   body={
-                                    <EuiText>
+                                    <EuiText
+                                      size="s"
+                                    >
                                       No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                     </EuiText>
                                   }
@@ -2427,9 +2449,11 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                                           <div
                                             className="euiText euiText--medium"
                                           >
-                                            <EuiText>
+                                            <EuiText
+                                              size="s"
+                                            >
                                               <div
-                                                className="euiText euiText--medium"
+                                                className="euiText euiText--small"
                                               >
                                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                               </div>
@@ -3420,7 +3444,9 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                   </EuiSpacer>
                   <EuiEmptyPrompt
                     body={
-                      <EuiText>
+                      <EuiText
+                        size="s"
+                      >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </EuiText>
                     }
@@ -3459,9 +3485,11 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                             <div
                               className="euiText euiText--medium"
                             >
-                              <EuiText>
+                              <EuiText
+                                size="s"
+                              >
                                 <div
-                                  className="euiText euiText--medium"
+                                  className="euiText euiText--small"
                                 >
                                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                 </div>
@@ -3581,7 +3609,9 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                 </EuiSpacer>
                 <EuiEmptyPrompt
                   body={
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                     </EuiText>
                   }
@@ -3620,9 +3650,11 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                           <div
                             className="euiText euiText--medium"
                           >
-                            <EuiText>
+                            <EuiText
+                              size="s"
+                            >
                               <div
-                                className="euiText euiText--medium"
+                                className="euiText euiText--small"
                               >
                                 No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                               </div>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
@@ -3444,7 +3444,9 @@ exports[`Dashboard table component renders empty dashboard table message 1`] = `
         </EuiSpacer>
         <EuiEmptyPrompt
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
             </EuiText>
           }
@@ -3483,9 +3485,11 @@ exports[`Dashboard table component renders empty dashboard table message 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
@@ -92,7 +92,9 @@ exports[`Error Rates Table component renders empty top error rates table 1`] = `
         </EuiSpacer>
         <EuiEmptyPrompt
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
             </EuiText>
           }
@@ -131,9 +133,11 @@ exports[`Error Rates Table component renders empty top error rates table 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
@@ -184,7 +184,9 @@ exports[`Latency Table component renders empty top error rates table 1`] = `
         </EuiSpacer>
         <EuiEmptyPrompt
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
             </EuiText>
           }
@@ -223,9 +225,11 @@ exports[`Latency Table component renders empty top error rates table 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>

--- a/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
+++ b/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
@@ -5,10 +5,10 @@
 
 import {
   EuiButtonIcon,
-  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
+  EuiSmallButtonIcon,
   EuiText,
 } from '@elastic/eui';
 import React, { useState } from 'react';

--- a/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
+++ b/public/components/trace_analytics/components/dashboard/latency_trend_cell.tsx
@@ -5,10 +5,10 @@
 
 import {
   EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPopover,
-  EuiSmallButtonIcon,
   EuiText,
 } from '@elastic/eui';
 import React, { useState } from 'react';

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
@@ -9,15 +9,15 @@ exports[`Service view component renders service view 1`] = `
         gutterSize="s"
       >
         <EuiFlexItem>
-          <EuiTitle
-            size="l"
+          <EuiText
+            size="s"
           >
-            <h2
+            <h1
               className="overview-content"
             >
               order
-            </h2>
-          </EuiTitle>
+            </h1>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem
           grow={false}

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -1635,7 +1635,9 @@ exports[`Services component renders empty services page 1`] = `
             </EuiSpacer>
             <EuiEmptyPrompt
               body={
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
               }
@@ -1674,9 +1676,11 @@ exports[`Services component renders empty services page 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        <EuiText>
+                        <EuiText
+                          size="s"
+                        >
                           <div
-                            className="euiText euiText--medium"
+                            className="euiText euiText--small"
                           >
                             No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </div>
@@ -2168,7 +2172,9 @@ exports[`Services component renders empty services page 1`] = `
               </EuiSpacer>
               <EuiEmptyPrompt
                 body={
-                  <EuiText>
+                  <EuiText
+                    size="s"
+                  >
                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                   </EuiText>
                 }
@@ -2207,9 +2213,11 @@ exports[`Services component renders empty services page 1`] = `
                         <div
                           className="euiText euiText--medium"
                         >
-                          <EuiText>
+                          <EuiText
+                            size="s"
+                          >
                             <div
-                              className="euiText euiText--medium"
+                              className="euiText euiText--small"
                             >
                               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                             </div>
@@ -3845,7 +3853,9 @@ exports[`Services component renders jaeger services page 1`] = `
             </EuiSpacer>
             <EuiEmptyPrompt
               body={
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
               }
@@ -3884,9 +3894,11 @@ exports[`Services component renders jaeger services page 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        <EuiText>
+                        <EuiText
+                          size="s"
+                        >
                           <div
-                            className="euiText euiText--medium"
+                            className="euiText euiText--small"
                           >
                             No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </div>
@@ -5557,7 +5569,9 @@ exports[`Services component renders services page 1`] = `
             </EuiSpacer>
             <EuiEmptyPrompt
               body={
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
               }
@@ -5596,9 +5610,11 @@ exports[`Services component renders services page 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        <EuiText>
+                        <EuiText
+                          size="s"
+                        >
                           <div
-                            className="euiText euiText--medium"
+                            className="euiText euiText--small"
                           >
                             No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </div>
@@ -6090,7 +6106,9 @@ exports[`Services component renders services page 1`] = `
               </EuiSpacer>
               <EuiEmptyPrompt
                 body={
-                  <EuiText>
+                  <EuiText
+                    size="s"
+                  >
                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                   </EuiText>
                 }
@@ -6129,9 +6147,11 @@ exports[`Services component renders services page 1`] = `
                         <div
                           className="euiText euiText--medium"
                         >
-                          <EuiText>
+                          <EuiText
+                            size="s"
+                          >
                             <div
-                              className="euiText euiText--medium"
+                              className="euiText euiText--small"
                             >
                               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                             </div>

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -149,7 +149,9 @@ exports[`Services table component renders empty jaeger services table message 1`
         </EuiSpacer>
         <EuiEmptyPrompt
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
             </EuiText>
           }
@@ -188,9 +190,11 @@ exports[`Services table component renders empty jaeger services table message 1`
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>
@@ -401,7 +405,9 @@ exports[`Services table component renders empty services table message 1`] = `
         </EuiSpacer>
         <EuiEmptyPrompt
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
             </EuiText>
           }
@@ -440,9 +446,11 @@ exports[`Services table component renders empty services table message 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>

--- a/public/components/trace_analytics/components/services/service_trends_plots.tsx
+++ b/public/components/trace_analytics/components/services/service_trends_plots.tsx
@@ -58,6 +58,7 @@ export const ServiceTrendsPlots = ({
             anchorPosition="downCenter"
             isOpen={isPopoverOpen}
             closePopover={() => setIsPopoverOpen(false)}
+            panelPaddingSize="s"
           >
             <EuiFlexGroup justifyContent="spaceBetween">
               <EuiFlexItem grow={false}>

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -23,7 +23,6 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -220,9 +219,9 @@ export function ServiceView(props: ServiceViewProps) {
           <EuiFlyoutHeader hasBorder>
             <EuiFlexGroup justifyContent="spaceBetween">
               <EuiFlexItem>
-                <EuiTitle size="l">
+                <EuiText size="s">
                   <h2 className="overview-content">{serviceName}</h2>
-                </EuiTitle>
+                </EuiText>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiPopover
@@ -231,7 +230,7 @@ export function ServiceView(props: ServiceViewProps) {
                   isOpen={actionsMenuPopover}
                   closePopover={() => setActionsMenuPopover(false)}
                 >
-                  <EuiContextMenu initialPanelId={0} panels={actionsMenu} />
+                  <EuiContextMenu initialPanelId={0} panels={actionsMenu} size="s" />
                 </EuiPopover>
               </EuiFlexItem>
             </EuiFlexGroup>
@@ -240,9 +239,9 @@ export function ServiceView(props: ServiceViewProps) {
         ) : (
           <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem>
-              <EuiTitle size="l">
-                <h2 className="overview-content">{serviceName}</h2>
-              </EuiTitle>
+              <EuiText size="s">
+                <h1 className="overview-content">{serviceName}</h1>
+              </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               {renderDatePicker(startTime, setStartTime, endTime, setEndTime)}

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
@@ -78,11 +78,13 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                     <div
                       class="euiFlexItem"
                     >
-                      <h2
-                        class="euiTitle euiTitle--medium"
+                      <div
+                        class="euiText euiText--small"
                       >
-                        Span detail
-                      </h2>
+                        <h2>
+                          Span detail
+                        </h2>
+                      </div>
                     </div>
                     <div
                       class="euiFlexItem"
@@ -255,11 +257,13 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                             <div
                               class="euiFlexItem"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiText euiText--small"
                               >
-                                Span detail
-                              </h2>
+                                <h2>
+                                  Span detail
+                                </h2>
+                              </div>
                             </div>
                             <div
                               class="euiFlexItem"
@@ -364,11 +368,13 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                               <div
                                 class="euiFlexItem"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiText euiText--small"
                                 >
-                                  Span detail
-                                </h2>
+                                  <h2>
+                                    Span detail
+                                  </h2>
+                                </div>
                               </div>
                               <div
                                 class="euiFlexItem"
@@ -473,11 +479,13 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                                 <div
                                   class="euiFlexItem"
                                 >
-                                  <h2
-                                    class="euiTitle euiTitle--medium"
+                                  <div
+                                    class="euiText euiText--small"
                                   >
-                                    Span detail
-                                  </h2>
+                                    <h2>
+                                      Span detail
+                                    </h2>
+                                  </div>
                                 </div>
                                 <div
                                   class="euiFlexItem"
@@ -570,11 +578,13 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                                   <div
                                     class="euiFlexItem"
                                   >
-                                    <h2
-                                      class="euiTitle euiTitle--medium"
+                                    <div
+                                      class="euiText euiText--small"
                                     >
-                                      Span detail
-                                    </h2>
+                                      <h2>
+                                        Span detail
+                                      </h2>
+                                    </div>
                                   </div>
                                   <div
                                     class="euiFlexItem"
@@ -736,13 +746,17 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                                   <div
                                     className="euiFlexItem"
                                   >
-                                    <EuiTitle>
-                                      <h2
-                                        className="euiTitle euiTitle--medium"
+                                    <EuiText
+                                      size="s"
+                                    >
+                                      <div
+                                        className="euiText euiText--small"
                                       >
-                                        Span detail
-                                      </h2>
-                                    </EuiTitle>
+                                        <h2>
+                                          Span detail
+                                        </h2>
+                                      </div>
+                                    </EuiText>
                                   </div>
                                 </EuiFlexItem>
                                 <EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
@@ -260,7 +260,9 @@ exports[`<SpanDetailTable /> spec renders the empty component 1`] = `
     </EuiSpacer>
     <EuiEmptyPrompt
       body={
-        <EuiText>
+        <EuiText
+          size="s"
+        >
           No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
         </EuiText>
       }
@@ -299,9 +301,11 @@ exports[`<SpanDetailTable /> spec renders the empty component 1`] = `
               <div
                 className="euiText euiText--medium"
               >
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   <div
-                    className="euiText euiText--medium"
+                    className="euiText euiText--small"
                   >
                     No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                   </div>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
@@ -9,15 +9,15 @@ exports[`Trace view component renders trace view 1`] = `
         gutterSize="s"
       >
         <EuiFlexItem>
-          <EuiTitle
-            size="l"
+          <EuiText
+            size="s"
           >
-            <h2
+            <h1
               className="overview-content"
             >
               test
-            </h2>
-          </EuiTitle>
+            </h1>
+          </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -1647,7 +1647,9 @@ exports[`Traces component renders empty traces page 1`] = `
             </EuiSpacer>
             <EuiEmptyPrompt
               body={
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
               }
@@ -1686,9 +1688,11 @@ exports[`Traces component renders empty traces page 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        <EuiText>
+                        <EuiText
+                          size="s"
+                        >
                           <div
-                            className="euiText euiText--medium"
+                            className="euiText euiText--small"
                           >
                             No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </div>
@@ -3367,7 +3371,9 @@ exports[`Traces component renders jaeger traces page 1`] = `
             </EuiSpacer>
             <EuiEmptyPrompt
               body={
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
               }
@@ -3406,9 +3412,11 @@ exports[`Traces component renders jaeger traces page 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        <EuiText>
+                        <EuiText
+                          size="s"
+                        >
                           <div
-                            className="euiText euiText--medium"
+                            className="euiText euiText--small"
                           >
                             No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </div>
@@ -5084,7 +5092,9 @@ exports[`Traces component renders traces page 1`] = `
             </EuiSpacer>
             <EuiEmptyPrompt
               body={
-                <EuiText>
+                <EuiText
+                  size="s"
+                >
                   No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
               }
@@ -5123,9 +5133,11 @@ exports[`Traces component renders traces page 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        <EuiText>
+                        <EuiText
+                          size="s"
+                        >
                           <div
-                            className="euiText euiText--medium"
+                            className="euiText euiText--small"
                           >
                             No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </div>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -73,17 +73,19 @@ exports[`Traces table component renders empty traces table message 1`] = `
       >
         <EuiEmptyPrompt
           actions={
-            <EuiSmallButton
+            <EuiSmallButtonEmpty
               color="primary"
               iconSide="right"
               iconType="popout"
               onClick={[Function]}
             >
               Learn more
-            </EuiSmallButton>
+            </EuiSmallButtonEmpty>
           }
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
             </EuiText>
           }
@@ -122,9 +124,11 @@ exports[`Traces table component renders empty traces table message 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
                       </div>
@@ -140,96 +144,79 @@ exports[`Traces table component renders empty traces table message 1`] = `
                 className="euiSpacer euiSpacer--l"
               />
             </EuiSpacer>
-            <EuiSmallButton
+            <EuiSmallButtonEmpty
               color="primary"
               iconSide="right"
               iconType="popout"
               onClick={[Function]}
             >
-              <EuiButton
+              <EuiButtonEmpty
                 color="primary"
                 iconSide="right"
                 iconType="popout"
                 onClick={[Function]}
                 size="s"
               >
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  color="primary"
+                <button
+                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
                   disabled={false}
-                  element="button"
-                  iconSide="right"
-                  iconType="popout"
-                  isDisabled={false}
                   onClick={[Function]}
-                  size="s"
                   type="button"
                 >
-                  <button
-                    className="euiButton euiButton--primary euiButton--small"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
+                  <EuiButtonContent
+                    className="euiButtonEmpty__content"
+                    iconSide="right"
+                    iconSize="m"
+                    iconType="popout"
+                    textProps={
                       Object {
-                        "minWidth": undefined,
+                        "className": "euiButtonEmpty__text",
                       }
                     }
-                    type="button"
                   >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconSide="right"
-                      iconType="popout"
-                      textProps={
-                        Object {
-                          "className": "euiButton__text",
-                        }
-                      }
+                    <span
+                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                     >
-                      <span
-                        className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                      <EuiIcon
+                        className="euiButtonContent__icon"
+                        color="inherit"
+                        size="m"
+                        type="popout"
                       >
-                        <EuiIcon
-                          className="euiButtonContent__icon"
-                          color="inherit"
-                          size="m"
-                          type="popout"
+                        <EuiIconBeaker
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                          focusable="false"
+                          role="img"
+                          style={null}
                         >
-                          <EuiIconBeaker
+                          <svg
                             aria-hidden={true}
                             className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                             focusable="false"
+                            height={16}
                             role="img"
                             style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                        <span
-                          className="euiButton__text"
-                        >
-                          Learn more
-                        </span>
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </EuiIconBeaker>
+                      </EuiIcon>
+                      <span
+                        className="euiButtonEmpty__text"
+                      >
+                        Learn more
                       </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
-            </EuiSmallButton>
+                    </span>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </div>
         </EuiEmptyPrompt>
       </MissingConfigurationMessage>
@@ -318,7 +305,9 @@ exports[`Traces table component renders empty traces table message 2`] = `
         </EuiSpacer>
         <EuiEmptyPrompt
           body={
-            <EuiText>
+            <EuiText
+              size="s"
+            >
               No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
             </EuiText>
           }
@@ -357,9 +346,11 @@ exports[`Traces table component renders empty traces table message 2`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    <EuiText>
+                    <EuiText
+                      size="s"
+                    >
                       <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
                         No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -16,7 +16,6 @@ import {
   EuiHorizontalRule,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
@@ -314,9 +313,9 @@ export function SpanDetailFlyout(props: {
           <EuiSpacer size="s" />
           <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
             <EuiFlexItem>
-              <EuiTitle>
+              <EuiText size="s">
                 <h2>Span detail</h2>
-              </EuiTitle>
+              </EuiText>
             </EuiFlexItem>
             {mode === 'data_prepper' && (
               <EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -16,7 +16,6 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import React, { useEffect, useState } from 'react';
@@ -55,9 +54,9 @@ export function TraceView(props: TraceViewProps) {
     return (
       <>
         <EuiFlexItem>
-          <EuiTitle size="l">
-            <h2 className="overview-content">{traceId}</h2>
-          </EuiTitle>
+          <EuiText size="s">
+            <h1 className="overview-content">{traceId}</h1>
+          </EuiText>
         </EuiFlexItem>
       </>
     );


### PR DESCRIPTION
### Description
This PR applies the Look & Feel density and consistency changes to Traces and Metrics:
1. Use small context menus
2. Use small tabs
3. Standardize paragraph size (15.75px next theme / 14px V7 theme)
4. Use semantic headers (H1s on main pages, H2s on modals/flyouts)
5. Modal/Flyout Typography
6. Buttons for actions, only using primary buttons for primary calls to action
7. Use small padding on popovers

## Screenshots
### Metrics: Popover Padding
| Scope | Before | After |
| ----- | ----- | ----- |
| Metrics | <img width="460" alt="Popover Before" src="https://github.com/user-attachments/assets/5920d5d4-fc47-471d-803b-65547b0a0ccb"> | <img width="460" alt="Popover Post" src="https://github.com/user-attachments/assets/3b42c5dc-9ce7-426b-a978-7987859bb52c"> |

### Small context Menu
| Scope | Before | After |
| ----- | ----- | ----- |
| Save | <img width="798" alt="Trace Save Popover Before" src="https://github.com/user-attachments/assets/40e20959-7fde-48cc-b0a2-7fac07ea3d53"> | <img width="798" alt="Trace Save Popover Post" src="https://github.com/user-attachments/assets/7a73f209-e53c-4075-8ce4-5feeedc52479"> |
| Filters | <img width="465" alt="Trace Analytics Filters Before" src="https://github.com/user-attachments/assets/90959c83-98e7-4d0b-954e-9d9d0d6e926c"> | <img width="465" alt="Trace Analytics Post" src="https://github.com/user-attachments/assets/447b73a6-e480-445f-aca1-e4388936123d"> |
| Actions | <img width="798" alt="Trace Actions Popover Before" src="https://github.com/user-attachments/assets/e7bc093c-3670-4d92-9923-2d37de318af1"> | <img width="798" alt="Trace Actions Popover Post" src="https://github.com/user-attachments/assets/01929a18-23be-45df-b7d6-504832fbdd36"> |

#### Buttons
| Scope | Before | After |
| ----- | ----- | ----- |
| Empty | <img width="897" alt="Trace Empty Button Before" src="https://github.com/user-attachments/assets/bb1be9c5-62b4-47d9-b6c1-85a707e19184"> | <img width="897" alt="Trace Empty Button Post" src="https://github.com/user-attachments/assets/c3985211-8b57-447c-827d-c0161487f612"> |

#### Paragraph size
| Scope | Before | After |
| ----- | ----- | ----- |
| Empty | <img width="623" alt="Trace Empty Message Before" src="https://github.com/user-attachments/assets/2ff01df3-24f1-4a0a-ba93-43c3fb40226f"> | <img width="623" alt="Trace Empty Message Post" src="https://github.com/user-attachments/assets/a086beb5-23e8-4298-bf19-e1dafa2e9f7e"> |
| Map | <img width="742" alt="Trace Map Node Before" src="https://github.com/user-attachments/assets/6833fa9d-390b-496e-86f5-559084023391"> | <img width="742" alt="Trace Map Node Post" src="https://github.com/user-attachments/assets/18dfdbda-ba55-421c-b0e2-db499525f9e6"> |

#### Semantic Headers 
| Scope | Before | After |
| ----- | ----- | ----- |
| Trace ID | <img width="954" alt="Trace View ID Before" src="https://github.com/user-attachments/assets/42fad4a4-eae8-4e49-a959-bb4dcfb6f3ad"> | <img width="954" alt="Trace View ID Post" src="https://github.com/user-attachments/assets/0795ad30-109e-4133-94de-df02617d514d"> |
| Service | <img width="584" alt="Traces Service Page Before" src="https://github.com/user-attachments/assets/c5ce830a-e8d3-4bbf-aa13-1e4ca62380ac"> | <img width="584" alt="Traces Service Page Post" src="https://github.com/user-attachments/assets/309e8552-8632-4b19-86f4-735b58ebbf1e"> 

#### Flyouts 
| Scope | Before | After |
| ----- | ----- | ----- |
| Header | <img width="799" alt="Trace Header Before" src="https://github.com/user-attachments/assets/104f23e6-f893-4d35-85b1-ee9a2d485476"> | <img width="799" alt="Trace Header Post" src="https://github.com/user-attachments/assets/ba85cad7-01af-4e67-b3c4-190edce596d8"> |
| Span Header | <img width="419" alt="Trace Span Header Before" src="https://github.com/user-attachments/assets/623f0cbc-6685-480a-99f4-4df6aa56ec65"> | <img width="419" alt="Trace Span Header Post" src="https://github.com/user-attachments/assets/6146f313-2151-4d1b-8299-243ba5a29f61"> |

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
