### PR TITLE
[Look&Feel] Custom Panels Density and Consistency Improvements

### DIFF
--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_table.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_table.test.tsx.snap
@@ -16,11 +16,13 @@ exports[`Panels Table Component render dashboard table container with panels 1`]
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
+          <div
+            class="euiText euiText--small"
           >
-            Observability dashboards
-          </h1>
+            <h1>
+              Observability dashboards
+            </h1>
+          </div>
         </div>
       </header>
       <div
@@ -859,11 +861,13 @@ exports[`Panels Table Component renders empty dashboard table container 1`] = `
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
+          <div
+            class="euiText euiText--small"
           >
-            Observability dashboards
-          </h1>
+            <h1>
+              Observability dashboards
+            </h1>
+          </div>
         </div>
       </header>
       <div
@@ -1099,11 +1103,13 @@ exports[`Panels Table Component renders empty panel table container2 1`] = `
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
+          <div
+            class="euiText euiText--small"
           >
-            Observability dashboards
-          </h1>
+            <h1>
+              Observability dashboards
+            </h1>
+          </div>
         </div>
       </header>
       <div

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -15,10 +15,13 @@ exports[`Panels View Component render panel view container and refresh panel 1`]
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
-            data-test-subj="panelNameHeader"
-          />
+          <div
+            class="euiText euiText--small"
+          >
+            <h1
+              data-test-subj="panelNameHeader"
+            />
+          </div>
           <div
             class="euiFlexItem"
           >
