### PR TITLE
[Look&Feel] Notebooks Density and Consistency Improvements

### DIFF
--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -135,7 +135,7 @@ describe('Testing paragraphs', () => {
     cy.get('a[data-test-subj="createNotebookPrimaryBtn"]').click();
     cy.get('input[data-test-subj="custom-input-modal-input"]').focus().type(TEST_NOTEBOOK);
     cy.get('button[data-test-subj="custom-input-modal-confirm-button"]').click();
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
   });
 
   beforeEach(() => {
@@ -166,7 +166,7 @@ describe('Testing paragraphs', () => {
 
   it('Has working breadcrumbs', () => {
     cy.get('a[data-test-subj="breadcrumb last"]').contains(TEST_NOTEBOOK).click();
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('a[data-test-subj="breadcrumb"]').contains('Notebooks').click();
     cy.get('h3[data-test-subj="notebookTableTitle"]').should('exist');
     cy.get('a[data-test-subj="breadcrumb first"]').contains('Observability').click();
@@ -336,7 +336,7 @@ describe('Testing paragraphs', () => {
   });
 
   it('Clears outputs', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('[data-test-subj="notebook-paragraph-actions-button"]').should('exist');
     cy.get('[data-test-subj="notebook-paragraph-actions-button"]').click();
     cy.get('.euiContextMenuItem__text').contains('Clear all outputs').click();
@@ -346,7 +346,7 @@ describe('Testing paragraphs', () => {
   });
 
   it('Runs all paragraphs', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('[data-test-subj="notebook-paragraph-actions-button"]').click();
     cy.get('.euiContextMenuItem__text').contains('Run all paragraphs').click();
 
@@ -354,7 +354,7 @@ describe('Testing paragraphs', () => {
   });
 
   it('Adds paragraph to top', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
 
     cy.get('[data-test-subj="notebook-paragraph-actions-button"]').click();
     cy.get('.euiContextMenuItem__text').contains('Add paragraph to top').click();
@@ -364,7 +364,7 @@ describe('Testing paragraphs', () => {
   });
 
   it('Adds paragraph to bottom', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('[data-test-subj="notebook-paragraph-actions-button"]').click();
     cy.get('.euiContextMenuItem__text').contains('Add paragraph to bottom').click();
     cy.get('.euiContextMenuItem__text').contains('Code block').click();
@@ -374,7 +374,7 @@ describe('Testing paragraphs', () => {
   });
 
   it('Moves paragraphs', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('.euiButtonIcon[aria-label="Open paragraph menu"').eq(0).click();
     cy.get('.euiContextMenuItem-isDisabled').should('have.length.gte', 2);
     cy.get('.euiContextMenuItem__text').contains('Move to bottom').click();
@@ -383,7 +383,7 @@ describe('Testing paragraphs', () => {
   });
 
   it('Duplicates and renames the notebook', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('[data-test-subj="notebook-notebook-actions-button"]').click();
     cy.get('.euiContextMenuItem__text').contains('Duplicate notebook').click();
     cy.get('.euiButton__text').contains('Duplicate').click();
@@ -394,14 +394,14 @@ describe('Testing paragraphs', () => {
     cy.get('.euiButton__text').last().contains('Rename').click();
     cy.reload();
 
-    cy.get('.euiTitle')
+    cy.get('.euiText')
       .contains(TEST_NOTEBOOK + ' (rename)')
       .should('exist');
     cy.get(`a[href="${SAMPLE_URL}"]`).should('have.length.gte', 2);
   });
 
   it('Deletes paragraphs', () => {
-    cy.get('h1[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+    cy.get('div[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('[data-test-subj="notebook-paragraph-actions-button"]').click();
     cy.get('.euiContextMenuItem__text').contains('Delete all paragraphs').click();
     cy.get('button[data-test-subj="confirmModalConfirmButton"]').click();

--- a/public/components/notebooks/components/__tests__/__snapshots__/note_table.test.tsx.snap
+++ b/public/components/notebooks/components/__tests__/__snapshots__/note_table.test.tsx.snap
@@ -16,11 +16,13 @@ exports[`<NoteTable /> spec renders the component 1`] = `
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
+          <div
+            class="euiText euiText--small"
           >
-            Notebooks
-          </h1>
+            <h1>
+              Notebooks
+            </h1>
+          </div>
         </div>
       </header>
       <div
@@ -935,11 +937,13 @@ exports[`<NoteTable /> spec renders the empty component 1`] = `
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
+          <div
+            class="euiText euiText--small"
           >
-            Notebooks
-          </h1>
+            <h1>
+              Notebooks
+            </h1>
+          </div>
         </div>
       </header>
       <div
@@ -1094,7 +1098,7 @@ exports[`<NoteTable /> spec renders the empty component 1`] = `
               class="euiSpacer euiSpacer--m"
             />
             <div
-              class="euiText euiText--medium"
+              class="euiText euiText--small"
             >
               <div
                 class="euiTextColor euiTextColor--subdued"

--- a/public/components/notebooks/components/__tests__/__snapshots__/notebook.test.tsx.snap
+++ b/public/components/notebooks/components/__tests__/__snapshots__/notebook.test.tsx.snap
@@ -152,12 +152,14 @@ exports[`<Notebook /> spec Renders the empty component 1`] = `
       <div
         class="euiSpacer euiSpacer--s"
       />
-      <h1
-        class="euiTitle euiTitle--large"
+      <div
+        class="euiText euiText--small"
         data-test-subj="notebookTitle"
       >
-        sample-notebook-1
-      </h1>
+        <h1>
+          sample-notebook-1
+        </h1>
+      </div>
       <div
         class="euiSpacer euiSpacer--l"
       />
@@ -171,7 +173,7 @@ exports[`<Notebook /> spec Renders the empty component 1`] = `
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <div
-            class="euiText euiText--medium"
+            class="euiText euiText--small"
           >
             <div>
               <p>
@@ -203,7 +205,7 @@ exports[`<Notebook /> spec Renders the empty component 1`] = `
                 No paragraphs
               </h2>
               <div
-                class="euiText euiText--medium"
+                class="euiText euiText--small"
               >
                 Add a paragraph to compose your document or story. Notebooks now support two types of input:
               </div>
@@ -426,10 +428,12 @@ exports[`<Notebook /> spec Renders the visualization component 1`] = `
       <div
         class="euiSpacer euiSpacer--s"
       />
-      <h1
-        class="euiTitle euiTitle--large"
+      <div
+        class="euiText euiText--small"
         data-test-subj="notebookTitle"
-      />
+      >
+        <h1 />
+      </div>
       <div
         class="euiSpacer euiSpacer--l"
       />
@@ -485,7 +489,7 @@ exports[`<Notebook /> spec Renders the visualization component 1`] = `
           class="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <div
-            class="euiText euiText--medium"
+            class="euiText euiText--small"
           >
             <div>
               <p>
@@ -517,7 +521,7 @@ exports[`<Notebook /> spec Renders the visualization component 1`] = `
                 No paragraphs
               </h2>
               <div
-                class="euiText euiText--medium"
+                class="euiText euiText--small"
               >
                 Add a paragraph to compose your document or story. Notebooks now support two types of input:
               </div>

--- a/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
@@ -8,14 +8,24 @@ exports[`modal_containers spec render delete notebooks modal 1`] = `
   >
     <EuiModalHeader>
       <EuiModalHeaderTitle>
-        title
+        <EuiText
+          size="s"
+        >
+          <h2>
+            title
+          </h2>
+        </EuiText>
       </EuiModalHeaderTitle>
     </EuiModalHeader>
     <EuiModalBody>
-      <EuiText>
+      <EuiText
+        size="s"
+      >
         message
       </EuiText>
-      <EuiText>
+      <EuiText
+        size="s"
+      >
         The action cannot be undone.
       </EuiText>
       <EuiSpacer />
@@ -69,7 +79,13 @@ exports[`modal_containers spec render get custom modal 1`] = `
   >
     <EuiModalHeader>
       <EuiModalHeaderTitle>
-        title
+        <EuiText
+          size="s"
+        >
+          <h2>
+            title
+          </h2>
+        </EuiText>
       </EuiModalHeaderTitle>
     </EuiModalHeader>
     <EuiModalBody>
@@ -101,7 +117,6 @@ exports[`modal_containers spec render get custom modal 1`] = `
       </EuiSmallButtonEmpty>
       <EuiSmallButton
         data-test-subj="custom-input-modal-confirm-button"
-        fill={true}
         onClick={[Function]}
       >
         Confirm

--- a/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`modal_containers spec render get custom modal 1`] = `
       </EuiSmallButtonEmpty>
       <EuiSmallButton
         data-test-subj="custom-input-modal-confirm-button"
+        fill={true}
         onClick={[Function]}
       >
         Confirm

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`<CustomInputModal /> spec renders the component 1`] = `
       </EuiSmallButtonEmpty>
       <EuiSmallButton
         data-test-subj="custom-input-modal-confirm-button"
+        fill={true}
         onClick={[Function]}
       >
         Confirm
@@ -101,6 +102,7 @@ exports[`<CustomInputModal /> spec renders the component 2`] = `
       </EuiSmallButtonEmpty>
       <EuiSmallButton
         data-test-subj="custom-input-modal-confirm-button"
+        fill={true}
         onClick={[Function]}
       >
         Confirm

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
@@ -8,7 +8,13 @@ exports[`<CustomInputModal /> spec renders the component 1`] = `
   >
     <EuiModalHeader>
       <EuiModalHeaderTitle>
-        title
+        <EuiText
+          size="s"
+        >
+          <h2>
+            title
+          </h2>
+        </EuiText>
       </EuiModalHeaderTitle>
     </EuiModalHeader>
     <EuiModalBody>
@@ -40,7 +46,6 @@ exports[`<CustomInputModal /> spec renders the component 1`] = `
       </EuiSmallButtonEmpty>
       <EuiSmallButton
         data-test-subj="custom-input-modal-confirm-button"
-        fill={true}
         onClick={[Function]}
       >
         Confirm
@@ -58,7 +63,13 @@ exports[`<CustomInputModal /> spec renders the component 2`] = `
   >
     <EuiModalHeader>
       <EuiModalHeaderTitle>
-        title
+        <EuiText
+          size="s"
+        >
+          <h2>
+            title
+          </h2>
+        </EuiText>
       </EuiModalHeaderTitle>
     </EuiModalHeader>
     <EuiModalBody>
@@ -90,7 +101,6 @@ exports[`<CustomInputModal /> spec renders the component 2`] = `
       </EuiSmallButtonEmpty>
       <EuiSmallButton
         data-test-subj="custom-input-modal-confirm-button"
-        fill={true}
         onClick={[Function]}
       >
         Confirm

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -16,6 +16,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiSmallButton,
+  EuiText,
 } from '@elastic/eui';
 
 /*
@@ -30,7 +31,7 @@ import {
  * btn2txt - string as content to fill "confirm button"
  * openNoteName - Default input value for the field
  */
-type CustomInputModalProps = {
+interface CustomInputModalProps {
   runModal: (value: string) => void;
   closeModal: (
     event?: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -41,10 +42,19 @@ type CustomInputModalProps = {
   btn2txt: string;
   openNoteName: string;
   helpText: string;
-};
+}
 
 export const CustomInputModal = (props: CustomInputModalProps) => {
-  const { runModal, closeModal, labelTxt, titletxt, btn1txt, btn2txt, openNoteName, helpText } = props;
+  const {
+    runModal,
+    closeModal,
+    labelTxt,
+    titletxt,
+    btn1txt,
+    btn2txt,
+    openNoteName,
+    helpText,
+  } = props;
   const [value, setValue] = useState(openNoteName || ''); // sets input value
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,7 +65,11 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={closeModal} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{titletxt}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{titletxt}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
@@ -73,7 +87,10 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
 
         <EuiModalFooter>
           <EuiSmallButtonEmpty onClick={closeModal}>{btn1txt}</EuiSmallButtonEmpty>
-          <EuiSmallButton data-test-subj="custom-input-modal-confirm-button" onClick={() => runModal(value)} fill>
+          <EuiSmallButton
+            data-test-subj="custom-input-modal-confirm-button"
+            onClick={() => runModal(value)}
+          >
             {btn2txt}
           </EuiSmallButton>
         </EuiModalFooter>

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -31,7 +31,7 @@ import {
  * btn2txt - string as content to fill "confirm button"
  * openNoteName - Default input value for the field
  */
-type CustomInputModalProps = {
+interface CustomInputModalProps {
   runModal: (value: string) => void;
   closeModal: (
     event?: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -42,7 +42,7 @@ type CustomInputModalProps = {
   btn2txt: string;
   openNoteName: string;
   helpText: string;
-};
+}
 
 export const CustomInputModal = (props: CustomInputModalProps) => {
   const {

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -90,6 +90,7 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
           <EuiSmallButton
             data-test-subj="custom-input-modal-confirm-button"
             onClick={() => runModal(value)}
+            fill
           >
             {btn2txt}
           </EuiSmallButton>

--- a/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/custom_input_modal.tsx
@@ -31,7 +31,7 @@ import {
  * btn2txt - string as content to fill "confirm button"
  * openNoteName - Default input value for the field
  */
-interface CustomInputModalProps {
+type CustomInputModalProps = {
   runModal: (value: string) => void;
   closeModal: (
     event?: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -42,7 +42,7 @@ interface CustomInputModalProps {
   btn2txt: string;
   openNoteName: string;
   helpText: string;
-}
+};
 
 export const CustomInputModal = (props: CustomInputModalProps) => {
   const {

--- a/public/components/notebooks/components/helpers/custom_modals/reporting_loading_modal.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/reporting_loading_modal.tsx
@@ -7,21 +7,18 @@ import {
   EuiOverlayMask,
   EuiModal,
   EuiModalHeader,
-  EuiTitle,
   EuiText,
   EuiModalBody,
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
-  EuiSmallButton
-} from "@elastic/eui";
-import React from "react";
+  EuiSmallButton,
+} from '@elastic/eui';
+import React from 'react';
 
-export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
-  const {
-    setShowLoading
-  } = props;
+export function GenerateReportLoadingModal(props: { setShowLoading: any }) {
+  const { setShowLoading } = props;
 
   const closeModal = () => {
     setShowLoading(false);
@@ -36,15 +33,15 @@ export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
           id="downloadInProgressLoadingModal"
         >
           <EuiModalHeader>
-            <EuiTitle>
-              <EuiText textAlign="right">
-                <h2>Generating report</h2>
-              </EuiText>
-            </EuiTitle>
+            <EuiText size="s" textAlign="right">
+              <h2>Generating report</h2>
+            </EuiText>
           </EuiModalHeader>
           <EuiModalBody>
-            <EuiText>Preparing your file for download.</EuiText>
-            <EuiText>You can close this dialog while we continue in the background.</EuiText>
+            <EuiText size="s">Preparing your file for download.</EuiText>
+            <EuiText size="s">
+              You can close this dialog while we continue in the background.
+            </EuiText>
             <EuiSpacer />
             <EuiFlexGroup justifyContent="center" alignItems="center">
               <EuiFlexItem grow={false}>
@@ -67,4 +64,4 @@ export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
       </EuiOverlayMask>
     </div>
   );
-};
+}

--- a/public/components/notebooks/components/helpers/modal_containers.tsx
+++ b/public/components/notebooks/components/helpers/modal_containers.tsx
@@ -18,7 +18,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiText,
-  EuiSpacer
+  EuiSpacer,
 } from '@elastic/eui';
 import { CustomInputModal } from './custom_modals/custom_input_modal';
 
@@ -38,7 +38,7 @@ export const getCustomModal = (
   btn1txt: string,
   btn2txt: string,
   openNoteName?: string,
-  helpText?: string,
+  helpText?: string
 ) => {
   return (
     <CustomInputModal
@@ -92,7 +92,12 @@ export const getSampleNotebooksModal = (
         confirmButtonText="Yes"
         defaultFocusedButton="confirm"
       >
-        <p>Do you want to add sample notebooks? This will also add Dashboards sample flights and logs data if they have not been added.</p>
+        <EuiText size="s">
+          <p>
+            Do you want to add sample notebooks? This will also add Dashboards sample flights and
+            logs data if they have not been added.
+          </p>
+        </EuiText>
       </EuiConfirmModal>
     </EuiOverlayMask>
   );
@@ -105,7 +110,7 @@ export const getDeleteModal = (
   onConfirm: (event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void,
   title: string,
   message: string,
-  confirmMessage?: string,
+  confirmMessage?: string
 ) => {
   return (
     <EuiOverlayMask>
@@ -114,11 +119,11 @@ export const getDeleteModal = (
         onCancel={onCancel}
         onConfirm={onConfirm}
         cancelButtonText="Cancel"
-        confirmButtonText={confirmMessage || "Delete"}
+        confirmButtonText={confirmMessage || 'Delete'}
         buttonColor="danger"
         defaultFocusedButton="confirm"
       >
-        {message}
+        <EuiText size="s">{message}</EuiText>
       </EuiConfirmModal>
     </EuiOverlayMask>
   );
@@ -145,12 +150,16 @@ export const DeleteNotebookModal = ({
     <EuiOverlayMask>
       <EuiModal onClose={onCancel} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{title}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{title}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          <EuiText>{message}</EuiText>
-          <EuiText>The action cannot be undone.</EuiText>
+          <EuiText size="s">{message}</EuiText>
+          <EuiText size="s">The action cannot be undone.</EuiText>
           <EuiSpacer />
           <EuiForm>
             <EuiCompressedFormRow label={'To confirm deletion, enter "delete" in the text field'}>

--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -234,9 +234,9 @@ export function NoteTable({
         <EuiPageBody component="div">
           <EuiPageHeader>
             <EuiPageHeaderSection>
-              <EuiTitle size="l">
+              <EuiText size="s">
                 <h1>Notebooks</h1>
-              </EuiTitle>
+              </EuiText>
             </EuiPageHeaderSection>
           </EuiPageHeader>
           <EuiPageContent id="notebookArea">
@@ -266,7 +266,7 @@ export function NoteTable({
                       isOpen={isActionsPopoverOpen}
                       closePopover={() => setIsActionsPopoverOpen(false)}
                     >
-                      <EuiContextMenuPanel items={popoverItems} />
+                      <EuiContextMenuPanel items={popoverItems} size="s" />
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
@@ -322,7 +322,7 @@ export function NoteTable({
                 <EuiText textAlign="center" data-test-subj="notebookEmptyTableText">
                   <h2>No notebooks</h2>
                   <EuiSpacer size="m" />
-                  <EuiText color="subdued">
+                  <EuiText color="subdued" size="s">
                     Use notebooks to create post-mortem reports, build live infrastructure
                     <br />
                     reports, or foster explorative collaborations with data.

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -21,7 +21,6 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import CSS from 'csstype';
 import moment from 'moment';
@@ -1007,7 +1006,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
           isOpen={this.state.isReportingActionsPopoverOpen}
           closePopover={() => this.setState({ isReportingActionsPopoverOpen: false })}
         >
-          <EuiContextMenu initialPanelId={0} panels={reportingActionPanels} />
+          <EuiContextMenu initialPanelId={0} panels={reportingActionPanels} size="s" />
         </EuiPopover>
       </div>
     ) : null;
@@ -1059,7 +1058,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                     isOpen={this.state.isParaActionsPopoverOpen}
                     closePopover={() => this.setState({ isParaActionsPopoverOpen: false })}
                   >
-                    <EuiContextMenu initialPanelId={0} panels={paraActionsPanels} />
+                    <EuiContextMenu initialPanelId={0} panels={paraActionsPanels} size="s" />
                   </EuiPopover>
                 </EuiFlexItem>
               )}
@@ -1084,7 +1083,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                     isOpen={this.state.isNoteActionsPopoverOpen}
                     closePopover={() => this.setState({ isNoteActionsPopoverOpen: false })}
                   >
-                    <EuiContextMenu initialPanelId={0} panels={noteActionsPanels} />
+                    <EuiContextMenu initialPanelId={0} panels={noteActionsPanels} size="s" />
                   </EuiPopover>
                 </EuiFlexItem>
               ) : (
@@ -1109,9 +1108,9 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
               )}
             </EuiFlexGroup>
             <EuiSpacer size="s" />
-            <EuiTitle size="l" data-test-subj="notebookTitle">
+            <EuiText size="s" data-test-subj="notebookTitle">
               <h1>{this.state.path}</h1>
-            </EuiTitle>
+            </EuiText>
             <EuiSpacer />
             {!this.state.savedObjectNotebook && (
               <EuiFlexGroup>
@@ -1133,7 +1132,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             <EuiSpacer size="m" />
             <EuiFlexGroup alignItems={'flexStart'} gutterSize={'l'}>
               <EuiFlexItem grow={false}>
-                <EuiText>{createdText}</EuiText>
+                <EuiText size="s">{createdText}</EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
             {this.state.parsedPara.length > 0 ? (
@@ -1198,7 +1197,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                       isOpen={this.state.isAddParaPopoverOpen}
                       closePopover={() => this.setState({ isAddParaPopoverOpen: false })}
                     >
-                      <EuiContextMenu initialPanelId={0} panels={addParaPanels} />
+                      <EuiContextMenu initialPanelId={0} panels={addParaPanels} size="s" />
                     </EuiPopover>
                   </>
                 )}
@@ -1210,7 +1209,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                   <EuiSpacer size="xxl" />
                   <EuiText textAlign="center">
                     <h2>No paragraphs</h2>
-                    <EuiText>
+                    <EuiText size="s">
                       Add a paragraph to compose your document or story. Notebooks now support two
                       types of input:
                     </EuiText>

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_output.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_output.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<ParaOutput /> spec renders dashboards visualization outputs 1`] = `
 
 exports[`<ParaOutput /> spec renders markdown outputs 1`] = `
 <div
-  class="euiText euiText--medium wrapAll markdown-output-text"
+  class="euiText euiText--small wrapAll markdown-output-text"
   data-test-subj="markdownOutputText"
 >
   <div

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/paragraphs.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/paragraphs.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <button
-          class="euiButton euiButton--primary euiButton--small euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small"
           data-test-subj="runRefreshBtn-0"
           type="button"
         >
@@ -293,7 +293,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
         class="euiFlexItem"
       >
         <div
-          class="euiText euiText--medium"
+          class="euiText euiText--small"
           data-test-subj="lastRunText"
         >
           <div
@@ -314,7 +314,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
       style="opacity: 1; padding: 15px;"
     >
       <div
-        class="euiText euiText--medium wrapAll markdown-output-text"
+        class="euiText euiText--small wrapAll markdown-output-text"
         data-test-subj="markdownOutputText"
       >
         <div

--- a/public/components/notebooks/components/paragraph_components/para_input.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_input.tsx
@@ -186,7 +186,11 @@ export const ParaInput = (props: {
           <EuiOverlayMask>
             <EuiModal onClose={() => setIsModalOpen(false)} style={{ width: 500 }}>
               <EuiModalHeader>
-                <EuiModalHeaderTitle>Browse visualizations</EuiModalHeaderTitle>
+                <EuiModalHeaderTitle>
+                  <EuiText size="s">
+                    <h2>Browse visualizations</h2>
+                  </EuiText>
+                </EuiModalHeaderTitle>
               </EuiModalHeader>
 
               <EuiModalBody>
@@ -219,7 +223,9 @@ export const ParaInput = (props: {
               </EuiModalBody>
 
               <EuiModalFooter>
-                <EuiSmallButtonEmpty onClick={() => setIsModalOpen(false)}>Cancel</EuiSmallButtonEmpty>
+                <EuiSmallButtonEmpty onClick={() => setIsModalOpen(false)}>
+                  Cancel
+                </EuiSmallButtonEmpty>
                 <EuiSmallButton
                   data-test-subj="para-input-select-button"
                   onClick={() => onSelect()}

--- a/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -108,6 +108,7 @@ const OutputBody = ({
             key={key}
             className="wrapAll markdown-output-text"
             data-test-subj="markdownOutputText"
+            size="s"
           >
             <MarkdownRender source={val} />
           </EuiText>

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -447,7 +447,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
               isOpen={isPopoverOpen}
               closePopover={() => setIsPopoverOpen(false)}
             >
-              <EuiContextMenu initialPanelId={0} panels={panels} />
+              <EuiContextMenu initialPanelId={0} panels={panels} size="s" />
             </EuiPopover>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -469,7 +469,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
             )}
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText color="subdued" data-test-subj="lastRunText">
+            <EuiText color="subdued" data-test-subj="lastRunText" size="s">
               {`Last successful run ${moment(props.dateModified).format(UI_DATE_FORMAT)}.`}
             </EuiText>
           </EuiFlexItem>
@@ -484,12 +484,12 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
             <EuiIcon type="questionInCircle" color="primary" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiText color="subdued">
+            <EuiText color="subdued" size="s">
               {`Output available from ${moment(props.dateModified).format(UI_DATE_FORMAT)}`}
             </EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText>
+            <EuiText size="s">
               <EuiLink
                 data-test-subj="viewBothLink"
                 onClick={() => props.setSelectedViewId('view_both', index)}
@@ -618,7 +618,6 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
                   <EuiSmallButton
                     data-test-subj={`runRefreshBtn-${index}`}
                     onClick={() => onRunPara()}
-                    fill
                   >
                     {isOutputAvailable ? 'Refresh' : 'Run'}
                   </EuiSmallButton>


### PR DESCRIPTION
### Description
This PR applies the Look & Feel density and consistency changes to Notebooks:
1. Use small context menus
2. Use small tabs
3. Standardize paragraph size (15.75px next theme / 14px V7 theme)
4. Use semantic headers (H1s on main pages, H2s on modals/flyouts)
5. Modal/Flyout Typography
6. Buttons for actions, only using primary buttons for primary calls to action
7. Use small padding on popovers

## Screenshots
### Small context Menu
| Scope | Before | After |
| ----- | ----- | ----- |
| Notebook: Header Reporting | <img width="952" alt="Notebook Header Reporting Before" src="https://github.com/user-attachments/assets/f3d8e5f1-c465-4cfd-8d2d-9861479503dc"> | <img width="952" alt="Notebook Header Reporting Post" src="https://github.com/user-attachments/assets/01ba4d2d-e62c-45c7-bdec-58e3ac1db89c"> |
| Notebook: Header Paragraph | <img width="952" alt="Notebook Header Paragraph Before" src="https://github.com/user-attachments/assets/d89ba6e4-a6e7-4462-af09-b6fc64ac370a"> | <img width="952" alt="Notebook Header Paragraph Post" src="https://github.com/user-attachments/assets/c93e700b-002d-4399-8de4-dec8a4f61fa7"> |
| Notebook: Header Notebook | <img width="952" alt="Notebook Header Notebook HeaderActions Before" src="https://github.com/user-attachments/assets/5ad9408a-9e23-4dfe-9474-ce3eb369f93e"> | <img width="952" alt="Notebook Header Notebook HeaderActions Post" src="https://github.com/user-attachments/assets/3d3b6dcc-33b9-4abb-b026-8b60a6da4ee0"> |
| Notebook: Add | <img width="594" alt="Notebook Add Paragraph Before" src="https://github.com/user-attachments/assets/8f57355a-0c49-4ed0-925e-b46eeb99ff37"> | <img width="594" alt="Notebook Add Paragraph Post" src="https://github.com/user-attachments/assets/d4edef02-34e6-4f26-bad4-600077d2f2f1"> |
| Notebook: Paragraph | <img width="594" alt="Notebook Paragraph Options Before" src="https://github.com/user-attachments/assets/47b73a7c-bb4a-44b9-99dd-12d09d269fc0"> | <img width="594" alt="Notebook Paragraph Options Post" src="https://github.com/user-attachments/assets/716dc8d5-f451-4efd-bd0c-a224ffb5a58e"> |
| Notebook: Listing | <img width="341" alt="Notebooks Listing Before" src="https://github.com/user-attachments/assets/eccff32c-0a23-4286-b6a2-fe610fe5c80a"> | <img width="341" alt="Notebooks Listing Post" src="https://github.com/user-attachments/assets/089ad6c3-ae09-48f2-9f97-ca3acfc3fab6"> |

#### Paragraph size
| Scope | Before | After |
| ----- | ----- | ----- |
| Notebooks: Empty overview | <img width="851" alt="Notebooks Empty Before" src="https://github.com/user-attachments/assets/e266ec25-a92f-491e-8e11-4ca6419ca34d"> | <img width="851" alt="Notebooks Empty Post" src="https://github.com/user-attachments/assets/7287bc16-fa8e-484c-9e4d-cacc0918613e"> |
| Notebooks: Empty notebook | <img width="955" alt="Notebook Empty Before" src="https://github.com/user-attachments/assets/851273fe-baf0-441a-8ab9-6fa9a1a7c563"> | <img width="955" alt="Notebook Empty Post" src="https://github.com/user-attachments/assets/6f02b28d-9177-4400-bea3-a53552b833d1"> |
| Notebooks: Timestamp | <img width="955" alt="Notebook Output Timestamp Before" src="https://github.com/user-attachments/assets/87f2e1a6-b072-4db1-b901-3d8753347541"> | <img width="955" alt="Notebook Output Timestamp Post" src="https://github.com/user-attachments/assets/23cc98ab-cea2-443f-87e7-e97df7e95638"> |
| Notebooks: Created | <img width="955" alt="Notebook Created Before" src="https://github.com/user-attachments/assets/7297c016-3bee-42e3-aa31-a6662f883924"> | <img width="955" alt="Notebook Created Post" src="https://github.com/user-attachments/assets/64decc58-d443-4fdd-ba97-1f5e77414b28"> |
| Notebooks: Quickstart | <img width="955" alt="Notebook OutputMD Before" src="https://github.com/user-attachments/assets/eb8663cc-4ee9-4315-a22b-e1ca2f886f79"> | <img width="955" alt="Notebook OutputMD Post" src="https://github.com/user-attachments/assets/24bab5d2-c063-471c-900a-85dedd33304d"> |

#### Semantic Headers 
| Scope | Before | After |
| ----- | ----- | ----- |
| Notebooks: Overview | <img width="851" alt="Notebooks Listing Before" src="https://github.com/user-attachments/assets/16f9630a-2e99-4ba8-b4cd-86818c075bad"> | <img width="851" alt="Notebooks Listing Post" src="https://github.com/user-attachments/assets/fa1b59c0-e642-4b73-9b87-5ea3ee2c66f3"> |
| Notebooks: Title | <img width="952" alt="Notebook before" src="https://github.com/user-attachments/assets/c493ea91-9e0b-4caf-b95a-05dd9e5b1b69"> | <img width="952" alt="Notebook post" src="https://github.com/user-attachments/assets/becbd176-e15f-48b6-875b-0b7fa3933375"> |

#### Modals 
| Scope | Before | After |
| ----- | ----- | ----- |
| Notebooks: Browse Vis | <img width="523" alt="Notebooks Browse Before" src="https://github.com/user-attachments/assets/53d79804-b605-4ee5-a85d-04f482f27a73"> | <img width="523" alt="Notebooks Browse Post" src="https://github.com/user-attachments/assets/a67cd9ce-01df-4d57-bd58-f848a6b550ad"> |
| Notebooks: Duplicate | <img width="478" alt="Notebooks Custom Input Modal Before" src="https://github.com/user-attachments/assets/2718b643-5e0f-4001-993f-105f63ba81eb"> | <img width="478" alt="Notebooks Custom Input Modal Post" src="https://github.com/user-attachments/assets/cd63f46c-f3d5-49a5-a451-b98effc97b83"> |
| Notebooks: Delete | <img width="787" alt="Delete Notebook Before" src="https://github.com/user-attachments/assets/4fcfe378-0b33-4b5a-8da1-08eaaee98616"> | <img width="787" alt="Delete Notebook Post" src="https://github.com/user-attachments/assets/e8003543-ac3d-417d-86b6-fa0cb8d71e1f"> |
| Delete All Paragraphs | <img width="643" alt="Delete All Paragraphs Before" src="https://github.com/user-attachments/assets/c4b2d745-40a9-45be-9a46-9999ec643b81"> | <img width="643" alt="Delete All Paragraphs Post" src="https://github.com/user-attachments/assets/a6b54752-823c-4b30-a98c-a9136124b5b2"> |
| Delete Header | <img width="787" alt="Delete NotebookHeader Before" src="https://github.com/user-attachments/assets/a86e05a4-7098-490e-b1ce-72cee446c754"> | <img width="787" alt="Delete NotebookHeader Post" src="https://github.com/user-attachments/assets/e880bcb6-7d6b-4368-b1d5-313e58ba0ab7"> |
| Sample | <img width="784" alt="Sample Notebooks Add Before 2" src="https://github.com/user-attachments/assets/e8c8bbb7-ada4-430b-b3ab-4f7df917097a"> | <img width="784" alt="Sample Notebooks Add Post 2" src="https://github.com/user-attachments/assets/91bb0e63-0140-4380-92e1-71a97a38d3da"> |

#### Buttons
| Scope | Before | After |
| ----- | ----- | ----- |
| Refresh | <img width="954" alt="Notebook Refresh Before" src="https://github.com/user-attachments/assets/91ba0c8b-5cc7-4671-b13e-b4b06ef98433"> | <img width="954" alt="Notebook Refresh Post" src="https://github.com/user-attachments/assets/d8261bdf-8193-4333-9034-01a70fceb266"> |


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