@@ -446,10 +449,13 @@ exports[`Panels View Component render panel view so container and reload dashboa
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
-            data-test-subj="panelNameHeader"
-          />
+          <div
+            class="euiText euiText--small"
+          >
+            <h1
+              data-test-subj="panelNameHeader"
+            />
+          </div>
           <div
             class="euiFlexItem"
           >
@@ -1354,14 +1360,17 @@ exports[`Panels View Component renders panel view container with visualizations 
                     <div
                       className="euiPageHeaderSection"
                     >
-                      <EuiTitle
-                        size="l"
+                      <EuiText
+                        size="s"
                       >
-                        <h1
-                          className="euiTitle euiTitle--large"
-                          data-test-subj="panelNameHeader"
-                        />
-                      </EuiTitle>
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <h1
+                            data-test-subj="panelNameHeader"
+                          />
+                        </div>
+                      </EuiText>
                       <EuiFlexItem>
                         <div
                           className="euiFlexItem"
@@ -3705,14 +3714,17 @@ exports[`Panels View Component renders panel view container without visualizatio
                     <div
                       className="euiPageHeaderSection"
                     >
-                      <EuiTitle
-                        size="l"
+                      <EuiText
+                        size="s"
                       >
-                        <h1
-                          className="euiTitle euiTitle--large"
-                          data-test-subj="panelNameHeader"
-                        />
-                      </EuiTitle>
+                        <div
+                          className="euiText euiText--small"
+                        >
+                          <h1
+                            data-test-subj="panelNameHeader"
+                          />
+                        </div>
+                      </EuiText>
                       <EuiFlexItem>
                         <div
                           className="euiFlexItem"

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view_so.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view_so.test.tsx.snap
@@ -15,10 +15,13 @@ exports[`Panels View SO Component render panel view container and refresh panel 
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
-            data-test-subj="panelNameHeader"
-          />
+          <div
+            class="euiText euiText--small"
+          >
+            <h1
+              data-test-subj="panelNameHeader"
+            />
+          </div>
           <div
             class="euiFlexItem"
           >
@@ -446,10 +449,13 @@ exports[`Panels View SO Component render panel view so container and reload dash
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
-            data-test-subj="panelNameHeader"
-          />
+          <div
+            class="euiText euiText--small"
+          >
+            <h1
+              data-test-subj="panelNameHeader"
+            />
+          </div>
           <div
             class="euiFlexItem"
           >
@@ -879,10 +885,13 @@ exports[`Panels View SO Component renders panels view SO container with visualiz
         <div
           class="euiPageHeaderSection"
         >
-          <h1
-            class="euiTitle euiTitle--large"
-            data-test-subj="panelNameHeader"
-          />
+          <div
+            class="euiText euiText--small"
+          >
+            <h1
+              data-test-subj="panelNameHeader"
+            />
+          </div>
           <div
             class="euiFlexItem"
           >

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -342,9 +342,9 @@ export const CustomPanelTable = ({
         <EuiPageBody component="div">
           <EuiPageHeader>
             <EuiPageHeaderSection>
-              <EuiTitle size="l">
+              <EuiText size="s">
                 <h1>Observability dashboards</h1>
-              </EuiTitle>
+              </EuiText>
             </EuiPageHeaderSection>
           </EuiPageHeader>
           <EuiPageContent id="customPanelArea">
@@ -374,11 +374,15 @@ export const CustomPanelTable = ({
                       isOpen={isActionsPopoverOpen}
                       closePopover={() => setIsActionsPopoverOpen(false)}
                     >
-                      <EuiContextMenuPanel items={popoverItems()} />
+                      <EuiContextMenuPanel items={popoverItems()} size="s" />
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiSmallButton fill href="#/create" data-test-subj="customPanels__createNewPanels">
+                    <EuiSmallButton
+                      fill
+                      href="#/create"
+                      data-test-subj="customPanels__createNewPanels"
+                    >
                       Create Dashboard
                     </EuiSmallButton>
                   </EuiFlexItem>

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -155,7 +155,7 @@ export const CustomPanelTable = ({
           sourcePanel = legacyFetchResult.operationalPanel;
         }
 
-        const { id, ...newPanel } = {
+        const { ...newPanel } = {
           ...sourcePanel,
           title: newName,
         };

--- a/public/components/custom_panels/custom_panel_view.tsx
+++ b/public/components/custom_panels/custom_panel_view.tsx
@@ -21,7 +21,7 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiCompressedSuperDatePicker,
-  EuiTitle,
+  EuiText,
   OnTimeChangeProps,
   ShortDate,
 } from '@elastic/eui';
@@ -465,7 +465,11 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
   );
 
   const saveButton = (
-    <EuiSmallButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
+    <EuiSmallButton
+      data-test-subj="savePanelButton"
+      iconType="save"
+      onClick={() => editPanel('save')}
+    >
       Save
     </EuiSmallButton>
   );
@@ -612,9 +616,9 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
             {appPanel || (
               <>
                 <EuiPageHeaderSection>
-                  <EuiTitle size="l">
+                  <EuiText size="s">
                     <h1 data-test-subj="panelNameHeader">{openPanelName}</h1>
-                  </EuiTitle>
+                  </EuiText>
                   <EuiFlexItem>
                     <EuiSpacer size="s" />
                   </EuiFlexItem>
@@ -638,7 +642,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
                         isOpen={panelsMenuPopover}
                         closePopover={() => setPanelsMenuPopover(false)}
                       >
-                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} />
+                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} size="s" />
                       </EuiPopover>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -22,7 +22,7 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiCompressedSuperDatePicker,
-  EuiTitle,
+  EuiText,
   OnTimeChangeProps,
   ShortDate,
 } from '@elastic/eui';
@@ -375,7 +375,11 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
   );
 
   const saveButton = (
-    <EuiSmallButton data-test-subj="savePanelButton" iconType="save" onClick={() => editPanel('save')}>
+    <EuiSmallButton
+      data-test-subj="savePanelButton"
+      iconType="save"
+      onClick={() => editPanel('save')}
+    >
       Save
     </EuiSmallButton>
   );
@@ -562,9 +566,9 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
             {appPanel || (
               <>
                 <EuiPageHeaderSection>
-                  <EuiTitle size="l">
+                  <EuiText size="s">
                     <h1 data-test-subj="panelNameHeader">{panel?.title}</h1>
-                  </EuiTitle>
+                  </EuiText>
                   <EuiFlexItem>
                     <EuiSpacer size="s" />
                   </EuiFlexItem>
@@ -587,7 +591,7 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
                         isOpen={panelsMenuPopover}
                         closePopover={() => setPanelsMenuPopover(false)}
                       >
-                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} />
+                        <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} size="s" />
                       </EuiPopover>
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>

--- a/public/components/custom_panels/custom_panel_view_so.tsx
+++ b/public/components/custom_panels/custom_panel_view_so.tsx
@@ -29,7 +29,7 @@ import {
 import { DurationRange } from '@elastic/eui/src/components/date_picker/types';
 import last from 'lodash/last';
 import moment from 'moment';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { CoreStart } from '../../../../../src/core/public';
 import { CREATE_PANEL_MESSAGE } from '../../../common/constants/custom_panels';
@@ -119,7 +119,6 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
     parentBreadcrumbs,
     childBreadcrumbs,
     updateAvailabilityVizId,
-    cloneCustomPanel,
     onEditClick,
     onAddClick,
   } = props;
@@ -131,7 +130,7 @@ export const CustomPanelViewSO = (props: CustomPanelViewProps) => {
   const [loading, setLoading] = useState(true);
 
   const [pplFilterValue, setPPLFilterValue] = useState('');
-  const [baseQuery, setBaseQuery] = useState('');
+  const [baseQuery, _] = useState('');
   const [onRefresh, setOnRefresh] = useState(false);
 
   const [inputDisabled, setInputDisabled] = useState(true);

--- a/public/components/custom_panels/helpers/__tests__/__snapshots__/custom_input_model.test.tsx.snap
+++ b/public/components/custom_panels/helpers/__tests__/__snapshots__/custom_input_model.test.tsx.snap
@@ -8,7 +8,13 @@ exports[`Custom Input Model component renders custom input modal with multiple a
   >
     <EuiModalHeader>
       <EuiModalHeaderTitle>
-        Input test
+        <EuiText
+          size="s"
+        >
+          <h2>
+            Input test
+          </h2>
+        </EuiText>
       </EuiModalHeaderTitle>
     </EuiModalHeader>
     <EuiModalBody>
@@ -58,7 +64,13 @@ exports[`Custom Input Model component renders custom input modal with single arg
   >
     <EuiModalHeader>
       <EuiModalHeaderTitle>
-        Input test
+        <EuiText
+          size="s"
+        >
+          <h2>
+            Input test
+          </h2>
+        </EuiText>
       </EuiModalHeaderTitle>
     </EuiModalHeader>
     <EuiModalBody>

--- a/public/components/custom_panels/helpers/add_visualization_popover.tsx
+++ b/public/components/custom_panels/helpers/add_visualization_popover.tsx
@@ -86,7 +86,7 @@ export const AddVisualizationPopover = ({
       panelPaddingSize="none"
       anchorPosition="downLeft"
     >
-      <EuiContextMenu initialPanelId={0} panels={getVizContextPanels()} />
+      <EuiContextMenu initialPanelId={0} panels={getVizContextPanels()} size="s" />
     </EuiPopover>
   );
 };

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -16,6 +16,7 @@ import {
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiSmallButton,
+  EuiText,
 } from '@elastic/eui';
 
 /*
@@ -71,7 +72,11 @@ export const CustomInputModal = (props: CustomInputModalProps) => {
     <EuiOverlayMask>
       <EuiModal onClose={closeModal} initialFocus="[name=input]">
         <EuiModalHeader>
-          <EuiModalHeaderTitle>{titletxt}</EuiModalHeaderTitle>
+          <EuiModalHeaderTitle>
+            <EuiText size="s">
+              <h2>{titletxt}</h2>
+            </EuiText>
+          </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>

--- a/public/components/custom_panels/helpers/custom_input_modal.tsx
+++ b/public/components/custom_panels/helpers/custom_input_modal.tsx
@@ -34,7 +34,7 @@ import {
  * optionalArgs - Arguments needed to pass them to runModal function
  */
 
-type CustomInputModalProps = {
+interface CustomInputModalProps {
   runModal:
     | ((value: string, value2: string, value3: string, value4: string) => void)
     | ((value: string) => void);
@@ -48,7 +48,7 @@ type CustomInputModalProps = {
   openPanelName?: string;
   helpText?: string;
   optionalArgs?: string[];
-};
+}
 
 export const CustomInputModal = (props: CustomInputModalProps) => {
   const {

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -132,12 +132,16 @@ export const VisualizationContainer = ({
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <h1>{visualizationMetaData.name}</h1>
+              <EuiText size="s">
+                <h2>{visualizationMetaData.name}</h2>
+              </EuiText>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
 
           <EuiModalBody>
-            This PPL Query is generated in runtime from selected data source
+            <EuiText size="s">
+              This PPL Query is generated in runtime from selected data source
+            </EuiText>
             <EuiSpacer />
             <EuiCodeBlock language="html" isCopyable>
               {visualizationMetaData.query}
@@ -156,12 +160,14 @@ export const VisualizationContainer = ({
         <EuiModal onClose={closeModal}>
           <EuiModalHeader>
             <EuiModalHeaderTitle>
-              <h1>{isError.errorMessage}</h1>
+              <EuiText size="s">
+                <h2>{isError.errorMessage}</h2>
+              </EuiText>
             </EuiModalHeaderTitle>
           </EuiModalHeader>
 
           <EuiModalBody>
-            Error Details
+            <EuiText size="s">Error Details</EuiText>
             <EuiSpacer />
             <EuiCodeBlock language="html" isCopyable>
               {isError.errorDetails}
@@ -388,10 +394,12 @@ export const VisualizationContainer = ({
                   isOpen={isPopoverOpen}
                   closePopover={closeActionsMenu}
                   anchorPosition="downLeft"
+                  panelPaddingSize="none"
                 >
                   <EuiContextMenuPanel
                     items={popoverPanel}
                     data-test-subj="panelViz__popoverPanel"
+                    size="s"
                   />
                 </EuiPopover>
               )}

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
@@ -74,15 +74,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
       <EuiFlyoutHeader
         hasBorder={true}
       >
-        <EuiTitle
-          size="m"
+        <EuiText
+          size="s"
         >
           <h2
             id="addVisualizationFlyout"
           >
             Select existing visualization
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
     }
   >
@@ -142,12 +142,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                     <div
                       class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                     >
-                      <h2
-                        class="euiTitle euiTitle--medium"
-                        id="addVisualizationFlyout"
+                      <div
+                        class="euiText euiText--small"
                       >
-                        Select existing visualization
-                      </h2>
+                        <h2
+                          id="addVisualizationFlyout"
+                        >
+                          Select existing visualization
+                        </h2>
+                      </div>
                     </div>
                     <div
                       class="euiFlyoutBody"
@@ -358,12 +361,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                             <div
                               class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                                id="addVisualizationFlyout"
+                              <div
+                                class="euiText euiText--small"
                               >
-                                Select existing visualization
-                              </h2>
+                                <h2
+                                  id="addVisualizationFlyout"
+                                >
+                                  Select existing visualization
+                                </h2>
+                              </div>
                             </div>
                             <div
                               class="euiFlyoutBody"
@@ -506,12 +512,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                               <div
                                 class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
-                                  id="addVisualizationFlyout"
+                                <div
+                                  class="euiText euiText--small"
                                 >
-                                  Select existing visualization
-                                </h2>
+                                  <h2
+                                    id="addVisualizationFlyout"
+                                  >
+                                    Select existing visualization
+                                  </h2>
+                                </div>
                               </div>
                               <div
                                 class="euiFlyoutBody"
@@ -654,12 +663,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                 <div
                                   class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                 >
-                                  <h2
-                                    class="euiTitle euiTitle--medium"
-                                    id="addVisualizationFlyout"
+                                  <div
+                                    class="euiText euiText--small"
                                   >
-                                    Select existing visualization
-                                  </h2>
+                                    <h2
+                                      id="addVisualizationFlyout"
+                                    >
+                                      Select existing visualization
+                                    </h2>
+                                  </div>
                                 </div>
                                 <div
                                   class="euiFlyoutBody"
@@ -790,12 +802,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                   <div
                                     class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                   >
-                                    <h2
-                                      class="euiTitle euiTitle--medium"
-                                      id="addVisualizationFlyout"
+                                    <div
+                                      class="euiText euiText--small"
                                     >
-                                      Select existing visualization
-                                    </h2>
+                                      <h2
+                                        id="addVisualizationFlyout"
+                                      >
+                                        Select existing visualization
+                                      </h2>
+                                    </div>
                                   </div>
                                   <div
                                     class="euiFlyoutBody"
@@ -986,16 +1001,19 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                               <div
                                 className="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                               >
-                                <EuiTitle
-                                  size="m"
+                                <EuiText
+                                  size="s"
                                 >
-                                  <h2
-                                    className="euiTitle euiTitle--medium"
-                                    id="addVisualizationFlyout"
+                                  <div
+                                    className="euiText euiText--small"
                                   >
-                                    Select existing visualization
-                                  </h2>
-                                </EuiTitle>
+                                    <h2
+                                      id="addVisualizationFlyout"
+                                    >
+                                      Select existing visualization
+                                    </h2>
+                                  </div>
+                                </EuiText>
                               </div>
                             </EuiFlyoutHeader>
                             <EuiFlyoutBody
@@ -1375,15 +1393,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
       <EuiFlyoutHeader
         hasBorder={true}
       >
-        <EuiTitle
-          size="m"
+        <EuiText
+          size="s"
         >
           <h2
             id="addVisualizationFlyout"
           >
             Replace visualization
           </h2>
-        </EuiTitle>
+        </EuiText>
       </EuiFlyoutHeader>
     }
   >
@@ -1443,12 +1461,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                     <div
                       class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                     >
-                      <h2
-                        class="euiTitle euiTitle--medium"
-                        id="addVisualizationFlyout"
+                      <div
+                        class="euiText euiText--small"
                       >
-                        Replace visualization
-                      </h2>
+                        <h2
+                          id="addVisualizationFlyout"
+                        >
+                          Replace visualization
+                        </h2>
+                      </div>
                     </div>
                     <div
                       class="euiFlyoutBody"
@@ -1659,12 +1680,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                             <div
                               class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                                id="addVisualizationFlyout"
+                              <div
+                                class="euiText euiText--small"
                               >
-                                Replace visualization
-                              </h2>
+                                <h2
+                                  id="addVisualizationFlyout"
+                                >
+                                  Replace visualization
+                                </h2>
+                              </div>
                             </div>
                             <div
                               class="euiFlyoutBody"
@@ -1807,12 +1831,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                               <div
                                 class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
-                                  id="addVisualizationFlyout"
+                                <div
+                                  class="euiText euiText--small"
                                 >
-                                  Replace visualization
-                                </h2>
+                                  <h2
+                                    id="addVisualizationFlyout"
+                                  >
+                                    Replace visualization
+                                  </h2>
+                                </div>
                               </div>
                               <div
                                 class="euiFlyoutBody"
@@ -1955,12 +1982,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                 <div
                                   class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                 >
-                                  <h2
-                                    class="euiTitle euiTitle--medium"
-                                    id="addVisualizationFlyout"
+                                  <div
+                                    class="euiText euiText--small"
                                   >
-                                    Replace visualization
-                                  </h2>
+                                    <h2
+                                      id="addVisualizationFlyout"
+                                    >
+                                      Replace visualization
+                                    </h2>
+                                  </div>
                                 </div>
                                 <div
                                   class="euiFlyoutBody"
@@ -2091,12 +2121,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                   <div
                                     class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                   >
-                                    <h2
-                                      class="euiTitle euiTitle--medium"
-                                      id="addVisualizationFlyout"
+                                    <div
+                                      class="euiText euiText--small"
                                     >
-                                      Replace visualization
-                                    </h2>
+                                      <h2
+                                        id="addVisualizationFlyout"
+                                      >
+                                        Replace visualization
+                                      </h2>
+                                    </div>
                                   </div>
                                   <div
                                     class="euiFlyoutBody"
@@ -2287,16 +2320,19 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                               <div
                                 className="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                               >
-                                <EuiTitle
-                                  size="m"
+                                <EuiText
+                                  size="s"
                                 >
-                                  <h2
-                                    className="euiTitle euiTitle--medium"
-                                    id="addVisualizationFlyout"
+                                  <div
+                                    className="euiText euiText--small"
                                   >
-                                    Replace visualization
-                                  </h2>
-                                </EuiTitle>
+                                    <h2
+                                      id="addVisualizationFlyout"
+                                    >
+                                      Replace visualization
+                                    </h2>
+                                  </div>
+                                </EuiText>
                               </div>
                             </EuiFlyoutHeader>
                             <EuiFlyoutBody

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
@@ -85,15 +85,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
         <EuiFlyoutHeader
           hasBorder={true}
         >
-          <EuiTitle
-            size="m"
+          <EuiText
+            size="s"
           >
             <h2
               id="addVisualizationFlyout"
             >
               Select existing visualization
             </h2>
-          </EuiTitle>
+          </EuiText>
         </EuiFlyoutHeader>
       }
     >
@@ -153,12 +153,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                       <div
                         class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                       >
-                        <h2
-                          class="euiTitle euiTitle--medium"
-                          id="addVisualizationFlyout"
+                        <div
+                          class="euiText euiText--small"
                         >
-                          Select existing visualization
-                        </h2>
+                          <h2
+                            id="addVisualizationFlyout"
+                          >
+                            Select existing visualization
+                          </h2>
+                        </div>
                       </div>
                       <div
                         class="euiFlyoutBody"
@@ -369,12 +372,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                               <div
                                 class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
-                                  id="addVisualizationFlyout"
+                                <div
+                                  class="euiText euiText--small"
                                 >
-                                  Select existing visualization
-                                </h2>
+                                  <h2
+                                    id="addVisualizationFlyout"
+                                  >
+                                    Select existing visualization
+                                  </h2>
+                                </div>
                               </div>
                               <div
                                 class="euiFlyoutBody"
@@ -517,12 +523,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                 <div
                                   class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                 >
-                                  <h2
-                                    class="euiTitle euiTitle--medium"
-                                    id="addVisualizationFlyout"
+                                  <div
+                                    class="euiText euiText--small"
                                   >
-                                    Select existing visualization
-                                  </h2>
+                                    <h2
+                                      id="addVisualizationFlyout"
+                                    >
+                                      Select existing visualization
+                                    </h2>
+                                  </div>
                                 </div>
                                 <div
                                   class="euiFlyoutBody"
@@ -665,12 +674,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                   <div
                                     class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                   >
-                                    <h2
-                                      class="euiTitle euiTitle--medium"
-                                      id="addVisualizationFlyout"
+                                    <div
+                                      class="euiText euiText--small"
                                     >
-                                      Select existing visualization
-                                    </h2>
+                                      <h2
+                                        id="addVisualizationFlyout"
+                                      >
+                                        Select existing visualization
+                                      </h2>
+                                    </div>
                                   </div>
                                   <div
                                     class="euiFlyoutBody"
@@ -801,12 +813,15 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                     <div
                                       class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                     >
-                                      <h2
-                                        class="euiTitle euiTitle--medium"
-                                        id="addVisualizationFlyout"
+                                      <div
+                                        class="euiText euiText--small"
                                       >
-                                        Select existing visualization
-                                      </h2>
+                                        <h2
+                                          id="addVisualizationFlyout"
+                                        >
+                                          Select existing visualization
+                                        </h2>
+                                      </div>
                                     </div>
                                     <div
                                       class="euiFlyoutBody"
@@ -997,16 +1012,19 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                 <div
                                   className="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                 >
-                                  <EuiTitle
-                                    size="m"
+                                  <EuiText
+                                    size="s"
                                   >
-                                    <h2
-                                      className="euiTitle euiTitle--medium"
-                                      id="addVisualizationFlyout"
+                                    <div
+                                      className="euiText euiText--small"
                                     >
-                                      Select existing visualization
-                                    </h2>
-                                  </EuiTitle>
+                                      <h2
+                                        id="addVisualizationFlyout"
+                                      >
+                                        Select existing visualization
+                                      </h2>
+                                    </div>
+                                  </EuiText>
                                 </div>
                               </EuiFlyoutHeader>
                               <EuiFlyoutBody
@@ -1381,15 +1399,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
         <EuiFlyoutHeader
           hasBorder={true}
         >
-          <EuiTitle
-            size="m"
+          <EuiText
+            size="s"
           >
             <h2
               id="addVisualizationFlyout"
             >
               Replace visualization
             </h2>
-          </EuiTitle>
+          </EuiText>
         </EuiFlyoutHeader>
       }
     >
@@ -1449,12 +1467,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                       <div
                         class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                       >
-                        <h2
-                          class="euiTitle euiTitle--medium"
-                          id="addVisualizationFlyout"
+                        <div
+                          class="euiText euiText--small"
                         >
-                          Replace visualization
-                        </h2>
+                          <h2
+                            id="addVisualizationFlyout"
+                          >
+                            Replace visualization
+                          </h2>
+                        </div>
                       </div>
                       <div
                         class="euiFlyoutBody"
@@ -1665,12 +1686,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                               <div
                                 class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
-                                  id="addVisualizationFlyout"
+                                <div
+                                  class="euiText euiText--small"
                                 >
-                                  Replace visualization
-                                </h2>
+                                  <h2
+                                    id="addVisualizationFlyout"
+                                  >
+                                    Replace visualization
+                                  </h2>
+                                </div>
                               </div>
                               <div
                                 class="euiFlyoutBody"
@@ -1813,12 +1837,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                 <div
                                   class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                 >
-                                  <h2
-                                    class="euiTitle euiTitle--medium"
-                                    id="addVisualizationFlyout"
+                                  <div
+                                    class="euiText euiText--small"
                                   >
-                                    Replace visualization
-                                  </h2>
+                                    <h2
+                                      id="addVisualizationFlyout"
+                                    >
+                                      Replace visualization
+                                    </h2>
+                                  </div>
                                 </div>
                                 <div
                                   class="euiFlyoutBody"
@@ -1961,12 +1988,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                   <div
                                     class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                   >
-                                    <h2
-                                      class="euiTitle euiTitle--medium"
-                                      id="addVisualizationFlyout"
+                                    <div
+                                      class="euiText euiText--small"
                                     >
-                                      Replace visualization
-                                    </h2>
+                                      <h2
+                                        id="addVisualizationFlyout"
+                                      >
+                                        Replace visualization
+                                      </h2>
+                                    </div>
                                   </div>
                                   <div
                                     class="euiFlyoutBody"
@@ -2097,12 +2127,15 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                     <div
                                       class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                     >
-                                      <h2
-                                        class="euiTitle euiTitle--medium"
-                                        id="addVisualizationFlyout"
+                                      <div
+                                        class="euiText euiText--small"
                                       >
-                                        Replace visualization
-                                      </h2>
+                                        <h2
+                                          id="addVisualizationFlyout"
+                                        >
+                                          Replace visualization
+                                        </h2>
+                                      </div>
                                     </div>
                                     <div
                                       class="euiFlyoutBody"
@@ -2293,16 +2326,19 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                 <div
                                   className="euiFlyoutHeader euiFlyoutHeader--hasBorder"
                                 >
-                                  <EuiTitle
-                                    size="m"
+                                  <EuiText
+                                    size="s"
                                   >
-                                    <h2
-                                      className="euiTitle euiTitle--medium"
-                                      id="addVisualizationFlyout"
+                                    <div
+                                      className="euiText euiText--small"
                                     >
-                                      Replace visualization
-                                    </h2>
-                                  </EuiTitle>
+                                      <h2
+                                        id="addVisualizationFlyout"
+                                      >
+                                        Replace visualization
+                                      </h2>
+                                    </div>
+                                  </EuiText>
                                 </div>
                               </EuiFlyoutHeader>
                               <EuiFlyoutBody

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -127,7 +127,7 @@ export const VisaulizationFlyout = ({
   const [modalContent, setModalContent] = useState(<></>);
 
   const closeModal = () => setIsModalVisible(false);
-  const showModal = (modalType: string) => {
+  const showModal = (_: string) => {
     setModalContent(
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -28,7 +28,6 @@ import {
   EuiSelectOption,
   EuiSpacer,
   EuiText,
-  EuiTitle,
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
@@ -133,12 +132,14 @@ export const VisaulizationFlyout = ({
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <h1>{isPreviewError.errorMessage}</h1>
+            <EuiText size="s">
+              <h2>{isPreviewError.errorMessage}</h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          Error Details
+          <EuiText size="s">Error Details</EuiText>
           <EuiSpacer />
           <EuiCodeBlock language="html" isCopyable>
             {isPreviewError.errorDetails}
@@ -267,11 +268,11 @@ export const VisaulizationFlyout = ({
 
   const flyoutHeader = (
     <EuiFlyoutHeader hasBorder>
-      <EuiTitle size="m">
+      <EuiText size="s">
         <h2 id="addVisualizationFlyout">
           {isFlyoutReplacement ? 'Replace visualization' : 'Select existing visualization'}
         </h2>
-      </EuiTitle>
+      </EuiText>
     </EuiFlyoutHeader>
   );
 

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -127,7 +127,7 @@ export const VisaulizationFlyoutSO = ({
   const [modalContent, setModalContent] = useState(<></>);
 
   const closeModal = () => setIsModalVisible(false);
-  const showModal = (modalType: string) => {
+  const showModal = (_: string) => {
     setModalContent(
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>
@@ -178,7 +178,7 @@ export const VisaulizationFlyoutSO = ({
         replaceVizInPanel(panel, replaceVisualizationId, selectValue, newVisualizationTitle)
       );
     } else {
-      const visualizationsWithNewPanel = addVisualizationPanel({
+      addVisualizationPanel({
         savedVisualizationId: selectValue,
         onSuccess: `Visualization ${newVisualizationTitle} successfully added!`,
         onFailure: `Error in adding ${newVisualizationTitle} visualization to the panel`,

--- a/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout_so.tsx
@@ -28,7 +28,6 @@ import {
   EuiSelectOption,
   EuiSpacer,
   EuiText,
-  EuiTitle,
   EuiToolTip,
   ShortDate,
 } from '@elastic/eui';
@@ -133,12 +132,14 @@ export const VisaulizationFlyoutSO = ({
       <EuiModal onClose={closeModal}>
         <EuiModalHeader>
           <EuiModalHeaderTitle>
-            <h1>{isPreviewError.errorMessage}</h1>
+            <EuiText size="s">
+              <h2>{isPreviewError.errorMessage}</h2>
+            </EuiText>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 
         <EuiModalBody>
-          Error Details
+          <EuiText size="s">Error Details</EuiText>
           <EuiSpacer />
           <EuiCodeBlock language="html" isCopyable>
             {isPreviewError.errorDetails}
@@ -249,11 +250,11 @@ export const VisaulizationFlyoutSO = ({
 
   const flyoutHeader = (
     <EuiFlyoutHeader hasBorder>
-      <EuiTitle size="m">
+      <EuiText size="s">
         <h2 id="addVisualizationFlyout">
           {isFlyoutReplacement ? 'Replace visualization' : 'Select existing visualization'}
         </h2>
-      </EuiTitle>
+      </EuiText>
     </EuiFlyoutHeader>
   );
 


### PR DESCRIPTION
### Description
This PR applies the Look & Feel density and consistency changes to the Observability Custom Panels Folder:
1. Use small context menus
2. Use small tabs
3. Standardize paragraph size (15.75px next theme / 14px V7 theme)
4. Use semantic headers (H1s on main pages, H2s on modals/flyouts)
5. Modal/Flyout Typography
6. Buttons for actions, only using primary buttons for primary calls to action
7. Use small padding on popovers

## Screenshots
### Small context Menu
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboards: Overview Actions | <img width="795" alt="Dashboards Actions Before" src="https://github.com/user-attachments/assets/d6f2b6e5-d525-4817-a8e8-d1d0517cdef8"> | <img width="795" alt="Dashboards Post" src="https://github.com/user-attachments/assets/67413e5d-33c3-4f4a-b728-2251a2f3948b"> |
| Dashboards: Actions | <img width="795" alt="Dashboards SO Actions Before" src="https://github.com/user-attachments/assets/626afec3-f5b4-483a-8d79-b2160cd48b8b"> | <img width="795" alt="Dashboards SO Actions Post" src="https://github.com/user-attachments/assets/5d10d530-7581-4960-ab58-c2e474694c30"> |
| Dashboards: Vis Actions | <img width="795" alt="Dashboards Vis Actions Before" src="https://github.com/user-attachments/assets/7eb6743f-bf51-4628-827d-de297e97fc51"> | <img width="795" alt="Dashboards Vis Actions Post" src="https://github.com/user-attachments/assets/ca2ce4c6-a7b3-42ea-8434-ebd1f1c73ea7"> |
| Dashboards: Vis | <img width="795" alt="Dashboards Vis Before" src="https://github.com/user-attachments/assets/dfaa6d98-0daf-4ab6-be5c-4bb30808fbf5"> | <img width="795" alt="Dashboards Vis Post" src="https://github.com/user-attachments/assets/707240c8-1c69-4427-bea8-1e4226fb9347"> |


#### Semantic Headers 
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboard: Overview | <img width="795" alt="Dashboards Before" src="https://github.com/user-attachments/assets/e27a8618-21de-4549-9fa0-2ede08b01c6c"> | <img width="795" alt="Dashboards Post" src="https://github.com/user-attachments/assets/1d64cccd-25d6-4faa-b99c-bc13b1e190fc"> |
| Dashboard: Title | <img width="548" alt="Dashboard Before" src="https://github.com/user-attachments/assets/b87095d6-a1c8-4b7c-b398-0f94b4582225"> | <img width="548" alt="Dashboard Post" src="https://github.com/user-attachments/assets/00dbb9b9-fc47-46c3-98e4-a39faaed4eba"> |

#### Flyouts 
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboard: Select Vis | <img width="548" alt="Dashboards Select Vis Before" src="https://github.com/user-attachments/assets/31115331-9470-449f-a526-819ef8c046bd"> | <img width="548" alt="Dashboards Select Vis Post" src="https://github.com/user-attachments/assets/28887c54-7b53-4014-a596-21f53c1585a0"> |

#### Modals 
| Scope | Before | After |
| ----- | ----- | ----- |
| Dashboard: Create | <img width="465" alt="Dashboards Create Before" src="https://github.com/user-attachments/assets/79c6b14a-ea1b-44c8-bd24-46db9a4ba24b"> | <img width="465" alt="Dashboards Create Post" src="https://github.com/user-attachments/assets/ea13b9ad-6d4a-4f13-ae69-f3d757340cf0"> | 
| Dashboard: Error | <img width="764" alt="Dashboard Error Header Before" src="https://github.com/user-attachments/assets/5688a486-dded-419a-9410-d207b3ea678f"> | <img width="764" alt="Dashboard Error Header Post" src="https://github.com/user-attachments/assets/11b1f2cc-ae78-4fad-9841-fc7d3466b1da"> |
| Dashboard: Error | <img width="764" alt="Dashboard Error p Before" src="https://github.com/user-attachments/assets/38e97c71-8305-4993-a584-7f58c312a2db"> | <img width="764" alt="Dashboard Error P Post" src="https://github.com/user-attachments/assets/c3962c62-b837-43db-9575-4bddc7ba31e4"> |
| Dashboard: Samples | <img width="795" alt="Dashboard Samples Before" src="https://github.com/user-attachments/assets/14a1b1aa-96e2-411f-a85d-dc83b6bc62e4"> | <img width="795" alt="Dashboard Samples Post" src="https://github.com/user-attachments/assets/d30cb267-7308-415d-85ee-9b8a21b49f71"> |


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
